### PR TITLE
unroll first iteration of bn-mul

### DIFF
--- a/code/bignum/Hacl.Bignum.Karatsuba.fst
+++ b/code/bignum/Hacl.Bignum.Karatsuba.fst
@@ -194,7 +194,7 @@ let rec karatsuba () = karatsuba_open karastuba
 
 inline_for_extraction noextract
 let bn_karatsuba_mul_st (t:limb_t) =
-    len:size_t{4 * v len <= max_size_t}
+    len:size_t{0 < v len /\ 4 * v len <= max_size_t}
   -> a:lbignum t len
   -> b:lbignum t len
   -> tmp:lbignum t (4ul *! len)

--- a/code/bignum/Hacl.Bignum.MontArithmetic.fsti
+++ b/code/bignum/Hacl.Bignum.MontArithmetic.fsti
@@ -150,6 +150,7 @@ let bn_field_init_st (t:limb_t) (len:BN.meta_len t) =
     B.(fresh_loc (footprint h1 res) h0 h1) /\
     B.(loc_includes (loc_region_only true r) (footprint h1 res)) /\
     freeable h1 res /\
+    (B.deref h1 res).len == len /\ bn_v_n h1 res == bn_v h0 n /\
     S.bn_mont_ctx_inv (as_pctx h1 res) /\
     as_pctx h1 res == S.bn_field_init (as_seq h0 n))
 

--- a/code/bignum/Hacl.Bignum.fsti
+++ b/code/bignum/Hacl.Bignum.fsti
@@ -205,7 +205,7 @@ val bn_karatsuba_mul:
 
 
 inline_for_extraction noextract
-let bn_mul_st (t:limb_t) (aLen:size_t) (bLen:size_t{v aLen + v bLen <= max_size_t}) (a:lbignum t aLen) =
+let bn_mul_st (t:limb_t) (aLen:size_t) (bLen:size_t{0 < v bLen /\ v aLen + v bLen <= max_size_t}) (a:lbignum t aLen) =
     b:lbignum t bLen
   -> res:lbignum t (aLen +! bLen) ->
   Stack unit
@@ -220,7 +220,7 @@ inline_for_extraction noextract
 val bn_mul:
     #t:limb_t
   -> aLen:size_t
-  -> bLen:size_t{v aLen + v bLen <= max_size_t}
+  -> bLen:size_t{0 < v bLen /\ v aLen + v bLen <= max_size_t}
   -> a:lbignum t aLen ->
   bn_mul_st t aLen bLen a
 

--- a/code/bignum/Hacl.Spec.Bignum.MontArithmetic.fsti
+++ b/code/bignum/Hacl.Spec.Bignum.MontArithmetic.fsti
@@ -48,7 +48,7 @@ val bn_field_check_modulus: #t:limb_t -> #len:BN.bn_len t -> n:lbignum t len ->
 val bn_field_init: #t:limb_t -> #len:BN.bn_len t -> n:lbignum t len ->
   Pure (bn_mont_ctx t)
   (requires bn_mont_ctx_pre n)
-  (ensures  fun k -> bn_mont_ctx_inv k)
+  (ensures  fun k -> bn_mont_ctx_inv k /\ k.n == n /\ k.len == len)
 
 
 val bn_to_field: #t:limb_t -> k:bn_mont_ctx t{bn_mont_ctx_inv k} -> a:lbignum t k.len ->

--- a/dist/gcc-compatible/Hacl_Bignum256.c
+++ b/dist/gcc-compatible/Hacl_Bignum256.c
@@ -246,29 +246,49 @@ Write `a * b` in `res`.
 void Hacl_Bignum256_mul(uint64_t *a, uint64_t *b, uint64_t *res)
 {
   memset(res, 0U, (uint32_t)8U * sizeof (uint64_t));
-  KRML_MAYBE_FOR4(i0,
-    (uint32_t)0U,
+  uint64_t b0 = b[0U];
+  uint64_t *uu____0 = res;
+  uint64_t c = (uint64_t)0U;
+  {
+    uint64_t a_i = a[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = uu____0 + (uint32_t)4U * (uint32_t)0U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i, b0, c, res_i0);
+    uint64_t a_i0 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i0, b0, c, res_i1);
+    uint64_t a_i1 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i1, b0, c, res_i2);
+    uint64_t a_i2 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i2, b0, c, res_i);
+  }
+  uint64_t r = c;
+  uint64_t c0 = r;
+  res[4U] = c0;
+  KRML_MAYBE_FOR3(i0,
+    (uint32_t)1U,
     (uint32_t)4U,
     (uint32_t)1U,
     uint64_t bj = b[i0];
     uint64_t *res_j = res + i0;
-    uint64_t c = (uint64_t)0U;
+    uint64_t c1 = (uint64_t)0U;
     {
       uint64_t a_i = a[(uint32_t)4U * (uint32_t)0U];
       uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i0);
       uint64_t a_i0 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
       uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c, res_i1);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c1, res_i1);
       uint64_t a_i1 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
       uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c1, res_i2);
       uint64_t a_i2 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
       uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c1, res_i);
     }
-    uint64_t r = c;
-    res[(uint32_t)4U + i0] = r;);
+    uint64_t r0 = c1;
+    res[(uint32_t)4U + i0] = r0;);
 }
 
 /*
@@ -454,29 +474,49 @@ amont_mul(uint64_t *n, uint64_t nInv_u64, uint64_t *aM, uint64_t *bM, uint64_t *
 {
   uint64_t c[8U] = { 0U };
   memset(c, 0U, (uint32_t)8U * sizeof (uint64_t));
-  KRML_MAYBE_FOR4(i0,
-    (uint32_t)0U,
+  uint64_t b0 = bM[0U];
+  uint64_t *uu____0 = c;
+  uint64_t c1 = (uint64_t)0U;
+  {
+    uint64_t a_i = aM[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = uu____0 + (uint32_t)4U * (uint32_t)0U;
+    c1 = Hacl_Bignum_Base_mul_wide_add_u64(a_i, b0, c1, res_i0);
+    uint64_t a_i0 = aM[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
+    c1 = Hacl_Bignum_Base_mul_wide_add_u64(a_i0, b0, c1, res_i1);
+    uint64_t a_i1 = aM[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
+    c1 = Hacl_Bignum_Base_mul_wide_add_u64(a_i1, b0, c1, res_i2);
+    uint64_t a_i2 = aM[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c1 = Hacl_Bignum_Base_mul_wide_add_u64(a_i2, b0, c1, res_i);
+  }
+  uint64_t r = c1;
+  uint64_t c10 = r;
+  c[4U] = c10;
+  KRML_MAYBE_FOR3(i0,
+    (uint32_t)1U,
     (uint32_t)4U,
     (uint32_t)1U,
     uint64_t bj = bM[i0];
     uint64_t *res_j = c + i0;
-    uint64_t c1 = (uint64_t)0U;
+    uint64_t c2 = (uint64_t)0U;
     {
       uint64_t a_i = aM[(uint32_t)4U * (uint32_t)0U];
       uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i0);
+      c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c2, res_i0);
       uint64_t a_i0 = aM[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
       uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c1, res_i1);
+      c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c2, res_i1);
       uint64_t a_i1 = aM[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
       uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c1, res_i2);
+      c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c2, res_i2);
       uint64_t a_i2 = aM[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
       uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c1, res_i);
+      c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c2, res_i);
     }
-    uint64_t r = c1;
-    c[(uint32_t)4U + i0] = r;);
+    uint64_t r0 = c2;
+    c[(uint32_t)4U + i0] = r0;);
   areduction(n, nInv_u64, c, resM);
 }
 

--- a/dist/gcc-compatible/Hacl_Bignum256_32.c
+++ b/dist/gcc-compatible/Hacl_Bignum256_32.c
@@ -258,31 +258,53 @@ Write `a * b` in `res`.
 void Hacl_Bignum256_32_mul(uint32_t *a, uint32_t *b, uint32_t *res)
 {
   memset(res, 0U, (uint32_t)16U * sizeof (uint32_t));
-  KRML_MAYBE_FOR8(i0,
+  uint32_t b0 = b[0U];
+  uint32_t *uu____0 = res;
+  uint32_t c = (uint32_t)0U;
+  KRML_MAYBE_FOR2(i,
     (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
+    uint32_t a_i = a[(uint32_t)4U * i];
+    uint32_t *res_i0 = uu____0 + (uint32_t)4U * i;
+    c = Hacl_Bignum_Base_mul_wide_add_u32(a_i, b0, c, res_i0);
+    uint32_t a_i0 = a[(uint32_t)4U * i + (uint32_t)1U];
+    uint32_t *res_i1 = uu____0 + (uint32_t)4U * i + (uint32_t)1U;
+    c = Hacl_Bignum_Base_mul_wide_add_u32(a_i0, b0, c, res_i1);
+    uint32_t a_i1 = a[(uint32_t)4U * i + (uint32_t)2U];
+    uint32_t *res_i2 = uu____0 + (uint32_t)4U * i + (uint32_t)2U;
+    c = Hacl_Bignum_Base_mul_wide_add_u32(a_i1, b0, c, res_i2);
+    uint32_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
+    uint32_t *res_i = uu____0 + (uint32_t)4U * i + (uint32_t)3U;
+    c = Hacl_Bignum_Base_mul_wide_add_u32(a_i2, b0, c, res_i););
+  uint32_t r = c;
+  uint32_t c0 = r;
+  res[8U] = c0;
+  KRML_MAYBE_FOR7(i0,
+    (uint32_t)1U,
     (uint32_t)8U,
     (uint32_t)1U,
     uint32_t bj = b[i0];
     uint32_t *res_j = res + i0;
-    uint32_t c = (uint32_t)0U;
+    uint32_t c1 = (uint32_t)0U;
     KRML_MAYBE_FOR2(i,
       (uint32_t)0U,
       (uint32_t)2U,
       (uint32_t)1U,
       uint32_t a_i = a[(uint32_t)4U * i];
       uint32_t *res_i0 = res_j + (uint32_t)4U * i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c, res_i0);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c1, res_i0);
       uint32_t a_i0 = a[(uint32_t)4U * i + (uint32_t)1U];
       uint32_t *res_i1 = res_j + (uint32_t)4U * i + (uint32_t)1U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i0, bj, c, res_i1);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i0, bj, c1, res_i1);
       uint32_t a_i1 = a[(uint32_t)4U * i + (uint32_t)2U];
       uint32_t *res_i2 = res_j + (uint32_t)4U * i + (uint32_t)2U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, bj, c, res_i2);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, bj, c1, res_i2);
       uint32_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, bj, c, res_i););
-    uint32_t r = c;
-    res[(uint32_t)8U + i0] = r;);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, bj, c1, res_i););
+    uint32_t r0 = c1;
+    res[(uint32_t)8U + i0] = r0;);
 }
 
 /*
@@ -474,31 +496,53 @@ amont_mul(uint32_t *n, uint32_t nInv_u64, uint32_t *aM, uint32_t *bM, uint32_t *
 {
   uint32_t c[16U] = { 0U };
   memset(c, 0U, (uint32_t)16U * sizeof (uint32_t));
-  KRML_MAYBE_FOR8(i0,
+  uint32_t b0 = bM[0U];
+  uint32_t *uu____0 = c;
+  uint32_t c1 = (uint32_t)0U;
+  KRML_MAYBE_FOR2(i,
     (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
+    uint32_t a_i = aM[(uint32_t)4U * i];
+    uint32_t *res_i0 = uu____0 + (uint32_t)4U * i;
+    c1 = Hacl_Bignum_Base_mul_wide_add_u32(a_i, b0, c1, res_i0);
+    uint32_t a_i0 = aM[(uint32_t)4U * i + (uint32_t)1U];
+    uint32_t *res_i1 = uu____0 + (uint32_t)4U * i + (uint32_t)1U;
+    c1 = Hacl_Bignum_Base_mul_wide_add_u32(a_i0, b0, c1, res_i1);
+    uint32_t a_i1 = aM[(uint32_t)4U * i + (uint32_t)2U];
+    uint32_t *res_i2 = uu____0 + (uint32_t)4U * i + (uint32_t)2U;
+    c1 = Hacl_Bignum_Base_mul_wide_add_u32(a_i1, b0, c1, res_i2);
+    uint32_t a_i2 = aM[(uint32_t)4U * i + (uint32_t)3U];
+    uint32_t *res_i = uu____0 + (uint32_t)4U * i + (uint32_t)3U;
+    c1 = Hacl_Bignum_Base_mul_wide_add_u32(a_i2, b0, c1, res_i););
+  uint32_t r = c1;
+  uint32_t c10 = r;
+  c[8U] = c10;
+  KRML_MAYBE_FOR7(i0,
+    (uint32_t)1U,
     (uint32_t)8U,
     (uint32_t)1U,
     uint32_t bj = bM[i0];
     uint32_t *res_j = c + i0;
-    uint32_t c1 = (uint32_t)0U;
+    uint32_t c2 = (uint32_t)0U;
     KRML_MAYBE_FOR2(i,
       (uint32_t)0U,
       (uint32_t)2U,
       (uint32_t)1U,
       uint32_t a_i = aM[(uint32_t)4U * i];
       uint32_t *res_i0 = res_j + (uint32_t)4U * i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c1, res_i0);
+      c2 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c2, res_i0);
       uint32_t a_i0 = aM[(uint32_t)4U * i + (uint32_t)1U];
       uint32_t *res_i1 = res_j + (uint32_t)4U * i + (uint32_t)1U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i0, bj, c1, res_i1);
+      c2 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i0, bj, c2, res_i1);
       uint32_t a_i1 = aM[(uint32_t)4U * i + (uint32_t)2U];
       uint32_t *res_i2 = res_j + (uint32_t)4U * i + (uint32_t)2U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, bj, c1, res_i2);
+      c2 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, bj, c2, res_i2);
       uint32_t a_i2 = aM[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, bj, c1, res_i););
-    uint32_t r = c1;
-    c[(uint32_t)8U + i0] = r;);
+      c2 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, bj, c2, res_i););
+    uint32_t r0 = c2;
+    c[(uint32_t)8U + i0] = r0;);
   areduction(n, nInv_u64, c, resM);
 }
 

--- a/dist/gcc-compatible/Hacl_Bignum_Base.h
+++ b/dist/gcc-compatible/Hacl_Bignum_Base.h
@@ -71,6 +71,14 @@ Hacl_Bignum_Convert_bn_to_bytes_be_uint64(uint32_t len, uint64_t *b, uint8_t *re
   memcpy(res, tmp + tmpLen - len, len * sizeof (uint8_t));
 }
 
+static inline uint32_t
+Hacl_Bignum_Base_mul_wide_add_u32(uint32_t a, uint32_t b, uint32_t c_in, uint32_t *out)
+{
+  uint64_t res = (uint64_t)a * (uint64_t)b + (uint64_t)c_in;
+  out[0U] = (uint32_t)res;
+  return (uint32_t)(res >> (uint32_t)32U);
+}
+
 static inline uint64_t
 Hacl_Bignum_Base_mul_wide_add_u64(uint64_t a, uint64_t b, uint64_t c_in, uint64_t *out)
 {
@@ -266,34 +274,61 @@ Hacl_Bignum_Multiplication_bn_mul_u32(
 )
 {
   memset(res, 0U, (aLen + bLen) * sizeof (uint32_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < bLen; i0++)
+  uint32_t b0 = b[0U];
+  uint32_t *uu____0 = res;
+  uint32_t c = (uint32_t)0U;
+  for (uint32_t i = (uint32_t)0U; i < aLen / (uint32_t)4U; i++)
+  {
+    uint32_t a_i = a[(uint32_t)4U * i];
+    uint32_t *res_i0 = uu____0 + (uint32_t)4U * i;
+    c = Hacl_Bignum_Base_mul_wide_add_u32(a_i, b0, c, res_i0);
+    uint32_t a_i0 = a[(uint32_t)4U * i + (uint32_t)1U];
+    uint32_t *res_i1 = uu____0 + (uint32_t)4U * i + (uint32_t)1U;
+    c = Hacl_Bignum_Base_mul_wide_add_u32(a_i0, b0, c, res_i1);
+    uint32_t a_i1 = a[(uint32_t)4U * i + (uint32_t)2U];
+    uint32_t *res_i2 = uu____0 + (uint32_t)4U * i + (uint32_t)2U;
+    c = Hacl_Bignum_Base_mul_wide_add_u32(a_i1, b0, c, res_i2);
+    uint32_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
+    uint32_t *res_i = uu____0 + (uint32_t)4U * i + (uint32_t)3U;
+    c = Hacl_Bignum_Base_mul_wide_add_u32(a_i2, b0, c, res_i);
+  }
+  for (uint32_t i = aLen / (uint32_t)4U * (uint32_t)4U; i < aLen; i++)
+  {
+    uint32_t a_i = a[i];
+    uint32_t *res_i = uu____0 + i;
+    c = Hacl_Bignum_Base_mul_wide_add_u32(a_i, b0, c, res_i);
+  }
+  uint32_t r = c;
+  uint32_t c0 = r;
+  res[aLen] = c0;
+  for (uint32_t i0 = (uint32_t)1U; i0 < bLen; i0++)
   {
     uint32_t bj = b[i0];
     uint32_t *res_j = res + i0;
-    uint32_t c = (uint32_t)0U;
+    uint32_t c1 = (uint32_t)0U;
     for (uint32_t i = (uint32_t)0U; i < aLen / (uint32_t)4U; i++)
     {
       uint32_t a_i = a[(uint32_t)4U * i];
       uint32_t *res_i0 = res_j + (uint32_t)4U * i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c, res_i0);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c1, res_i0);
       uint32_t a_i0 = a[(uint32_t)4U * i + (uint32_t)1U];
       uint32_t *res_i1 = res_j + (uint32_t)4U * i + (uint32_t)1U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i0, bj, c, res_i1);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i0, bj, c1, res_i1);
       uint32_t a_i1 = a[(uint32_t)4U * i + (uint32_t)2U];
       uint32_t *res_i2 = res_j + (uint32_t)4U * i + (uint32_t)2U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, bj, c, res_i2);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, bj, c1, res_i2);
       uint32_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, bj, c, res_i);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, bj, c1, res_i);
     }
     for (uint32_t i = aLen / (uint32_t)4U * (uint32_t)4U; i < aLen; i++)
     {
       uint32_t a_i = a[i];
       uint32_t *res_i = res_j + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c, res_i);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c1, res_i);
     }
-    uint32_t r = c;
-    res[aLen + i0] = r;
+    uint32_t r0 = c1;
+    res[aLen + i0] = r0;
   }
 }
 
@@ -307,34 +342,61 @@ Hacl_Bignum_Multiplication_bn_mul_u64(
 )
 {
   memset(res, 0U, (aLen + bLen) * sizeof (uint64_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < bLen; i0++)
+  uint64_t b0 = b[0U];
+  uint64_t *uu____0 = res;
+  uint64_t c = (uint64_t)0U;
+  for (uint32_t i = (uint32_t)0U; i < aLen / (uint32_t)4U; i++)
+  {
+    uint64_t a_i = a[(uint32_t)4U * i];
+    uint64_t *res_i0 = uu____0 + (uint32_t)4U * i;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i, b0, c, res_i0);
+    uint64_t a_i0 = a[(uint32_t)4U * i + (uint32_t)1U];
+    uint64_t *res_i1 = uu____0 + (uint32_t)4U * i + (uint32_t)1U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i0, b0, c, res_i1);
+    uint64_t a_i1 = a[(uint32_t)4U * i + (uint32_t)2U];
+    uint64_t *res_i2 = uu____0 + (uint32_t)4U * i + (uint32_t)2U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i1, b0, c, res_i2);
+    uint64_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
+    uint64_t *res_i = uu____0 + (uint32_t)4U * i + (uint32_t)3U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i2, b0, c, res_i);
+  }
+  for (uint32_t i = aLen / (uint32_t)4U * (uint32_t)4U; i < aLen; i++)
+  {
+    uint64_t a_i = a[i];
+    uint64_t *res_i = uu____0 + i;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i, b0, c, res_i);
+  }
+  uint64_t r = c;
+  uint64_t c0 = r;
+  res[aLen] = c0;
+  for (uint32_t i0 = (uint32_t)1U; i0 < bLen; i0++)
   {
     uint64_t bj = b[i0];
     uint64_t *res_j = res + i0;
-    uint64_t c = (uint64_t)0U;
+    uint64_t c1 = (uint64_t)0U;
     for (uint32_t i = (uint32_t)0U; i < aLen / (uint32_t)4U; i++)
     {
       uint64_t a_i = a[(uint32_t)4U * i];
       uint64_t *res_i0 = res_j + (uint32_t)4U * i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i0);
       uint64_t a_i0 = a[(uint32_t)4U * i + (uint32_t)1U];
       uint64_t *res_i1 = res_j + (uint32_t)4U * i + (uint32_t)1U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c, res_i1);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c1, res_i1);
       uint64_t a_i1 = a[(uint32_t)4U * i + (uint32_t)2U];
       uint64_t *res_i2 = res_j + (uint32_t)4U * i + (uint32_t)2U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c1, res_i2);
       uint64_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c1, res_i);
     }
     for (uint32_t i = aLen / (uint32_t)4U * (uint32_t)4U; i < aLen; i++)
     {
       uint64_t a_i = a[i];
       uint64_t *res_i = res_j + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i);
     }
-    uint64_t r = c;
-    res[aLen + i0] = r;
+    uint64_t r0 = c1;
+    res[aLen + i0] = r0;
   }
 }
 

--- a/dist/gcc-compatible/Hacl_Curve25519_64_Slow.c
+++ b/dist/gcc-compatible/Hacl_Curve25519_64_Slow.c
@@ -125,57 +125,77 @@ static inline void fmul_(uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 {
   uint64_t *tmp0 = tmp;
   memset(tmp0, 0U, (uint32_t)8U * sizeof (uint64_t));
-  KRML_MAYBE_FOR4(i0,
-    (uint32_t)0U,
+  uint64_t b0 = f2[0U];
+  uint64_t *uu____0 = tmp0;
+  uint64_t c0 = (uint64_t)0U;
+  {
+    uint64_t a_i = f1[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = uu____0 + (uint32_t)4U * (uint32_t)0U;
+    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i, b0, c0, res_i0);
+    uint64_t a_i0 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
+    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i0, b0, c0, res_i1);
+    uint64_t a_i1 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
+    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i1, b0, c0, res_i2);
+    uint64_t a_i2 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i2, b0, c0, res_i);
+  }
+  uint64_t r = c0;
+  uint64_t c2 = r;
+  tmp0[4U] = c2;
+  KRML_MAYBE_FOR3(i0,
+    (uint32_t)1U,
     (uint32_t)4U,
     (uint32_t)1U,
     uint64_t bj = f2[i0];
     uint64_t *res_j = tmp0 + i0;
-    uint64_t c = (uint64_t)0U;
+    uint64_t c1 = (uint64_t)0U;
     {
       uint64_t a_i = f1[(uint32_t)4U * (uint32_t)0U];
       uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i0);
       uint64_t a_i0 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
       uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c, res_i1);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c1, res_i1);
       uint64_t a_i1 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
       uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c1, res_i2);
       uint64_t a_i2 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
       uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c1, res_i);
     }
-    uint64_t r = c;
-    tmp0[(uint32_t)4U + i0] = r;);
-  uint64_t *uu____0 = tmp0 + (uint32_t)4U;
-  uint64_t *uu____1 = tmp0;
-  uint64_t *res_j = uu____1;
-  uint64_t c0 = (uint64_t)0U;
-  {
-    uint64_t a_i = uu____0[(uint32_t)4U * (uint32_t)0U];
-    uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
-    c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, (uint64_t)38U, c0, res_i0);
-    uint64_t a_i0 = uu____0[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
-    uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
-    c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, (uint64_t)38U, c0, res_i1);
-    uint64_t a_i1 = uu____0[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
-    uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
-    c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, (uint64_t)38U, c0, res_i2);
-    uint64_t a_i2 = uu____0[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
-    uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
-    c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, (uint64_t)38U, c0, res_i);
-  }
-  uint64_t r = c0;
-  uint64_t c00 = r;
+    uint64_t r0 = c1;
+    tmp0[(uint32_t)4U + i0] = r0;);
+  uint64_t *uu____1 = tmp0 + (uint32_t)4U;
   uint64_t *uu____2 = tmp0;
+  uint64_t *res_j = uu____2;
+  uint64_t c1 = (uint64_t)0U;
+  {
+    uint64_t a_i = uu____1[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
+    c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, (uint64_t)38U, c1, res_i0);
+    uint64_t a_i0 = uu____1[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
+    c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, (uint64_t)38U, c1, res_i1);
+    uint64_t a_i1 = uu____1[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
+    c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, (uint64_t)38U, c1, res_i2);
+    uint64_t a_i2 = uu____1[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, (uint64_t)38U, c1, res_i);
+  }
+  uint64_t r0 = c1;
+  uint64_t c00 = r0;
+  uint64_t *uu____3 = tmp0;
   uint64_t
   c01 =
     Lib_IntTypes_Intrinsics_add_carry_u64((uint64_t)0U,
-      uu____2[0U],
+      uu____3[0U],
       c00 * (uint64_t)38U,
       out);
-  uint64_t *a1 = uu____2 + (uint32_t)1U;
+  uint64_t *a1 = uu____3 + (uint32_t)1U;
   uint64_t *res1 = out + (uint32_t)1U;
   uint64_t c = c01;
   KRML_MAYBE_FOR3(i,
@@ -185,9 +205,9 @@ static inline void fmul_(uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     uint64_t t1 = a1[i];
     uint64_t *res_i = res1 + i;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, (uint64_t)0U, res_i););
-  uint64_t c1 = c;
-  uint64_t c2 = c1;
-  out[0U] = out[0U] + c2 * (uint64_t)38U;
+  uint64_t c10 = c;
+  uint64_t c3 = c10;
+  out[0U] = out[0U] + c3 * (uint64_t)38U;
 }
 
 static inline void fmul2_(uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tmp)

--- a/dist/gcc-compatible/Hacl_K256_ECDSA.c
+++ b/dist/gcc-compatible/Hacl_K256_ECDSA.c
@@ -224,29 +224,49 @@ static void sub_mod4(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
 static void mul4(uint64_t *a, uint64_t *b, uint64_t *res)
 {
   memset(res, 0U, (uint32_t)8U * sizeof (uint64_t));
-  KRML_MAYBE_FOR4(i0,
-    (uint32_t)0U,
+  uint64_t b0 = b[0U];
+  uint64_t *uu____0 = res;
+  uint64_t c = (uint64_t)0U;
+  {
+    uint64_t a_i = a[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = uu____0 + (uint32_t)4U * (uint32_t)0U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i, b0, c, res_i0);
+    uint64_t a_i0 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i0, b0, c, res_i1);
+    uint64_t a_i1 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i1, b0, c, res_i2);
+    uint64_t a_i2 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i2, b0, c, res_i);
+  }
+  uint64_t r = c;
+  uint64_t c0 = r;
+  res[4U] = c0;
+  KRML_MAYBE_FOR3(i0,
+    (uint32_t)1U,
     (uint32_t)4U,
     (uint32_t)1U,
     uint64_t bj = b[i0];
     uint64_t *res_j = res + i0;
-    uint64_t c = (uint64_t)0U;
+    uint64_t c1 = (uint64_t)0U;
     {
       uint64_t a_i = a[(uint32_t)4U * (uint32_t)0U];
       uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i0);
       uint64_t a_i0 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
       uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c, res_i1);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c1, res_i1);
       uint64_t a_i1 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
       uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c1, res_i2);
       uint64_t a_i2 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
       uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c1, res_i);
     }
-    uint64_t r = c;
-    res[(uint32_t)4U + i0] = r;);
+    uint64_t r0 = c1;
+    res[(uint32_t)4U + i0] = r0;);
 }
 
 static void sqr4(uint64_t *a, uint64_t *res)
@@ -459,40 +479,65 @@ mul_pow2_256_minus_q_add(
   uint64_t tmp[len + (uint32_t)2U];
   memset(tmp, 0U, (len + (uint32_t)2U) * sizeof (uint64_t));
   memset(tmp, 0U, (len + (uint32_t)2U) * sizeof (uint64_t));
-  KRML_MAYBE_FOR2(i0,
-    (uint32_t)0U,
-    (uint32_t)2U,
-    (uint32_t)1U,
-    uint64_t bj = t01[i0];
-    uint64_t *res_j = tmp + i0;
-    uint64_t c = (uint64_t)0U;
+  uint64_t b0 = t01[0U];
+  uint64_t *uu____0 = tmp;
+  uint64_t c = (uint64_t)0U;
+  for (uint32_t i = (uint32_t)0U; i < len / (uint32_t)4U; i++)
+  {
+    uint64_t a_i = a[(uint32_t)4U * i];
+    uint64_t *res_i0 = uu____0 + (uint32_t)4U * i;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i, b0, c, res_i0);
+    uint64_t a_i0 = a[(uint32_t)4U * i + (uint32_t)1U];
+    uint64_t *res_i1 = uu____0 + (uint32_t)4U * i + (uint32_t)1U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i0, b0, c, res_i1);
+    uint64_t a_i1 = a[(uint32_t)4U * i + (uint32_t)2U];
+    uint64_t *res_i2 = uu____0 + (uint32_t)4U * i + (uint32_t)2U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i1, b0, c, res_i2);
+    uint64_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
+    uint64_t *res_i = uu____0 + (uint32_t)4U * i + (uint32_t)3U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i2, b0, c, res_i);
+  }
+  for (uint32_t i = len / (uint32_t)4U * (uint32_t)4U; i < len; i++)
+  {
+    uint64_t a_i = a[i];
+    uint64_t *res_i = uu____0 + i;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i, b0, c, res_i);
+  }
+  uint64_t r = c;
+  uint64_t c0 = r;
+  tmp[len] = c0;
+  {
+    uint64_t bj = t01[1U];
+    uint64_t *res_j = tmp + (uint32_t)1U;
+    uint64_t c1 = (uint64_t)0U;
     for (uint32_t i = (uint32_t)0U; i < len / (uint32_t)4U; i++)
     {
       uint64_t a_i = a[(uint32_t)4U * i];
       uint64_t *res_i0 = res_j + (uint32_t)4U * i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i0);
       uint64_t a_i0 = a[(uint32_t)4U * i + (uint32_t)1U];
       uint64_t *res_i1 = res_j + (uint32_t)4U * i + (uint32_t)1U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c, res_i1);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c1, res_i1);
       uint64_t a_i1 = a[(uint32_t)4U * i + (uint32_t)2U];
       uint64_t *res_i2 = res_j + (uint32_t)4U * i + (uint32_t)2U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c1, res_i2);
       uint64_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c1, res_i);
     }
     for (uint32_t i = len / (uint32_t)4U * (uint32_t)4U; i < len; i++)
     {
       uint64_t a_i = a[i];
       uint64_t *res_i = res_j + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i);
     }
-    uint64_t r = c;
-    tmp[len + i0] = r;);
+    uint64_t r0 = c1;
+    tmp[len + (uint32_t)1U] = r0;
+  }
   memcpy(res + (uint32_t)2U, a, len * sizeof (uint64_t));
-  uint64_t uu____0 = bn_add(resLen, res, len + (uint32_t)2U, tmp, res);
-  uint64_t c = bn_add(resLen, res, (uint32_t)4U, e, res);
-  return c;
+  uint64_t uu____1 = bn_add(resLen, res, len + (uint32_t)2U, tmp, res);
+  uint64_t c1 = bn_add(resLen, res, (uint32_t)4U, e, res);
+  return c1;
 }
 
 static inline void modq(uint64_t *out, uint64_t *a)

--- a/dist/gcc-compatible/Hacl_P256.c
+++ b/dist/gcc-compatible/Hacl_P256.c
@@ -519,29 +519,49 @@ static void montgomery_multiplication_buffer(uint64_t *a, uint64_t *b, uint64_t 
   uint64_t round2[8U] = { 0U };
   uint64_t round4[8U] = { 0U };
   memset(t, 0U, (uint32_t)8U * sizeof (uint64_t));
-  KRML_MAYBE_FOR4(i0,
-    (uint32_t)0U,
+  uint64_t b0 = b[0U];
+  uint64_t *uu____0 = t;
+  uint64_t c0 = (uint64_t)0U;
+  {
+    uint64_t a_i = a[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = uu____0 + (uint32_t)4U * (uint32_t)0U;
+    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i, b0, c0, res_i0);
+    uint64_t a_i0 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
+    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i0, b0, c0, res_i1);
+    uint64_t a_i1 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
+    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i1, b0, c0, res_i2);
+    uint64_t a_i2 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i2, b0, c0, res_i);
+  }
+  uint64_t r = c0;
+  uint64_t c2 = r;
+  t[4U] = c2;
+  KRML_MAYBE_FOR3(i0,
+    (uint32_t)1U,
     (uint32_t)4U,
     (uint32_t)1U,
     uint64_t bj = b[i0];
     uint64_t *res_j = t + i0;
-    uint64_t c = (uint64_t)0U;
+    uint64_t c1 = (uint64_t)0U;
     {
       uint64_t a_i = a[(uint32_t)4U * (uint32_t)0U];
       uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i0);
       uint64_t a_i0 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
       uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c, res_i1);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c1, res_i1);
       uint64_t a_i1 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
       uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c1, res_i2);
       uint64_t a_i2 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
       uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c1, res_i);
     }
-    uint64_t r = c;
-    t[(uint32_t)4U + i0] = r;);
+    uint64_t r0 = c1;
+    t[(uint32_t)4U + i0] = r0;);
   uint64_t tempRound[8U] = { 0U };
   uint64_t t20[8U] = { 0U };
   uint64_t t30[8U] = { 0U };
@@ -564,15 +584,15 @@ static void montgomery_multiplication_buffer(uint64_t *a, uint64_t *b, uint64_t 
   uint64_t h1 = temp1;
   mul64(f20, t10, o20, &temp1);
   uint64_t l1 = o20[0U];
-  uint64_t c2 = Lib_IntTypes_Intrinsics_add_carry_u64(c1, l1, h1, o20);
+  uint64_t c20 = Lib_IntTypes_Intrinsics_add_carry_u64(c1, l1, h1, o20);
   uint64_t h2 = temp1;
   mul64(f30, t10, o30, &temp1);
   uint64_t l2 = o30[0U];
-  uint64_t c3 = Lib_IntTypes_Intrinsics_add_carry_u64(c2, l2, h2, o30);
+  uint64_t c3 = Lib_IntTypes_Intrinsics_add_carry_u64(c20, l2, h2, o30);
   uint64_t temp00 = temp1;
-  uint64_t c0 = c3 + temp00;
-  t20[4U] = c0;
-  uint64_t uu____0 = add8(t, t20, t30);
+  uint64_t c4 = c3 + temp00;
+  t20[4U] = c4;
+  uint64_t uu____1 = add8(t, t20, t30);
   shift8(t30, tempRound);
   uint64_t t21[8U] = { 0U };
   uint64_t t31[8U] = { 0U };
@@ -595,15 +615,15 @@ static void montgomery_multiplication_buffer(uint64_t *a, uint64_t *b, uint64_t 
   uint64_t h4 = temp2;
   mul64(f21, t11, o21, &temp2);
   uint64_t l4 = o21[0U];
-  uint64_t c20 = Lib_IntTypes_Intrinsics_add_carry_u64(c10, l4, h4, o21);
+  uint64_t c21 = Lib_IntTypes_Intrinsics_add_carry_u64(c10, l4, h4, o21);
   uint64_t h5 = temp2;
   mul64(f31, t11, o31, &temp2);
   uint64_t l5 = o31[0U];
-  uint64_t c30 = Lib_IntTypes_Intrinsics_add_carry_u64(c20, l5, h5, o31);
+  uint64_t c30 = Lib_IntTypes_Intrinsics_add_carry_u64(c21, l5, h5, o31);
   uint64_t temp01 = temp2;
-  uint64_t c4 = c30 + temp01;
-  t21[4U] = c4;
-  uint64_t uu____1 = add8(tempRound, t21, t31);
+  uint64_t c5 = c30 + temp01;
+  t21[4U] = c5;
+  uint64_t uu____2 = add8(tempRound, t21, t31);
   shift8(t31, round2);
   uint64_t tempRound0[8U] = { 0U };
   uint64_t t2[8U] = { 0U };
@@ -627,15 +647,15 @@ static void montgomery_multiplication_buffer(uint64_t *a, uint64_t *b, uint64_t 
   uint64_t h7 = temp3;
   mul64(f22, t12, o22, &temp3);
   uint64_t l7 = o22[0U];
-  uint64_t c21 = Lib_IntTypes_Intrinsics_add_carry_u64(c11, l7, h7, o22);
+  uint64_t c22 = Lib_IntTypes_Intrinsics_add_carry_u64(c11, l7, h7, o22);
   uint64_t h8 = temp3;
   mul64(f32, t12, o32, &temp3);
   uint64_t l8 = o32[0U];
-  uint64_t c31 = Lib_IntTypes_Intrinsics_add_carry_u64(c21, l8, h8, o32);
+  uint64_t c31 = Lib_IntTypes_Intrinsics_add_carry_u64(c22, l8, h8, o32);
   uint64_t temp02 = temp3;
-  uint64_t c5 = c31 + temp02;
-  t2[4U] = c5;
-  uint64_t uu____2 = add8(round2, t2, t32);
+  uint64_t c6 = c31 + temp02;
+  t2[4U] = c6;
+  uint64_t uu____3 = add8(round2, t2, t32);
   shift8(t32, tempRound0);
   uint64_t t22[8U] = { 0U };
   uint64_t t3[8U] = { 0U };
@@ -658,15 +678,15 @@ static void montgomery_multiplication_buffer(uint64_t *a, uint64_t *b, uint64_t 
   uint64_t h10 = temp;
   mul64(f2, t1, o2, &temp);
   uint64_t l10 = o2[0U];
-  uint64_t c22 = Lib_IntTypes_Intrinsics_add_carry_u64(c12, l10, h10, o2);
+  uint64_t c23 = Lib_IntTypes_Intrinsics_add_carry_u64(c12, l10, h10, o2);
   uint64_t h = temp;
   mul64(f3, t1, o3, &temp);
   uint64_t l = o3[0U];
-  uint64_t c32 = Lib_IntTypes_Intrinsics_add_carry_u64(c22, l, h, o3);
+  uint64_t c32 = Lib_IntTypes_Intrinsics_add_carry_u64(c23, l, h, o3);
   uint64_t temp0 = temp;
-  uint64_t c6 = c32 + temp0;
-  t22[4U] = c6;
-  uint64_t uu____3 = add8(tempRound0, t22, t3);
+  uint64_t c7 = c32 + temp0;
+  t22[4U] = c7;
+  uint64_t uu____4 = add8(tempRound0, t22, t3);
   shift8(t3, round4);
   uint64_t tempBuffer[4U] = { 0U };
   uint64_t tempBufferForSubborrow = (uint64_t)0U;
@@ -1554,29 +1574,49 @@ static void montgomery_multiplication_ecdsa_module(uint64_t *a, uint64_t *b, uin
   uint64_t prime_p256_orderBuffer[4U] = { 0U };
   uint64_t k0 = (uint64_t)14758798090332847183U;
   memset(t, 0U, (uint32_t)8U * sizeof (uint64_t));
-  KRML_MAYBE_FOR4(i0,
-    (uint32_t)0U,
+  uint64_t b0 = b[0U];
+  uint64_t *uu____0 = t;
+  uint64_t c = (uint64_t)0U;
+  {
+    uint64_t a_i = a[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = uu____0 + (uint32_t)4U * (uint32_t)0U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i, b0, c, res_i0);
+    uint64_t a_i0 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i0, b0, c, res_i1);
+    uint64_t a_i1 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i1, b0, c, res_i2);
+    uint64_t a_i2 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = uu____0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c = Hacl_Bignum_Base_mul_wide_add_u64(a_i2, b0, c, res_i);
+  }
+  uint64_t r = c;
+  uint64_t c0 = r;
+  t[4U] = c0;
+  KRML_MAYBE_FOR3(i0,
+    (uint32_t)1U,
     (uint32_t)4U,
     (uint32_t)1U,
     uint64_t bj = b[i0];
     uint64_t *res_j = t + i0;
-    uint64_t c = (uint64_t)0U;
+    uint64_t c1 = (uint64_t)0U;
     {
       uint64_t a_i = a[(uint32_t)4U * (uint32_t)0U];
       uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i0);
       uint64_t a_i0 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
       uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c, res_i1);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c1, res_i1);
       uint64_t a_i1 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
       uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c1, res_i2);
       uint64_t a_i2 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
       uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c1, res_i);
     }
-    uint64_t r = c;
-    t[(uint32_t)4U + i0] = r;);
+    uint64_t r0 = c1;
+    t[(uint32_t)4U + i0] = r0;);
   montgomery_multiplication_round_twice(t, round2, k0);
   montgomery_multiplication_round_twice(round2, round4, k0);
   reduction_prime_2prime_with_carry(round4, result);

--- a/dist/gcc-compatible/lib/Hacl_Bignum_Base_bindings.ml
+++ b/dist/gcc-compatible/lib/Hacl_Bignum_Base_bindings.ml
@@ -8,6 +8,11 @@ module Bindings(F:Cstubs.FOREIGN) =
     let hacl_Bignum_Convert_bn_to_bytes_be_uint64 =
       foreign "Hacl_Bignum_Convert_bn_to_bytes_be_uint64"
         (uint32_t @-> ((ptr uint64_t) @-> (ocaml_bytes @-> (returning void))))
+    let hacl_Bignum_Base_mul_wide_add_u32 =
+      foreign "Hacl_Bignum_Base_mul_wide_add_u32"
+        (uint32_t @->
+           (uint32_t @->
+              (uint32_t @-> ((ptr uint32_t) @-> (returning uint32_t)))))
     let hacl_Bignum_Base_mul_wide_add_u64 =
       foreign "Hacl_Bignum_Base_mul_wide_add_u64"
         (uint64_t @->

--- a/dist/gcc-compatible/libevercrypt.def
+++ b/dist/gcc-compatible/libevercrypt.def
@@ -194,6 +194,7 @@ EXPORTS
   Hacl_Salsa20_hsalsa20
   Hacl_Bignum_Convert_bn_from_bytes_be_uint64
   Hacl_Bignum_Convert_bn_to_bytes_be_uint64
+  Hacl_Bignum_Base_mul_wide_add_u32
   Hacl_Bignum_Base_mul_wide_add_u64
   Hacl_Bignum_Base_mul_wide_add2_u32
   Hacl_Bignum_Base_mul_wide_add2_u64


### PR DESCRIPTION
This PR unrolls the first iteration of schoolbook multiplication to avoid extra additions with zeros. 
It also makes the post-condition of `bn_field_init` more accurate.