### PR TITLE
Use non-zero pre-allocated vectors in Merkle tree deserialization.

### DIFF
--- a/dist/ccf/MerkleTree.c
+++ b/dist/ccf/MerkleTree.c
@@ -2244,8 +2244,10 @@ deserialize_hash_vec(
   uint32_t pos
 )
 {
+  regional__uint32_t__uint8_t_
+  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
+  hvrg =
     {
       .state = hash_size,
       .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
@@ -2259,10 +2261,12 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = rg.dummy
+          .thd = hvrg.dummy
         }
       );
   }
+  LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve___uint8_t_((uint32_t)1U, hrg.dummy);
   __bool_uint32_t_uint32_t scrut0 = deserialize_uint32_t(ok, buf, sz, pos);
   bool ok1 = scrut0.fst;
   uint32_t pos1 = scrut0.snd;
@@ -2274,7 +2278,7 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2285,12 +2289,10 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t__uint8_t_
-  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   LowStar_Vector_vector_str___uint8_t_ res = alloc___uint8_t_(n, hrg.dummy);
   __bool_uint32_t
   scrut = deserialize_hash_vec_i(hash_size, ok1, buf, sz, pos1, res, (uint32_t)0U);
@@ -2334,6 +2336,27 @@ deserialize_hash_vv_i(
 }
 
 static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+alloc_reserve__LowStar_Vector_vector_str__uint8_t_(
+  uint32_t len,
+  LowStar_Vector_vector_str___uint8_t_ ia
+)
+{
+  KRML_CHECK_SIZE(sizeof (LowStar_Vector_vector_str___uint8_t_), len);
+  LowStar_Vector_vector_str___uint8_t_
+  *buf = KRML_HOST_MALLOC(sizeof (LowStar_Vector_vector_str___uint8_t_) * len);
+  for (uint32_t _i = 0U; _i < len; ++_i)
+    buf[_i] = ia;
+  return
+    (
+      (LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
+        .sz = (uint32_t)0U,
+        .cap = len,
+        .vs = buf
+      }
+    );
+}
+
+static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 alloc__LowStar_Vector_vector_str__uint8_t_(
   uint32_t len,
   LowStar_Vector_vector_str___uint8_t_ v
@@ -2354,6 +2377,16 @@ __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_;
 static __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz, uint32_t pos)
 {
+  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
+  rg =
+    {
+      .state = hash_size,
+      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
+      .r_alloc = hash_vec_r_alloc,
+      .r_free = hash_vec_r_free
+    };
+  LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve__LowStar_Vector_vector_str__uint8_t_((uint32_t)1U, rg.dummy);
   if (!ok || pos >= sz)
   {
     return
@@ -2361,7 +2394,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2376,7 +2409,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2387,18 +2420,10 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
-    {
-      .state = hash_size,
-      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
-      .r_alloc = hash_vec_r_alloc,
-      .r_free = hash_vec_r_free
-    };
   LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
   res = alloc__LowStar_Vector_vector_str__uint8_t_(n, rg.dummy);
   __bool_uint32_t

--- a/dist/gcc-compatible/MerkleTree.c
+++ b/dist/gcc-compatible/MerkleTree.c
@@ -2244,8 +2244,10 @@ deserialize_hash_vec(
   uint32_t pos
 )
 {
+  regional__uint32_t__uint8_t_
+  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
+  hvrg =
     {
       .state = hash_size,
       .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
@@ -2259,10 +2261,12 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = rg.dummy
+          .thd = hvrg.dummy
         }
       );
   }
+  LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve___uint8_t_((uint32_t)1U, hrg.dummy);
   __bool_uint32_t_uint32_t scrut0 = deserialize_uint32_t(ok, buf, sz, pos);
   bool ok1 = scrut0.fst;
   uint32_t pos1 = scrut0.snd;
@@ -2274,7 +2278,7 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2285,12 +2289,10 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t__uint8_t_
-  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   LowStar_Vector_vector_str___uint8_t_ res = alloc___uint8_t_(n, hrg.dummy);
   __bool_uint32_t
   scrut = deserialize_hash_vec_i(hash_size, ok1, buf, sz, pos1, res, (uint32_t)0U);
@@ -2334,6 +2336,27 @@ deserialize_hash_vv_i(
 }
 
 static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+alloc_reserve__LowStar_Vector_vector_str__uint8_t_(
+  uint32_t len,
+  LowStar_Vector_vector_str___uint8_t_ ia
+)
+{
+  KRML_CHECK_SIZE(sizeof (LowStar_Vector_vector_str___uint8_t_), len);
+  LowStar_Vector_vector_str___uint8_t_
+  *buf = KRML_HOST_MALLOC(sizeof (LowStar_Vector_vector_str___uint8_t_) * len);
+  for (uint32_t _i = 0U; _i < len; ++_i)
+    buf[_i] = ia;
+  return
+    (
+      (LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
+        .sz = (uint32_t)0U,
+        .cap = len,
+        .vs = buf
+      }
+    );
+}
+
+static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 alloc__LowStar_Vector_vector_str__uint8_t_(
   uint32_t len,
   LowStar_Vector_vector_str___uint8_t_ v
@@ -2354,6 +2377,16 @@ __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_;
 static __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz, uint32_t pos)
 {
+  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
+  rg =
+    {
+      .state = hash_size,
+      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
+      .r_alloc = hash_vec_r_alloc,
+      .r_free = hash_vec_r_free
+    };
+  LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve__LowStar_Vector_vector_str__uint8_t_((uint32_t)1U, rg.dummy);
   if (!ok || pos >= sz)
   {
     return
@@ -2361,7 +2394,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2376,7 +2409,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2387,18 +2420,10 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
-    {
-      .state = hash_size,
-      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
-      .r_alloc = hash_vec_r_alloc,
-      .r_free = hash_vec_r_free
-    };
   LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
   res = alloc__LowStar_Vector_vector_str__uint8_t_(n, rg.dummy);
   __bool_uint32_t

--- a/dist/gcc64-only/MerkleTree.c
+++ b/dist/gcc64-only/MerkleTree.c
@@ -2244,8 +2244,10 @@ deserialize_hash_vec(
   uint32_t pos
 )
 {
+  regional__uint32_t__uint8_t_
+  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
+  hvrg =
     {
       .state = hash_size,
       .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
@@ -2259,10 +2261,12 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = rg.dummy
+          .thd = hvrg.dummy
         }
       );
   }
+  LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve___uint8_t_((uint32_t)1U, hrg.dummy);
   __bool_uint32_t_uint32_t scrut0 = deserialize_uint32_t(ok, buf, sz, pos);
   bool ok1 = scrut0.fst;
   uint32_t pos1 = scrut0.snd;
@@ -2274,7 +2278,7 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2285,12 +2289,10 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t__uint8_t_
-  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   LowStar_Vector_vector_str___uint8_t_ res = alloc___uint8_t_(n, hrg.dummy);
   __bool_uint32_t
   scrut = deserialize_hash_vec_i(hash_size, ok1, buf, sz, pos1, res, (uint32_t)0U);
@@ -2334,6 +2336,27 @@ deserialize_hash_vv_i(
 }
 
 static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+alloc_reserve__LowStar_Vector_vector_str__uint8_t_(
+  uint32_t len,
+  LowStar_Vector_vector_str___uint8_t_ ia
+)
+{
+  KRML_CHECK_SIZE(sizeof (LowStar_Vector_vector_str___uint8_t_), len);
+  LowStar_Vector_vector_str___uint8_t_
+  *buf = KRML_HOST_MALLOC(sizeof (LowStar_Vector_vector_str___uint8_t_) * len);
+  for (uint32_t _i = 0U; _i < len; ++_i)
+    buf[_i] = ia;
+  return
+    (
+      (LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
+        .sz = (uint32_t)0U,
+        .cap = len,
+        .vs = buf
+      }
+    );
+}
+
+static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 alloc__LowStar_Vector_vector_str__uint8_t_(
   uint32_t len,
   LowStar_Vector_vector_str___uint8_t_ v
@@ -2354,6 +2377,16 @@ __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_;
 static __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz, uint32_t pos)
 {
+  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
+  rg =
+    {
+      .state = hash_size,
+      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
+      .r_alloc = hash_vec_r_alloc,
+      .r_free = hash_vec_r_free
+    };
+  LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve__LowStar_Vector_vector_str__uint8_t_((uint32_t)1U, rg.dummy);
   if (!ok || pos >= sz)
   {
     return
@@ -2361,7 +2394,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2376,7 +2409,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2387,18 +2420,10 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
-    {
-      .state = hash_size,
-      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
-      .r_alloc = hash_vec_r_alloc,
-      .r_free = hash_vec_r_free
-    };
   LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
   res = alloc__LowStar_Vector_vector_str__uint8_t_(n, rg.dummy);
   __bool_uint32_t

--- a/dist/merkle-tree/MerkleTree.c
+++ b/dist/merkle-tree/MerkleTree.c
@@ -2137,8 +2137,10 @@ deserialize_hash_vec(
   uint32_t pos
 )
 {
+  regional__uint32_t__uint8_t_
+  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
+  hvrg =
     {
       .state = hash_size,
       .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
@@ -2152,10 +2154,12 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = rg.dummy
+          .thd = hvrg.dummy
         }
       );
   }
+  LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve___uint8_t_((uint32_t)1U, hrg.dummy);
   __bool_uint32_t_uint32_t scrut0 = deserialize_uint32_t(ok, buf, sz, pos);
   bool ok1 = scrut0.fst;
   uint32_t pos1 = scrut0.snd;
@@ -2167,7 +2171,7 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2178,12 +2182,10 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t__uint8_t_
-  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   LowStar_Vector_vector_str___uint8_t_ res = alloc___uint8_t_(n, hrg.dummy);
   __bool_uint32_t
   scrut = deserialize_hash_vec_i(hash_size, ok1, buf, sz, pos1, res, (uint32_t)0U);
@@ -2227,6 +2229,27 @@ deserialize_hash_vv_i(
 }
 
 static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+alloc_reserve__LowStar_Vector_vector_str__uint8_t_(
+  uint32_t len,
+  LowStar_Vector_vector_str___uint8_t_ ia
+)
+{
+  KRML_CHECK_SIZE(sizeof (LowStar_Vector_vector_str___uint8_t_), len);
+  LowStar_Vector_vector_str___uint8_t_
+  *buf = KRML_HOST_MALLOC(sizeof (LowStar_Vector_vector_str___uint8_t_) * len);
+  for (uint32_t _i = 0U; _i < len; ++_i)
+    buf[_i] = ia;
+  return
+    (
+      (LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
+        .sz = (uint32_t)0U,
+        .cap = len,
+        .vs = buf
+      }
+    );
+}
+
+static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 alloc__LowStar_Vector_vector_str__uint8_t_(
   uint32_t len,
   LowStar_Vector_vector_str___uint8_t_ v
@@ -2247,6 +2270,16 @@ __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_;
 static __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz, uint32_t pos)
 {
+  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
+  rg =
+    {
+      .state = hash_size,
+      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
+      .r_alloc = hash_vec_r_alloc,
+      .r_free = hash_vec_r_free
+    };
+  LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve__LowStar_Vector_vector_str__uint8_t_((uint32_t)1U, rg.dummy);
   if (!ok || pos >= sz)
   {
     return
@@ -2254,7 +2287,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2269,7 +2302,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2280,18 +2313,10 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
-    {
-      .state = hash_size,
-      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
-      .r_alloc = hash_vec_r_alloc,
-      .r_free = hash_vec_r_free
-    };
   LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
   res = alloc__LowStar_Vector_vector_str__uint8_t_(n, rg.dummy);
   __bool_uint32_t

--- a/dist/mitls/MerkleTree.c
+++ b/dist/mitls/MerkleTree.c
@@ -2516,8 +2516,10 @@ deserialize_hash_vec(
   uint32_t pos
 )
 {
+  regional__uint32_t__uint8_t_
+  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
+  hvrg =
     {
       .state = hash_size,
       .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
@@ -2531,10 +2533,12 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = rg.dummy
+          .thd = hvrg.dummy
         }
       );
   }
+  LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve___uint8_t_((uint32_t)1U, hrg.dummy);
   __bool_uint32_t_uint32_t scrut0 = deserialize_uint32_t(ok, buf, sz, pos);
   bool ok1 = scrut0.fst;
   uint32_t pos1 = scrut0.snd;
@@ -2546,7 +2550,7 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2557,12 +2561,10 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t__uint8_t_
-  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   LowStar_Vector_vector_str___uint8_t_ res = alloc___uint8_t_(n, hrg.dummy);
   __bool_uint32_t
   scrut = deserialize_hash_vec_i(hash_size, ok1, buf, sz, pos1, res, (uint32_t)0U);
@@ -2632,6 +2634,27 @@ deserialize_hash_vv_i(
 }
 
 static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+alloc_reserve__LowStar_Vector_vector_str__uint8_t_(
+  uint32_t len,
+  LowStar_Vector_vector_str___uint8_t_ ia
+)
+{
+  KRML_CHECK_SIZE(sizeof (LowStar_Vector_vector_str___uint8_t_), len);
+  LowStar_Vector_vector_str___uint8_t_
+  *buf = KRML_HOST_MALLOC(sizeof (LowStar_Vector_vector_str___uint8_t_) * len);
+  for (uint32_t _i = 0U; _i < len; ++_i)
+    buf[_i] = ia;
+  return
+    (
+      (LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
+        .sz = (uint32_t)0U,
+        .cap = len,
+        .vs = buf
+      }
+    );
+}
+
+static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 alloc__LowStar_Vector_vector_str__uint8_t_(
   uint32_t len,
   LowStar_Vector_vector_str___uint8_t_ v
@@ -2652,6 +2675,16 @@ __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_;
 static __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz, uint32_t pos)
 {
+  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
+  rg =
+    {
+      .state = hash_size,
+      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
+      .r_alloc = hash_vec_r_alloc,
+      .r_free = hash_vec_r_free
+    };
+  LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve__LowStar_Vector_vector_str__uint8_t_((uint32_t)1U, rg.dummy);
   if (!ok || pos >= sz)
   {
     return
@@ -2659,7 +2692,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2674,7 +2707,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2685,18 +2718,10 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
-    {
-      .state = hash_size,
-      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
-      .r_alloc = hash_vec_r_alloc,
-      .r_free = hash_vec_r_free
-    };
   LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
   res = alloc__LowStar_Vector_vector_str__uint8_t_(n, rg.dummy);
   __bool_uint32_t

--- a/dist/msvc-compatible/MerkleTree.c
+++ b/dist/msvc-compatible/MerkleTree.c
@@ -2516,8 +2516,10 @@ deserialize_hash_vec(
   uint32_t pos
 )
 {
+  regional__uint32_t__uint8_t_
+  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
+  hvrg =
     {
       .state = hash_size,
       .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
@@ -2531,10 +2533,12 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = rg.dummy
+          .thd = hvrg.dummy
         }
       );
   }
+  LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve___uint8_t_((uint32_t)1U, hrg.dummy);
   __bool_uint32_t_uint32_t scrut0 = deserialize_uint32_t(ok, buf, sz, pos);
   bool ok1 = scrut0.fst;
   uint32_t pos1 = scrut0.snd;
@@ -2546,7 +2550,7 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2557,12 +2561,10 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t__uint8_t_
-  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   LowStar_Vector_vector_str___uint8_t_ res = alloc___uint8_t_(n, hrg.dummy);
   __bool_uint32_t
   scrut = deserialize_hash_vec_i(hash_size, ok1, buf, sz, pos1, res, (uint32_t)0U);
@@ -2632,6 +2634,27 @@ deserialize_hash_vv_i(
 }
 
 static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+alloc_reserve__LowStar_Vector_vector_str__uint8_t_(
+  uint32_t len,
+  LowStar_Vector_vector_str___uint8_t_ ia
+)
+{
+  KRML_CHECK_SIZE(sizeof (LowStar_Vector_vector_str___uint8_t_), len);
+  LowStar_Vector_vector_str___uint8_t_
+  *buf = KRML_HOST_MALLOC(sizeof (LowStar_Vector_vector_str___uint8_t_) * len);
+  for (uint32_t _i = 0U; _i < len; ++_i)
+    buf[_i] = ia;
+  return
+    (
+      (LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
+        .sz = (uint32_t)0U,
+        .cap = len,
+        .vs = buf
+      }
+    );
+}
+
+static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 alloc__LowStar_Vector_vector_str__uint8_t_(
   uint32_t len,
   LowStar_Vector_vector_str___uint8_t_ v
@@ -2652,6 +2675,16 @@ __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_;
 static __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz, uint32_t pos)
 {
+  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
+  rg =
+    {
+      .state = hash_size,
+      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
+      .r_alloc = hash_vec_r_alloc,
+      .r_free = hash_vec_r_free
+    };
+  LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve__LowStar_Vector_vector_str__uint8_t_((uint32_t)1U, rg.dummy);
   if (!ok || pos >= sz)
   {
     return
@@ -2659,7 +2692,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2674,7 +2707,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2685,18 +2718,10 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
-    {
-      .state = hash_size,
-      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
-      .r_alloc = hash_vec_r_alloc,
-      .r_free = hash_vec_r_free
-    };
   LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
   res = alloc__LowStar_Vector_vector_str__uint8_t_(n, rg.dummy);
   __bool_uint32_t

--- a/dist/portable-gcc-compatible/MerkleTree.c
+++ b/dist/portable-gcc-compatible/MerkleTree.c
@@ -2838,8 +2838,10 @@ deserialize_hash_vec(
   uint32_t pos
 )
 {
+  regional__uint32_t__uint8_t_
+  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
+  hvrg =
     {
       .state = hash_size,
       .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
@@ -2853,10 +2855,12 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = rg.dummy
+          .thd = hvrg.dummy
         }
       );
   }
+  LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve___uint8_t_((uint32_t)1U, hrg.dummy);
   __bool_uint32_t_uint32_t scrut0 = deserialize_uint32_t(ok, buf, sz, pos);
   bool ok1 = scrut0.fst;
   uint32_t pos1 = scrut0.snd;
@@ -2868,7 +2872,7 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2879,12 +2883,10 @@ deserialize_hash_vec(
         (__bool_uint32_t_LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t__uint8_t_
-  hrg = { .state = hash_size, .dummy = NULL, .r_alloc = hash_r_alloc, .r_free = hash_r_free };
   LowStar_Vector_vector_str___uint8_t_ res = alloc___uint8_t_(n, hrg.dummy);
   __bool_uint32_t
   scrut = deserialize_hash_vec_i(hash_size, ok1, buf, sz, pos1, res, (uint32_t)0U);
@@ -2933,6 +2935,31 @@ deserialize_hash_vv_i(
 
 /* SNIPPET_END: deserialize_hash_vv_i */
 
+/* SNIPPET_START: alloc_reserve__LowStar_Vector_vector_str__uint8_t_ */
+
+static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+alloc_reserve__LowStar_Vector_vector_str__uint8_t_(
+  uint32_t len,
+  LowStar_Vector_vector_str___uint8_t_ ia
+)
+{
+  KRML_CHECK_SIZE(sizeof (LowStar_Vector_vector_str___uint8_t_), len);
+  LowStar_Vector_vector_str___uint8_t_
+  *buf = KRML_HOST_MALLOC(sizeof (LowStar_Vector_vector_str___uint8_t_) * len);
+  for (uint32_t _i = 0U; _i < len; ++_i)
+    buf[_i] = ia;
+  return
+    (
+      (LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
+        .sz = (uint32_t)0U,
+        .cap = len,
+        .vs = buf
+      }
+    );
+}
+
+/* SNIPPET_END: alloc_reserve__LowStar_Vector_vector_str__uint8_t_ */
+
 /* SNIPPET_START: alloc__LowStar_Vector_vector_str__uint8_t_ */
 
 static LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
@@ -2964,6 +2991,16 @@ __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_;
 static __bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
 deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz, uint32_t pos)
 {
+  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
+  rg =
+    {
+      .state = hash_size,
+      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
+      .r_alloc = hash_vec_r_alloc,
+      .r_free = hash_vec_r_free
+    };
+  LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
+  empty_vec = alloc_reserve__LowStar_Vector_vector_str__uint8_t_((uint32_t)1U, rg.dummy);
   if (!ok || pos >= sz)
   {
     return
@@ -2971,7 +3008,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2986,7 +3023,7 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = false,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
@@ -2997,18 +3034,10 @@ deserialize_hash_vv(uint32_t hash_size, bool ok, const uint8_t *buf, uint32_t sz
         (__bool_uint32_t_LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_){
           .fst = true,
           .snd = pos1,
-          .thd = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL }
+          .thd = empty_vec
         }
       );
   }
-  regional__uint32_t_LowStar_Vector_vector_str___uint8_t_
-  rg =
-    {
-      .state = hash_size,
-      .dummy = { .sz = (uint32_t)0U, .cap = (uint32_t)0U, .vs = NULL },
-      .r_alloc = hash_vec_r_alloc,
-      .r_free = hash_vec_r_free
-    };
   LowStar_Vector_vector_str__LowStar_Vector_vector_str___uint8_t_
   res = alloc__LowStar_Vector_vector_str__uint8_t_(n, rg.dummy);
   __bool_uint32_t

--- a/secure_api/merkle_tree/MerkleTree.Low.Serialization.fst
+++ b/secure_api/merkle_tree/MerkleTree.Low.Serialization.fst
@@ -80,8 +80,8 @@ private let serialize_uint64_t (ok:bool) (x:uint64_t) (buf:uint8_p) (sz:uint32_t
 private let serialize_offset_t = serialize_uint64_t
 private let serialize_index_t = serialize_uint32_t
 
-private let rec serialize_hash_i 
-  (#hash_size:hash_size_t) 
+private let rec serialize_hash_i
+  (#hash_size:hash_size_t)
   (ok:bool) (x:hash #hash_size) (buf:uint8_p) (sz:uint32_t{B.len buf = sz}) (pos:uint32_t) (i:uint32_t{i < hash_size})
 : HST.ST (bool & uint32_t)
     (requires (fun h0 -> B.live h0 buf /\ B.live h0 x /\ B.len x = hash_size))
@@ -94,9 +94,9 @@ private let rec serialize_hash_i
        else (ok, pos)
 
 private
-let serialize_hash 
-  (#hash_size:hash_size_t) 
-  (ok:bool) (x:hash #hash_size) (buf:uint8_p) (sz:uint32_t{B.len buf = sz}) (pos:uint32_t) 
+let serialize_hash
+  (#hash_size:hash_size_t)
+  (ok:bool) (x:hash #hash_size) (buf:uint8_p) (sz:uint32_t{B.len buf = sz}) (pos:uint32_t)
 : HST.ST (bool & uint32_t)
   (requires (fun h0 -> B.live h0 buf /\ B.live h0 x /\ B.len x = hash_size))
   (ensures (fun h0 _ h1 -> modifies (B.loc_buffer buf) h0 h1))
@@ -108,7 +108,7 @@ let u64_add_fits (x:uint64_t) (y:uint64_t): Tot (r:bool{r ==> UInt.size (U64.v x
 
 #push-options "--z3rlimit 10 --initial_fuel 1 --max_fuel 1"
 private inline_for_extraction
-let hash_vec_bytes 
+let hash_vec_bytes
   (#hash_size:hash_size_t)
   (v:hash_vec #hash_size)
 : Tot uint64_t
@@ -117,8 +117,8 @@ let hash_vec_bytes
 #pop-options
 
 private
-let rec serialize_hash_vec_i 
-  (#hash_size:hash_size_t) 
+let rec serialize_hash_vec_i
+  (#hash_size:hash_size_t)
   (ok:bool) (x:hash_vec #hash_size) (buf:uint8_p) (sz:uint32_t{B.len buf = sz}) (pos:uint32_t) (i:uint32_t{i < V.size_of x})
 : HST.ST (bool & uint32_t)
   (requires (fun h0 -> B.live h0 buf /\ RV.rv_inv h0 x /\ loc_disjoint (B.loc_buffer buf) (loc_rvector x)))
@@ -133,9 +133,9 @@ let rec serialize_hash_vec_i
   end
 
 private
-let serialize_hash_vec 
-  (#hash_size:hash_size_t) 
-  (ok:bool) (x:hash_vec #hash_size) (buf:uint8_p) (sz:uint32_t{B.len buf = sz}) (pos:uint32_t) 
+let serialize_hash_vec
+  (#hash_size:hash_size_t)
+  (ok:bool) (x:hash_vec #hash_size) (buf:uint8_p) (sz:uint32_t{B.len buf = sz}) (pos:uint32_t)
 : HST.ST (bool & uint32_t)
   (requires (fun h0 -> B.live h0 buf /\ RV.rv_inv h0 x /\ HS.disjoint (B.frameOf buf) (Rgl?.region_of (hvreg hash_size) x)))
   (ensures (fun h0 _ h1 -> RV.rv_inv h1 x /\ modifies (B.loc_buffer buf) h0 h1))
@@ -150,9 +150,9 @@ let serialize_hash_vec
   end
 
 private inline_for_extraction
-let rec hash_vv_bytes_i 
-  (#hash_size:hash_size_t) 
-  (vv:hash_vv hash_size) 
+let rec hash_vv_bytes_i
+  (#hash_size:hash_size_t)
+  (vv:hash_vv hash_size)
   (i:uint32_t)
 : HST.ST uint64_t
   (requires (fun h0 -> V.live h0 vv))
@@ -170,8 +170,8 @@ let rec hash_vv_bytes_i
   end
 
 private inline_for_extraction
-let hash_vv_bytes 
-  (#hash_size:hash_size_t) 
+let hash_vv_bytes
+  (#hash_size:hash_size_t)
   (vv:hash_vv hash_size {V.size_of vv = merkle_tree_size_lg})
 : HST.ST uint64_t
   (requires (fun h0 -> V.live h0 vv))
@@ -179,8 +179,8 @@ let hash_vv_bytes
 = hash_vv_bytes_i vv 0ul
 
 private
-let rec serialize_hash_vv_i 
-  (#hash_size:hash_size_t) 
+let rec serialize_hash_vv_i
+  (#hash_size:hash_size_t)
   (ok:bool) (x:hash_vv hash_size) (buf:uint8_p) (sz:uint32_t{B.len buf = sz}) (pos:uint32_t) (i:uint32_t{i < V.size_of x})
 : HST.ST (bool & uint32_t)
   (requires (fun h0 -> B.live h0 buf /\ RV.rv_inv h0 x /\ HS.disjoint (B.frameOf buf) (Rgl?.region_of (hvvreg hash_size) x)))
@@ -199,8 +199,8 @@ let rec serialize_hash_vv_i
   end
 
 private
-let serialize_hash_vv 
-  (#hash_size:hash_size_t) 
+let serialize_hash_vv
+  (#hash_size:hash_size_t)
   (ok:bool) (x:hash_vv hash_size) (buf:uint8_p) (sz:uint32_t{B.len buf = sz}) (pos:uint32_t)
 : HST.ST (bool & uint32_t)
   (requires (fun h0 -> B.live h0 buf /\ RV.rv_inv h0 x /\ HS.disjoint (B.frameOf buf) (Rgl?.region_of (hvvreg hash_size) x)))
@@ -266,15 +266,15 @@ private let deserialize_offset_t = deserialize_uint64_t
 private let deserialize_index_t = deserialize_uint32_t
 
 private
-let deserialize_hash 
-  (#hash_size:hash_size_t) 
+let deserialize_hash
+  (#hash_size:hash_size_t)
   (ok:bool) (buf:const_uint8_p) (sz:uint32_t{CB.length buf = U32.v sz}) (r:HST.erid) (pos:uint32_t)
 : HST.ST (bool & uint32_t & hash #hash_size)
   (requires (fun h0 -> CB.live h0 buf))
   (ensures (fun h0 (k, _, h) h1 -> (k ==> Rgl?.r_inv (hreg hash_size) h1 h) /\
                                    loc_disjoint (loc_buffer (CB.cast buf)) (loc_buffer h) /\
                                    modifies B.loc_none h0 h1))
-= let rg = hreg hash_size in 
+= let rg = hreg hash_size in
   if not ok || pos >= sz then (false, pos, rg_dummy rg)
   else if sz - pos < hash_size then (false, pos, rg_dummy rg)
   else begin
@@ -284,8 +284,8 @@ let deserialize_hash
   end
 
 private
-let rec deserialize_hash_vec_i 
-  (#hash_size:hash_size_t) 
+let rec deserialize_hash_vec_i
+  (#hash_size:hash_size_t)
   (ok:bool) (buf:const_uint8_p) (sz:uint32_t{CB.length buf = U32.v sz}) (r:HST.erid) (pos:uint32_t) (res:hash_vec #hash_size) (i:uint32_t{i < V.size_of res})
 : HST.ST (bool & uint32_t)
   (requires (fun h0 -> CB.live h0 buf /\ V.live h0 res))
@@ -315,20 +315,21 @@ let rec deserialize_hash_vec_i
   end
 
 private
-let deserialize_hash_vec 
-  (#hash_size:hash_size_t) 
+let deserialize_hash_vec
+  (#hash_size:hash_size_t)
   (ok:bool) (buf:const_uint8_p) (sz:uint32_t{CB.length buf = U32.v sz}) (r:HST.erid) (pos:uint32_t)
 : HST.ST (bool & uint32_t & hash_vec #hash_size)
   (requires (fun h0 -> CB.live h0 buf))
   (ensures (fun h0 _ h1 -> B.modifies B.loc_none h0 h1))
-= let rg = hvreg hash_size in
-  if not ok || pos >= sz then (false, pos, rg_dummy rg)
+= let hrg = hreg hash_size in
+  let hvrg = hvreg hash_size in
+  if not ok || pos >= sz then (false, pos, rg_dummy hvrg)
   else begin
+    let empty_vec = V.alloc_reserve 1ul (rg_dummy hrg) r in
     let ok, pos, n = deserialize_uint32_t ok buf sz pos in
-    if not ok then (false, pos, V.alloc_empty hash)
-    else if n = 0ul then (true, pos, V.alloc_empty hash)
+    if not ok then (false, pos, empty_vec)
+    else if n = 0ul then (true, pos, empty_vec)
     else begin
-      let hrg = hreg hash_size in
       let res = V.alloc n (rg_dummy hrg) in
       let ok, pos = deserialize_hash_vec_i ok buf sz r pos res 0ul in
       (ok, pos, res)
@@ -336,8 +337,8 @@ let deserialize_hash_vec
   end
 
 private
-let rec deserialize_hash_vv_i 
-  (#hash_size:hash_size_t) 
+let rec deserialize_hash_vv_i
+  (#hash_size:hash_size_t)
   (ok:bool) (buf:const_uint8_p) (sz:uint32_t{CB.length buf = U32.v sz}) (r:HST.erid) (pos:uint32_t) (res:hash_vv hash_size) (i:uint32_t{i < V.size_of res})
 : HST.ST (bool & uint32_t)
   (requires (fun h0 -> CB.live h0 buf /\ V.live h0 res /\
@@ -369,19 +370,20 @@ let rec deserialize_hash_vv_i
     end
   end
 
-private let deserialize_hash_vv 
-  (#hash_size:hash_size_t) 
+private let deserialize_hash_vv
+  (#hash_size:hash_size_t)
   (ok:bool) (buf:const_uint8_p) (sz:uint32_t{CB.length buf = U32.v sz}) (r:HST.erid) (pos:uint32_t)
 : HST.ST (bool & uint32_t & hash_vv hash_size)
   (requires (fun h0 -> CB.live h0 buf))
   (ensures (fun h0 _ h1 -> modifies B.loc_none h0 h1))
-= if not ok || pos >= sz then (false, pos, V.alloc_empty hash_vec)
+= let rg = hvreg hash_size in
+  let empty_vec = V.alloc_reserve 1ul (rg_dummy rg) r in
+  if not ok || pos >= sz then (false, pos, empty_vec)
   else begin
     let ok, pos, n = deserialize_uint32_t ok buf sz pos in
-    if not ok then (false, pos, V.alloc_empty hash_vec)
-    else if n = 0ul then (true, pos, V.alloc_empty hash_vec)
+    if not ok then (false, pos, empty_vec)
+    else if n = 0ul then (true, pos, empty_vec)
     else begin
-      let rg = hvreg hash_size in
       let res = V.alloc n (rg_dummy rg) in
       let ok, pos = deserialize_hash_vv_i ok buf sz r pos res 0ul in
       (ok, pos, res)
@@ -443,15 +445,15 @@ let mt_serialize mt output sz =
 #pop-options
 
 #push-options "--z3rlimit 15 --initial_fuel 2 --max_fuel 2 --initial_ifuel 1 --max_ifuel 1"
-val mt_deserialize: 
+val mt_deserialize:
   #hsz:Ghost.erased hash_size_t ->
-  rid:HST.erid -> 
-  input:const_uint8_p -> 
-  sz:uint64_t{CB.length input = U64.v sz} -> 
-  hash_spec:Ghost.erased(MTS.hash_fun_t #(U32.v (Ghost.reveal hsz))) -> 
+  rid:HST.erid ->
+  input:const_uint8_p ->
+  sz:uint64_t{CB.length input = U64.v sz} ->
+  hash_spec:Ghost.erased(MTS.hash_fun_t #(U32.v (Ghost.reveal hsz))) ->
   hash_fun:hash_fun_t #(Ghost.reveal hsz) #hash_spec
 -> HST.ST (B.pointer_or_null merkle_tree)
-  (requires (fun h0 -> CB.live h0 input /\ 
+  (requires (fun h0 -> CB.live h0 input /\
                        HS.disjoint rid (B.frameOf (CB.cast input))))
   (ensures (fun h0 r h1 -> modifies B.loc_none h0 h1 /\
                         (not (g_is_null r)) ==> MT?.hash_size (B.get h1 r 0) = Ghost.reveal hsz))
@@ -511,12 +513,12 @@ let mt_deserialize_path rid input sz =
   let sz = FStar.Int.Cast.uint64_to_uint32 sz in
   let hvvrid = HST.new_region rid in
   let ok, pos, hash_size = deserialize_uint32_t true input sz 0ul in
-  if not ok || hash_size = 0ul then B.null #path 
-  else 
+  if not ok || hash_size = 0ul then B.null #path
+  else
     let ok, pos, hs = deserialize_hash_vec #hash_size ok input sz hvvrid pos in
     begin
       if not ok
       then (B.null #path)
       else (B.malloc rid (Path hash_size hs) 1ul)
-    end 
+    end
 #pop-options


### PR DESCRIPTION
Good to see PRs are now required!

This changes the vectors in Merkle tree deserialization to have a reserved size of 0, to circumvent https://github.com/FStarLang/FStar/issues/2072, so CCF can upgrade their Everest dependencies without hot-fixes again, see https://github.com/microsoft/CCF/issues/1362. (https://github.com/FStarLang/FStar/issues/2072 will ultimately require more proof work on my end).