### PR TITLE
add GLV for secp256k1-ecdsa-verify

### DIFF
--- a/code/k256/Hacl.Impl.K256.GLV.Constants.fst
+++ b/code/k256/Hacl.Impl.K256.GLV.Constants.fst
@@ -1,0 +1,322 @@
+module Hacl.Impl.K256.GLV.Constants
+
+open FStar.HyperStack
+open FStar.HyperStack.ST
+open FStar.Mul
+
+open Lib.IntTypes
+open Lib.Buffer
+
+module ST = FStar.HyperStack.ST
+
+module S = Spec.K256
+module SG = Hacl.Spec.K256.GLV
+module SGL = Hacl.Spec.K256.GLV.Lemmas
+
+open Hacl.K256.Field
+open Hacl.K256.Scalar
+open Hacl.Impl.K256.Point
+
+#set-options "--z3rlimit 50 --fuel 0 --ifuel 0"
+
+inline_for_extraction noextract
+val make_minus_lambda: f:qelem -> Stack unit
+  (requires fun h -> live h f)
+  (ensures  fun h0 _ h1 -> modifies (loc f) h0 h1 /\
+    qas_nat h1 f == SG.minus_lambda)
+
+let make_minus_lambda f =
+  [@inline_let]
+  let x =
+   (u64 0xe0cfc810b51283cf,
+    u64 0xa880b9fc8ec739c2,
+    u64 0x5ad9e3fd77ed9ba4,
+    u64 0xac9c52b33fa3cf1f) in
+
+  assert_norm (SG.minus_lambda == qas_nat4 x);
+  make_u64_4 f x
+
+
+inline_for_extraction noextract
+val make_beta: f:felem -> Stack unit
+  (requires fun h -> live h f)
+  (ensures  fun h0 _ h1 -> modifies (loc f) h0 h1 /\
+    as_nat h1 f == SG.beta /\ inv_fully_reduced h1 f)
+
+let make_beta f =
+  [@inline_let]
+  let x =
+   (u64 0x96c28719501ee,
+    u64 0x7512f58995c13,
+    u64 0xc3434e99cf049,
+    u64 0x7106e64479ea,
+    u64 0x7ae96a2b657c) in
+
+  assert_norm (0x96c28719501ee <= max52);
+  assert_norm (0x7ae96a2b657c <= max48);
+  assert_norm (SG.beta == as_nat5 x);
+  make_u52_5 f x
+
+
+inline_for_extraction noextract
+val make_minus_b1: f:qelem -> Stack unit
+  (requires fun h -> live h f)
+  (ensures  fun h0 _ h1 -> modifies (loc f) h0 h1 /\
+    qas_nat h1 f == SG.minus_b1)
+
+let make_minus_b1 f =
+  [@inline_let]
+  let x =
+   (u64 0x6f547fa90abfe4c3,
+    u64 0xe4437ed6010e8828,
+    u64 0x0,
+    u64 0x0) in
+
+  assert_norm (SG.minus_b1 == qas_nat4 x);
+  make_u64_4 f x
+
+
+inline_for_extraction noextract
+val make_minus_b2: f:qelem -> Stack unit
+  (requires fun h -> live h f)
+  (ensures  fun h0 _ h1 -> modifies (loc f) h0 h1 /\
+    qas_nat h1 f == SG.minus_b2)
+
+let make_minus_b2 f =
+  [@inline_let]
+  let x =
+   (u64 0xd765cda83db1562c,
+    u64 0x8a280ac50774346d,
+    u64 0xfffffffffffffffe,
+    u64 0xffffffffffffffff) in
+
+  assert_norm (SG.minus_b2 == qas_nat4 x);
+  make_u64_4 f x
+
+
+inline_for_extraction noextract
+val make_g1: f:qelem -> Stack unit
+  (requires fun h -> live h f)
+  (ensures  fun h0 _ h1 -> modifies (loc f) h0 h1 /\
+    qas_nat h1 f == SG.g1)
+
+let make_g1 f =
+  [@inline_let]
+  let x =
+   (u64 0xe893209a45dbb031,
+    u64 0x3daa8a1471e8ca7f,
+    u64 0xe86c90e49284eb15,
+    u64 0x3086d221a7d46bcd) in
+
+  assert_norm (SG.g1 == qas_nat4 x);
+  make_u64_4 f x
+
+
+inline_for_extraction noextract
+val make_g2: f:qelem -> Stack unit
+  (requires fun h -> live h f)
+  (ensures  fun h0 _ h1 -> modifies (loc f) h0 h1 /\
+    qas_nat h1 f == SG.g2)
+
+let make_g2 f =
+  [@inline_let]
+  let x =
+   (u64 0x1571b4ae8ac47f71,
+    u64 0x221208ac9df506c6,
+    u64 0x6f547fa90abfe4c4,
+    u64 0xe4437ed6010e8828) in
+
+  assert_norm (SG.g2 == qas_nat4 x);
+  make_u64_4 f x
+
+
+(**
+  Representing a scalar k as (r1 + r2 * lambda) mod S.q,
+  s.t. r1 and r2 are ~128 bits long
+*)
+
+inline_for_extraction noextract
+val scalar_split_lambda_g1g2 (tmp1 tmp2 r1 r2 k: qelem) : Stack unit
+  (requires fun h ->
+    live h k /\ live h r1 /\ live h r2 /\
+    live h tmp1 /\ live h tmp2 /\
+    disjoint k r1 /\ disjoint k r2 /\ disjoint r1 r2 /\
+    disjoint tmp1 r1 /\ disjoint tmp1 r2 /\ disjoint tmp1 k /\
+    disjoint tmp2 r1 /\ disjoint tmp2 r2 /\ disjoint tmp2 k /\
+    disjoint tmp1 tmp2 /\ qas_nat h k < S.q)
+  (ensures  fun h0 _ h1 ->
+    modifies (loc r1 |+| loc r2 |+| loc tmp1 |+| loc tmp2) h0 h1 /\
+   (let r1 = qas_nat h1 r1 in let r2 = qas_nat h1 r2 in
+    r1 < S.q /\ r1 = SG.qmul_shift_384 (qas_nat h0 k) SG.g1 /\
+    r2 < S.q /\ r2 = SG.qmul_shift_384 (qas_nat h0 k) SG.g2))
+
+let scalar_split_lambda_g1g2 tmp1 tmp2 r1 r2 k =
+  make_g1 tmp1; // tmp1 = g1
+  make_g2 tmp2; // tmp2 = g2
+  qmul_shift_384 r1 k tmp1; // r1 = c1 = qmul_shift_384 k g1
+  qmul_shift_384 r2 k tmp2; // r2 = c2 = qmul_shift_384 k g2
+  let h0 = ST.get () in
+  SG.qmul_shift_384_lemma (qas_nat h0 k) (qas_nat h0 tmp1);
+  SG.qmul_shift_384_lemma (qas_nat h0 k) (qas_nat h0 tmp2);
+  assert (qas_nat h0 r1 < S.q /\ qas_nat h0 r2 < S.q)
+
+
+// k = (r1 + lambda * k2) % S.q
+val scalar_split_lambda (r1 r2 k: qelem) : Stack unit
+  (requires fun h ->
+    live h k /\ live h r1 /\ live h r2 /\
+    disjoint k r1 /\ disjoint k r2 /\ disjoint r1 r2 /\
+    qas_nat h k < S.q)
+  (ensures  fun h0 _ h1 -> modifies (loc r1 |+| loc r2) h0 h1 /\
+   (let r1_s, r2_s = SG.scalar_split_lambda (qas_nat h0 k) in
+    qas_nat h1 r1 == r1_s /\ qas_nat h1 r2 == r2_s))
+
+[@CInline]
+let scalar_split_lambda r1 r2 k =
+  push_frame ();
+  let tmp1 = create_qelem () in
+  let tmp2 = create_qelem () in
+  scalar_split_lambda_g1g2 tmp1 tmp2 r1 r2 k;
+
+  make_minus_b1 tmp1; // tmp1 = minus_b1
+  make_minus_b2 tmp2; // tmp2 = minus_b2
+  qmul r1 r1 tmp1; // r1 = c1 = c1 * minus_b1
+  qmul r2 r2 tmp2; // r2 = c2 = c2 * minus_b2
+
+  make_minus_lambda tmp1; // tmp1 = minus_lambda
+  qadd r2 r1 r2; // r2 = r2 = c1 + c2
+  qmul tmp2 r2 tmp1; // tmp2 = r2 * minus_lambda
+  qadd r1 k tmp2; // r1 = r1 = k + r2 * minus_lambda
+  pop_frame ()
+
+
+(**
+ Fast computation of [lambda]P as (beta * px, py, pz) in projective coordinates
+*)
+
+// [lambda]P = (beta * px, py, pz)
+val point_mul_lambda: res:point -> p:point -> Stack unit
+  (requires fun h ->
+    live h res /\ live h p /\ eq_or_disjoint res p /\
+    point_inv h p)
+  (ensures  fun h0 _ h1 -> modifies (loc res) h0 h1 /\
+    point_inv h1 res /\
+    point_eval h1 res == SG.point_mul_lambda (point_eval h0 p))
+
+[@CInline]
+let point_mul_lambda res p =
+  push_frame ();
+  let rx, ry, rz = getx res, gety res, getz res in
+  let px, py, pz = getx p, gety p, getz p in
+  let beta = create_felem () in
+  make_beta beta;
+  fmul rx beta px;
+
+  copy_felem ry py;
+  copy_felem rz pz;
+  pop_frame ()
+
+
+// [lambda]P = (beta * px, py, pz)
+val point_mul_lambda_inplace: res:point -> Stack unit
+  (requires fun h ->
+    live h res /\ point_inv h res)
+  (ensures  fun h0 _ h1 -> modifies (loc res) h0 h1 /\
+    point_inv h1 res /\
+    point_eval h1 res == SG.point_mul_lambda (point_eval h0 res))
+
+[@CInline]
+let point_mul_lambda_inplace res =
+  push_frame ();
+  let rx, ry, rz = getx res, gety res, getz res in
+  let beta = create_felem () in
+  make_beta beta;
+  fmul rx beta rx;
+  pop_frame ()
+
+
+inline_for_extraction noextract
+val point_mul_lambda_and_split_lambda:
+  r1:qelem -> r2:qelem -> lambda_q:point -> scalar:qelem -> q:point -> Stack unit
+  (requires fun h ->
+    live h r1 /\ live h r2 /\ live h lambda_q /\ live h scalar /\ live h q /\
+    disjoint r1 r2 /\ disjoint r1 lambda_q /\ disjoint r1 scalar /\ disjoint r1 q /\
+    disjoint r2 lambda_q /\ disjoint r2 scalar /\ disjoint r2 q /\
+    disjoint lambda_q scalar /\ disjoint lambda_q q /\
+    point_inv h q /\ qas_nat h scalar < S.q)
+  (ensures fun h0 _ h1 -> modifies (loc r1 |+| loc r2 |+| loc lambda_q) h0 h1 /\
+    point_inv h1 lambda_q /\
+    point_eval h1 lambda_q == SG.point_mul_lambda (point_eval h0 q) /\
+   (let r1_s, r2_s = SG.scalar_split_lambda (qas_nat h0 scalar) in
+    qas_nat h1 r1 == r1_s /\ qas_nat h1 r2 == r2_s))
+
+let point_mul_lambda_and_split_lambda r1 r2 lambda_q scalar q =
+  scalar_split_lambda r1 r2 scalar; // (r1 + r2 * lambda) % S.q = scalar
+  point_mul_lambda lambda_q q // lambda_q = [lambda]Q
+
+
+inline_for_extraction noextract
+val point_negate_conditional_vartime: p:point -> is_negate:bool -> Stack unit
+  (requires fun h -> live h p /\ point_inv h p)
+  (ensures  fun h0 _ h1 -> modifies (loc p) h0 h1 /\
+    point_inv h1 p /\
+    point_eval h1 p == SG.point_negate_cond (point_eval h0 p) is_negate)
+
+let point_negate_conditional_vartime p is_negate =
+  if is_negate then point_negate p p
+
+
+inline_for_extraction noextract
+val negate_point_and_scalar_cond_vartime: k:qelem -> p:point -> Stack bool
+  (requires fun h ->
+    live h k /\ live h p /\ disjoint k p /\
+    qas_nat h k < S.q /\ point_inv h p)
+  (ensures  fun h0 b h1 -> modifies (loc k |+| loc p) h0 h1 /\
+    b == S.scalar_is_high (qas_nat h0 k) /\ point_inv h1 p /\
+    (let k_s, p_s = SG.negate_point_and_scalar_cond (qas_nat h0 k) (point_eval h0 p) in
+    qas_nat h1 k == k_s /\ point_eval h1 p == p_s))
+
+let negate_point_and_scalar_cond_vartime k p =
+  let b = is_qelem_le_q_halved_vartime k in
+  [@inline_let] let if_high = not b in
+  qnegate_conditional_vartime k if_high;
+  point_negate_conditional_vartime p if_high;
+  if_high
+
+
+inline_for_extraction noextract
+val ecmult_endo_split:
+    r1:qelem -> r2:qelem
+  -> q1:point -> q2:point
+  -> scalar:qelem -> q:point -> Stack (bool & bool)
+  (requires fun h ->
+    live h r1 /\ live h r2 /\ live h q1 /\
+    live h q2 /\ live h scalar /\ live h q /\
+    disjoint r1 r2 /\ disjoint r1 q1 /\ disjoint r1 q2 /\
+    disjoint r1 scalar /\ disjoint r1 q /\ disjoint r2 q1 /\
+    disjoint r2 q2 /\ disjoint r2 scalar /\ disjoint r2 q /\
+    disjoint q1 q2 /\ disjoint q1 scalar /\ disjoint q1 q /\
+    disjoint q2 scalar /\ disjoint q2 q /\
+    point_inv h q /\ qas_nat h scalar < S.q)
+  (ensures fun h0 (is_high1, is_high2) h1 ->
+    modifies (loc r1 |+| loc r2 |+| loc q1 |+| loc q2) h0 h1 /\
+    point_inv h1 q1 /\ point_inv h1 q2 /\
+   (let r1_s0, r2_s0 = SG.scalar_split_lambda (qas_nat h0 scalar) in
+    let r1_s, q1_s, r2_s, q2_s = SG.ecmult_endo_split (qas_nat h0 scalar) (point_eval h0 q) in
+    qas_nat h1 r1 == r1_s /\ r1_s < pow2 128 /\
+    qas_nat h1 r2 == r2_s /\ r2_s < pow2 128 /\
+    point_eval h1 q1 == q1_s /\ point_eval h1 q2 == q2_s /\
+    is_high1 == S.scalar_is_high r1_s0 /\
+    is_high2 == S.scalar_is_high r2_s0))
+
+let ecmult_endo_split r1 r2 q1 q2 scalar q =
+  let h0 = ST.get () in
+  // modifies r1, r2, q2 s.t. r1 + r2 * lambda = scalar /\ q2 = [lambda]q
+  point_mul_lambda_and_split_lambda r1 r2 q2 scalar q;
+  copy q1 q; // q1 = q
+  // modifies r1, q1
+  let is_high1 = negate_point_and_scalar_cond_vartime r1 q1 in
+  // modifies r2, q2
+  let is_high2 = negate_point_and_scalar_cond_vartime r2 q2 in
+  SGL.lemma_scalar_split_lambda_fits (qas_nat h0 scalar) (point_eval h0 q);
+  is_high1, is_high2

--- a/code/k256/Hacl.Impl.K256.GLV.Constants.fst
+++ b/code/k256/Hacl.Impl.K256.GLV.Constants.fst
@@ -256,6 +256,7 @@ let negate_point_and_scalar_cond_vartime k p =
   if_high
 
 
+[@CInline]
 let ecmult_endo_split r1 r2 q1 q2 scalar q =
   let h0 = ST.get () in
   // modifies r1, r2, q2 s.t. r1 + r2 * lambda = scalar /\ q2 = [lambda]q
@@ -265,5 +266,4 @@ let ecmult_endo_split r1 r2 q1 q2 scalar q =
   let is_high1 = negate_point_and_scalar_cond_vartime r1 q1 in
   // modifies r2, q2
   let is_high2 = negate_point_and_scalar_cond_vartime r2 q2 in
-  SGL.lemma_scalar_split_lambda_fits (qas_nat h0 scalar) (point_eval h0 q);
   is_high1, is_high2

--- a/code/k256/Hacl.Impl.K256.GLV.Constants.fst
+++ b/code/k256/Hacl.Impl.K256.GLV.Constants.fst
@@ -238,10 +238,6 @@ let point_mul_lambda_and_split_lambda r1 r2 lambda_q scalar q =
   point_mul_lambda lambda_q q // lambda_q = [lambda]Q
 
 
-let point_negate_conditional_vartime p is_negate =
-  if is_negate then point_negate p p
-
-
 inline_for_extraction noextract
 val negate_point_and_scalar_cond_vartime: k:qelem -> p:point -> Stack bool
   (requires fun h ->

--- a/code/k256/Hacl.Impl.K256.GLV.Constants.fsti
+++ b/code/k256/Hacl.Impl.K256.GLV.Constants.fsti
@@ -41,7 +41,6 @@ val point_mul_lambda_inplace: res:point -> Stack unit
     point_eval h1 res == SG.point_mul_lambda (point_eval h0 res))
 
 
-inline_for_extraction noextract
 val ecmult_endo_split:
     r1:qelem -> r2:qelem
   -> q1:point -> q2:point
@@ -60,8 +59,7 @@ val ecmult_endo_split:
     point_inv h1 q1 /\ point_inv h1 q2 /\
    (let r1_s0, r2_s0 = SG.scalar_split_lambda (qas_nat h0 scalar) in
     let r1_s, q1_s, r2_s, q2_s = SG.ecmult_endo_split (qas_nat h0 scalar) (point_eval h0 q) in
-    qas_nat h1 r1 == r1_s /\ r1_s < pow2 128 /\
-    qas_nat h1 r2 == r2_s /\ r2_s < pow2 128 /\
+    qas_nat h1 r1 == r1_s /\ qas_nat h1 r2 == r2_s /\
     point_eval h1 q1 == q1_s /\ point_eval h1 q2 == q2_s /\
     is_high1 == S.scalar_is_high r1_s0 /\
     is_high2 == S.scalar_is_high r2_s0))

--- a/code/k256/Hacl.Impl.K256.GLV.Constants.fsti
+++ b/code/k256/Hacl.Impl.K256.GLV.Constants.fsti
@@ -42,14 +42,6 @@ val point_mul_lambda_inplace: res:point -> Stack unit
 
 
 inline_for_extraction noextract
-val point_negate_conditional_vartime: p:point -> is_negate:bool -> Stack unit
-  (requires fun h -> live h p /\ point_inv h p)
-  (ensures  fun h0 _ h1 -> modifies (loc p) h0 h1 /\
-    point_inv h1 p /\
-    point_eval h1 p == SG.point_negate_cond (point_eval h0 p) is_negate)
-
-
-inline_for_extraction noextract
 val ecmult_endo_split:
     r1:qelem -> r2:qelem
   -> q1:point -> q2:point

--- a/code/k256/Hacl.Impl.K256.GLV.Constants.fsti
+++ b/code/k256/Hacl.Impl.K256.GLV.Constants.fsti
@@ -1,0 +1,75 @@
+module Hacl.Impl.K256.GLV.Constants
+
+open FStar.HyperStack
+open FStar.HyperStack.ST
+open FStar.Mul
+
+open Lib.IntTypes
+open Lib.Buffer
+
+module ST = FStar.HyperStack.ST
+
+module S = Spec.K256
+module SG = Hacl.Spec.K256.GLV
+
+open Hacl.K256.Field
+open Hacl.K256.Scalar
+open Hacl.Impl.K256.Point
+
+#set-options "--z3rlimit 50 --fuel 0 --ifuel 0"
+
+(**
+ Fast computation of [lambda]P as (beta * px, py, pz) in projective coordinates
+*)
+
+// [lambda]P = (beta * px, py, pz)
+val point_mul_lambda: res:point -> p:point -> Stack unit
+  (requires fun h ->
+    live h res /\ live h p /\ eq_or_disjoint res p /\
+    point_inv h p)
+  (ensures  fun h0 _ h1 -> modifies (loc res) h0 h1 /\
+    point_inv h1 res /\
+    point_eval h1 res == SG.point_mul_lambda (point_eval h0 p))
+
+
+// [lambda]P = (beta * px, py, pz)
+val point_mul_lambda_inplace: res:point -> Stack unit
+  (requires fun h ->
+    live h res /\ point_inv h res)
+  (ensures  fun h0 _ h1 -> modifies (loc res) h0 h1 /\
+    point_inv h1 res /\
+    point_eval h1 res == SG.point_mul_lambda (point_eval h0 res))
+
+
+inline_for_extraction noextract
+val point_negate_conditional_vartime: p:point -> is_negate:bool -> Stack unit
+  (requires fun h -> live h p /\ point_inv h p)
+  (ensures  fun h0 _ h1 -> modifies (loc p) h0 h1 /\
+    point_inv h1 p /\
+    point_eval h1 p == SG.point_negate_cond (point_eval h0 p) is_negate)
+
+
+inline_for_extraction noextract
+val ecmult_endo_split:
+    r1:qelem -> r2:qelem
+  -> q1:point -> q2:point
+  -> scalar:qelem -> q:point -> Stack (bool & bool)
+  (requires fun h ->
+    live h r1 /\ live h r2 /\ live h q1 /\
+    live h q2 /\ live h scalar /\ live h q /\
+    disjoint r1 r2 /\ disjoint r1 q1 /\ disjoint r1 q2 /\
+    disjoint r1 scalar /\ disjoint r1 q /\ disjoint r2 q1 /\
+    disjoint r2 q2 /\ disjoint r2 scalar /\ disjoint r2 q /\
+    disjoint q1 q2 /\ disjoint q1 scalar /\ disjoint q1 q /\
+    disjoint q2 scalar /\ disjoint q2 q /\
+    point_inv h q /\ qas_nat h scalar < S.q)
+  (ensures fun h0 (is_high1, is_high2) h1 ->
+    modifies (loc r1 |+| loc r2 |+| loc q1 |+| loc q2) h0 h1 /\
+    point_inv h1 q1 /\ point_inv h1 q2 /\
+   (let r1_s0, r2_s0 = SG.scalar_split_lambda (qas_nat h0 scalar) in
+    let r1_s, q1_s, r2_s, q2_s = SG.ecmult_endo_split (qas_nat h0 scalar) (point_eval h0 q) in
+    qas_nat h1 r1 == r1_s /\ r1_s < pow2 128 /\
+    qas_nat h1 r2 == r2_s /\ r2_s < pow2 128 /\
+    point_eval h1 q1 == q1_s /\ point_eval h1 q2 == q2_s /\
+    is_high1 == S.scalar_is_high r1_s0 /\
+    is_high2 == S.scalar_is_high r2_s0))

--- a/code/k256/Hacl.Impl.K256.GLV.fst
+++ b/code/k256/Hacl.Impl.K256.GLV.fst
@@ -28,34 +28,49 @@ open Hacl.Impl.K256.Point
 
 open Hacl.Impl.K256.GLV.Constants
 include Hacl.Impl.K256.Group
+include Hacl.K256.PrecompTable
 
 #set-options "--z3rlimit 50 --fuel 0 --ifuel 0"
 
-(**
- Fast computation of [scalar]Q in projective coordinates
-*)
+let _: squash(pow2 5 = 32) =
+  assert_norm (pow2 5 = 32)
+
+let _: squash(pow2 128 < S.q) =
+  assert_norm (pow2 128 < S.q)
+
+
+inline_for_extraction noextract
+let table_inv_w5 : BE.table_inv_t U64 15ul 32ul =
+  [@inline_let] let len = 15ul in
+  [@inline_let] let ctx_len = 0ul in
+  [@inline_let] let k = mk_k256_concrete_ops in
+  [@inline_let] let l = 5ul in
+  [@inline_let] let table_len = 32ul in
+  BE.table_inv_precomp len ctx_len k l table_len
+
 
 inline_for_extraction noextract
 let table_neg_inv_precomp
-  (q:LSeq.lseq uint64 15) (is_negate:bool) : BE.table_inv_t U64 15ul 16ul =
+  (q:LSeq.lseq uint64 15) (is_negate:bool) : BE.table_inv_t U64 15ul 32ul =
   fun a table ->
     point_eval_lseq a == SG.point_negate_cond (point_eval_lseq q) is_negate /\
-    (forall (j:nat{j < 16}).
-      PT.precomp_table_inv 15ul 0ul mk_k256_concrete_ops q 16ul table j)
+    (forall (j:nat{j < 32}).
+      PT.precomp_table_inv 15ul 0ul mk_k256_concrete_ops q 32ul table j)
+
 
 // This function returns [r_small]Q or [r_small](-Q)
 // using a precomputed table [0; Q; 2Q; ...; 15Q]
 inline_for_extraction noextract
 val lprecomp_get_vartime_neg:
     q:Ghost.erased (LSeq.lseq uint64 15){point_inv_lseq q} -> is_negate:bool ->
-  BE.pow_a_to_small_b_st U64 15ul 0ul mk_k256_concrete_ops 4ul 16ul
+  BE.pow_a_to_small_b_st U64 15ul 0ul mk_k256_concrete_ops 5ul 32ul
     (table_neg_inv_precomp q is_negate)
 
 let lprecomp_get_vartime_neg q is_negate ctx lambda_q table r_small res =
   let h0 = ST.get () in
   assert (table_neg_inv_precomp q is_negate lambda_q (as_seq h0 table));
   // table.[r_small] = [r_small]Q
-  BE.lprecomp_get_vartime 15ul 0ul mk_k256_concrete_ops 4ul 16ul ctx q table r_small res;
+  BE.lprecomp_get_vartime 15ul 0ul mk_k256_concrete_ops 5ul 32ul ctx q table r_small res;
   SE.pow_lemma S.mk_k256_concrete_ops (point_eval_lseq q) (v r_small);
   let h1 = ST.get () in
   assert (S.to_aff_point (point_eval h1 res) ==
@@ -77,12 +92,12 @@ let lprecomp_get_vartime_neg q is_negate ctx lambda_q table r_small res =
 
 inline_for_extraction noextract
 let table_lambda_neg_inv_precomp
-  (q:LSeq.lseq uint64 15) (is_negate:bool) : BE.table_inv_t U64 15ul 16ul =
+  (q:LSeq.lseq uint64 15) (is_negate:bool) : BE.table_inv_t U64 15ul 32ul =
   fun a table ->
     point_eval_lseq a ==
       SG.point_negate_cond (SG.point_mul_lambda (point_eval_lseq q)) is_negate /\
-    (forall (j:nat{j < 16}).
-      PT.precomp_table_inv 15ul 0ul mk_k256_concrete_ops q 16ul table j)
+    (forall (j:nat{j < 32}).
+      PT.precomp_table_inv 15ul 0ul mk_k256_concrete_ops q 32ul table j)
 
 
 // This function returns [r_small]([lambda]Q) or [r_small](-[lambda]Q)
@@ -90,14 +105,14 @@ let table_lambda_neg_inv_precomp
 inline_for_extraction noextract
 val lprecomp_get_vartime_lambda_neg:
     q:Ghost.erased (LSeq.lseq uint64 15){point_inv_lseq q} -> is_negate:bool ->
-  BE.pow_a_to_small_b_st U64 15ul 0ul mk_k256_concrete_ops 4ul 16ul
+  BE.pow_a_to_small_b_st U64 15ul 0ul mk_k256_concrete_ops 5ul 32ul
     (table_lambda_neg_inv_precomp q is_negate)
 
 let lprecomp_get_vartime_lambda_neg q is_negate ctx lambda_q table r_small res =
   let h0 = ST.get () in
   assert (table_lambda_neg_inv_precomp q is_negate lambda_q (as_seq h0 table));
   // table.[r_small] = [r_small]Q
-  BE.lprecomp_get_vartime 15ul 0ul mk_k256_concrete_ops 4ul 16ul ctx q table r_small res;
+  BE.lprecomp_get_vartime 15ul 0ul mk_k256_concrete_ops 5ul 32ul ctx q table r_small res;
   SE.pow_lemma S.mk_k256_concrete_ops (point_eval_lseq q) (v r_small);
   let h1 = ST.get () in
   assert (S.to_aff_point (point_eval h1 res) ==
@@ -129,169 +144,9 @@ let lprecomp_get_vartime_lambda_neg q is_negate ctx lambda_q table r_small res =
 //------------------------------
 
 inline_for_extraction noextract
-val point_mul_split_lambda_table:
-  out:point -> r1:qelem -> q1:point -> r2:qelem -> q2:point
-  -> p:point -> is_negate1:bool -> is_negate2:bool -> Stack unit
-  (requires fun h ->
-    live h out /\ live h r1 /\ live h r2 /\
-    live h q1 /\ live h q2 /\ live h p /\
-    eq_or_disjoint q1 q2 /\ disjoint out q1 /\ disjoint out q2 /\
-    disjoint out r1 /\ disjoint out r2 /\ disjoint out p /\
-    point_inv h q1 /\ point_inv h q2 /\ point_inv h p /\
-    point_eval h q1 == SG.point_negate_cond (point_eval h p) is_negate1 /\
-    point_eval h q2 == SG.point_negate_cond (SG.point_mul_lambda (point_eval h p)) is_negate2 /\
-    qas_nat h r1 < S.q /\ qas_nat h r1 < pow2 128 /\
-    qas_nat h r2 < S.q /\ qas_nat h r2 < pow2 128)
-  (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
-    point_inv h1 out /\
-    refl (as_seq h1 out) ==
-      LE.exp_double_fw S.mk_k256_comm_monoid
-        (refl (as_seq h0 q1)) 128 (qas_nat h0 r1)
-        (refl (as_seq h0 q2)) (qas_nat h0 r2) 4)
-
-let point_mul_split_lambda_table out r1 q1 r2 q2 p is_negate1 is_negate2 =
-  [@inline_let] let len = 15ul in
-  [@inline_let] let ctx_len = 0ul in
-  [@inline_let] let k = mk_k256_concrete_ops in
-  [@inline_let] let l = 4ul in
-  [@inline_let] let table_len = 16ul in
-  [@inline_let] let bLen = 4ul in
-  [@inline_let] let bBits = 128ul in
-
-  let h0 = ST.get () in
-  push_frame ();
-  let table = create (table_len *! len) (u64 0) in
-  PT.lprecomp_table len ctx_len k (null uint64) p table_len table;
-  let h1 = ST.get () in
-  assert (forall (j:nat{j < v table_len}).
-    PT.precomp_table_inv len ctx_len k (as_seq h1 p) table_len (as_seq h1 table) j);
-
-  assert (point_eval_lseq (as_seq h1 q1) ==
-    SG.point_negate_cond (point_eval_lseq (as_seq h1 p)) is_negate1);
-  [@inline_let]
-  let table_inv1 : BE.table_inv_t U64 len table_len =
-    table_neg_inv_precomp (as_seq h0 p) is_negate1 in
-  assert (table_inv1 (as_seq h1 q1) (as_seq h1 table));
-
-  assert (point_eval_lseq (as_seq h1 q2) ==
-    SG.point_negate_cond (SG.point_mul_lambda (point_eval_lseq (as_seq h1 p))) is_negate2);
-  [@inline_let]
-  let table_inv2 : BE.table_inv_t U64 len table_len =
-    table_lambda_neg_inv_precomp (as_seq h0 p) is_negate2 in
-  assert (table_inv2 (as_seq h1 q2) (as_seq h1 table));
-
-  ME.mk_lexp_double_fw_tables len ctx_len k l table_len
-    table_inv1 table_inv2
-    (lprecomp_get_vartime_neg (as_seq h0 p) is_negate1)
-    (lprecomp_get_vartime_lambda_neg (as_seq h0 p) is_negate2)
-    (null uint64) q1 bLen bBits r1 q2 r2 (to_const table) (to_const table) out;
-  pop_frame ()
-
-
-// [scalar]Q = [(r1 + r2 * lambda) % S.q]Q = [r1]Q + [r2]([lambda]Q)
-inline_for_extraction noextract
-val point_mul_split_lambda_vartime: out:point -> scalar:qelem -> q:point -> Stack unit
-  (requires fun h ->
-    live h out /\ live h scalar /\ live h q /\
-    disjoint out q /\ disjoint out scalar /\ disjoint q scalar /\
-    point_inv h q /\ qas_nat h scalar < S.q)
-  (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
-    point_inv h1 out /\
-    S.to_aff_point (point_eval h1 out) ==
-      S.aff_point_mul (qas_nat h0 scalar) (S.to_aff_point (point_eval h0 q)))
-
-let point_mul_split_lambda_vartime out scalar q =
-  let h0 = ST.get () in
-  push_frame ();
-  let r1 = create_qelem () in
-  let r2 = create_qelem () in
-  let q1 = create_point () in
-  let q2 = create_point () in
-  let is_high1, is_high2 = ecmult_endo_split r1 r2 q1 q2 scalar q in
-  let h1 = ST.get () in
-  assert (modifies (loc r1 |+| loc r2 |+| loc q1 |+| loc q2) h0 h1);
-  point_mul_split_lambda_table out r1 q1 r2 q2 q is_high1 is_high2;
-  let h2 = ST.get () in
-  assert (modifies (loc out) h1 h2);
-  assert (modifies (loc r1 |+| loc r2 |+| loc q1 |+| loc q2 |+| loc out) h0 h2);
-  pop_frame ();
-  let h3 = ST.get () in
-  assert (modifies (loc out) h0 h3);
-  assert (S.to_aff_point (point_eval h3 out) ==
-    SGL.aff_proj_point_mul_split_lambda (qas_nat h0 scalar) (point_eval h0 q));
-  SGL.lemma_aff_proj_point_mul_split_lambda (qas_nat h0 scalar) (point_eval h0 q)
-
-
-// TODO: precompute a table [0; G; 2G; ..; 15G]?
-val point_mul_g_split_lambda_vartime: out:point -> scalar:qelem -> Stack unit
-  (requires fun h ->
-    live h out /\ live h scalar /\ disjoint out scalar /\
-    qas_nat h scalar < S.q)
-  (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
-    point_inv h1 out /\
-    S.to_aff_point (point_eval h1 out) ==
-      S.aff_point_mul (qas_nat h0 scalar) (S.g_x, S.g_y))
-
-[@CInline]
-let point_mul_g_split_lambda_vartime out scalar =
-  SL.lemma_proj_aff_id (S.g_x, S.g_y);
-  push_frame ();
-  let g = create 15ul (u64 0) in
-  make_g g;
-  point_mul_split_lambda_vartime out scalar g;
-  pop_frame ()
-
-
-(**
- Fast computation of [scalar1]Q1 + [scalar2]Q2 in projective coordinates
-*)
-
-inline_for_extraction noextract
-val mk_two_tables:
-    table1:lbuffer uint64 (16ul *! 15ul)
-  -> table2:lbuffer uint64 (16ul *! 15ul)
-  -> p1:point -> p2:point ->
-  Stack unit
-  (requires fun h ->
-    live h table1 /\ live h table2 /\ live h p1 /\ live h p2 /\
-    disjoint table1 table2 /\ disjoint table1 p1 /\ disjoint table1 p2 /\
-    disjoint table2 p1 /\ disjoint table2 p2 /\
-    point_inv h p1 /\ point_inv h p2)
-  (ensures fun h0 _ h1 -> modifies (loc table1 |+| loc table2) h0 h1 /\
-   (let len = 15ul in
-    let ctx_len = 0ul in
-    let k = mk_k256_concrete_ops in
-    let l = 4ul in
-    let table_len = 16ul in
-    BE.table_inv_precomp len ctx_len k l table_len (as_seq h0 p1) (as_seq h1 table1) /\
-    BE.table_inv_precomp len ctx_len k l table_len (as_seq h0 p2) (as_seq h1 table2)))
-
-let mk_two_tables table1 table2 p1 p2 =
-  [@inline_let] let len = 15ul in
-  [@inline_let] let ctx_len = 0ul in
-  [@inline_let] let k = mk_k256_concrete_ops in
-  [@inline_let] let l = 4ul in
-  [@inline_let] let table_len = 16ul in
-
-  let h0 = ST.get () in
-  PT.lprecomp_table len ctx_len k (null uint64) p1 table_len table1;
-  let h1 = ST.get () in
-  assert (BE.table_inv_precomp len ctx_len k l table_len
-    (as_seq h1 p1) (as_seq h1 table1));
-
-  PT.lprecomp_table len ctx_len k (null uint64) p2 table_len table2;
-  let h2 = ST.get () in
-  assert (BE.table_inv_precomp len ctx_len k l table_len
-    (as_seq h2 p1) (as_seq h2 table1));
-  assert (BE.table_inv_precomp len ctx_len k l table_len
-    (as_seq h2 p2) (as_seq h2 table2))
-
-
-inline_for_extraction noextract
-val point_mul_double_split_lambda_table_noalloc:
+val point_mul_g_double_split_lambda_table_noalloc:
     out:point
-  -> table1:lbuffer uint64 (16ul *! 15ul)
-  -> table2:lbuffer uint64 (16ul *! 15ul)
+  -> table2:lbuffer uint64 (32ul *! 15ul)
   -> r1:qelem -> q1:point
   -> r2:qelem -> q2:point
   -> r3:qelem -> q3:point
@@ -301,20 +156,16 @@ val point_mul_double_split_lambda_table_noalloc:
   -> is_negate3:bool -> is_negate4:bool ->
   Stack unit
   (requires fun h ->
-    live h out /\ live h r1 /\ live h r2 /\ live h r3 /\ live h r4 /\
+    live h out /\ live h table2 /\
+    live h r1 /\ live h r2 /\ live h r3 /\ live h r4 /\
     live h q1 /\ live h q2 /\ live h q3 /\ live h q4 /\
-    live h p1 /\ live h p2 /\ live h table1 /\ live h table2 /\
+    live h p1 /\ live h p2 /\
 
     eq_or_disjoint q1 q2 /\ eq_or_disjoint q1 q3 /\ eq_or_disjoint q1 q4 /\
     eq_or_disjoint q2 q3 /\ eq_or_disjoint q2 q4 /\ eq_or_disjoint q3 q4 /\
     disjoint out q1 /\ disjoint out q2 /\ disjoint out q3 /\ disjoint out q4 /\
     disjoint out r1 /\ disjoint out r2 /\ disjoint out r3 /\ disjoint out r4 /\
-    disjoint out p1  /\ disjoint out p2 /\ disjoint table1 table2 /\
-
-    disjoint table1 out /\ disjoint table1 r1 /\ disjoint table1 r2 /\
-    disjoint table1 r3 /\ disjoint table1 r4 /\  disjoint table1 p1 /\
-    disjoint table1 p2 /\ disjoint table1 q1 /\ disjoint table1 q2 /\
-    disjoint table1 q3 /\ disjoint table1 q4 /\
+    disjoint out p1  /\ disjoint out p2 /\
 
     disjoint table2 out /\ disjoint table2 r1 /\ disjoint table2 r2 /\
     disjoint table2 r3 /\ disjoint table2 r4 /\  disjoint table2 p1 /\
@@ -323,6 +174,7 @@ val point_mul_double_split_lambda_table_noalloc:
 
     point_inv h q1 /\ point_inv h q2 /\ point_inv h q3 /\ point_inv h q4 /\
     point_inv h p1 /\ point_inv h p2 /\
+    point_eval h p1 == S.g /\
     point_eval h q1==SG.point_negate_cond (point_eval h p1) is_negate1 /\
     point_eval h q2==SG.point_negate_cond (SG.point_mul_lambda (point_eval h p1)) is_negate2 /\
     point_eval h q3==SG.point_negate_cond (point_eval h p2) is_negate3 /\
@@ -330,47 +182,47 @@ val point_mul_double_split_lambda_table_noalloc:
     qas_nat h r1 < S.q /\ qas_nat h r1 < pow2 128 /\
     qas_nat h r2 < S.q /\ qas_nat h r2 < pow2 128 /\
     qas_nat h r3 < S.q /\ qas_nat h r3 < pow2 128 /\
-    qas_nat h r4 < S.q /\ qas_nat h r4 < pow2 128)
-  (ensures  fun h0 _ h1 -> modifies (loc out |+| loc table1 |+| loc table2) h0 h1 /\
+    qas_nat h r4 < S.q /\ qas_nat h r4 < pow2 128 /\
+    table_inv_w5 (as_seq h p2) (as_seq h table2))
+  (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
     point_inv h1 out /\
     refl (as_seq h1 out) ==
       LE.exp_four_fw S.mk_k256_comm_monoid
         (refl (as_seq h0 q1)) 128 (qas_nat h0 r1)
         (refl (as_seq h0 q2)) (qas_nat h0 r2)
         (refl (as_seq h0 q3)) (qas_nat h0 r3)
-        (refl (as_seq h0 q4)) (qas_nat h0 r4) 4)
+        (refl (as_seq h0 q4)) (qas_nat h0 r4) 5)
 
-let point_mul_double_split_lambda_table_noalloc out table1 table2 r1 q1 r2 q2 r3 q3 r4 q4
-  p1 p2 is_negate1 is_negate2 is_negate3 is_negate4 =
+let point_mul_g_double_split_lambda_table_noalloc out table2 r1 q1 r2 q2 r3 q3 r4 q4 p1 p2
+  is_negate1 is_negate2 is_negate3 is_negate4 =
   [@inline_let] let len = 15ul in
   [@inline_let] let ctx_len = 0ul in
   [@inline_let] let k = mk_k256_concrete_ops in
-  [@inline_let] let l = 4ul in
-  [@inline_let] let table_len = 16ul in
+  [@inline_let] let l = 5ul in
+  [@inline_let] let table_len = 32ul in
   [@inline_let] let bLen = 4ul in
   [@inline_let] let bBits = 128ul in
 
   let h0 = ST.get () in
-  mk_two_tables table1 table2 p1 p2;
+  recall_contents precomp_basepoint_table_w5 precomp_basepoint_table_lseq_w5;
   let h1 = ST.get () in
-  assert (forall (j:nat{j < v table_len}).
-    PT.precomp_table_inv len ctx_len k (as_seq h1 p1) table_len (as_seq h1 table1) j);
-  assert (forall (j:nat{j < v table_len}).
-    PT.precomp_table_inv len ctx_len k (as_seq h1 p2) table_len (as_seq h1 table2) j);
+  precomp_basepoint_table_lemma_w5 ();
+  assert (table_inv_w5 (as_seq h1 p1) (as_seq h1 precomp_basepoint_table_w5));
+  assert (table_inv_w5 (as_seq h1 p2) (as_seq h1 table2));
 
   assert (point_eval_lseq (as_seq h1 q1) ==
     SG.point_negate_cond (point_eval_lseq (as_seq h1 p1)) is_negate1);
   [@inline_let]
   let table_inv1 : BE.table_inv_t U64 len table_len =
     table_neg_inv_precomp (as_seq h0 p1) is_negate1 in
-  assert (table_inv1 (as_seq h1 q1) (as_seq h1 table1));
+  assert (table_inv1 (as_seq h1 q1) (as_seq h1 precomp_basepoint_table_w5));
 
   assert (point_eval_lseq (as_seq h1 q2) ==
     SG.point_negate_cond (SG.point_mul_lambda (point_eval_lseq (as_seq h1 p1))) is_negate2);
   [@inline_let]
   let table_inv2 : BE.table_inv_t U64 len table_len =
     table_lambda_neg_inv_precomp (as_seq h0 p1) is_negate2 in
-  assert (table_inv2 (as_seq h1 q2) (as_seq h1 table1));
+  assert (table_inv2 (as_seq h1 q2) (as_seq h1 precomp_basepoint_table_w5));
 
   assert (point_eval_lseq (as_seq h1 q3) ==
     SG.point_negate_cond (point_eval_lseq (as_seq h1 p2)) is_negate3);
@@ -386,8 +238,6 @@ let point_mul_double_split_lambda_table_noalloc out table1 table2 r1 q1 r2 q2 r3
     table_lambda_neg_inv_precomp (as_seq h0 p2) is_negate4 in
   assert (table_inv4 (as_seq h1 q4) (as_seq h1 table2));
 
-  assert (modifies (loc table1 |+| loc table2) h0 h1);
-
   ME.mk_lexp_four_fw_tables len ctx_len k l table_len
     table_inv1 table_inv2 table_inv3 table_inv4
     (lprecomp_get_vartime_neg (as_seq h0 p1) is_negate1)
@@ -395,23 +245,13 @@ let point_mul_double_split_lambda_table_noalloc out table1 table2 r1 q1 r2 q2 r3
     (lprecomp_get_vartime_neg (as_seq h0 p2) is_negate3)
     (lprecomp_get_vartime_lambda_neg (as_seq h0 p2) is_negate4)
     (null uint64) q1 bLen bBits r1 q2 r2 q3 r3 q4 r4
-    (to_const table1) (to_const table1) (to_const table2) (to_const table2) out;
-
-  let h2 = ST.get () in
-  assert (modifies (loc out) h1 h2);
-  assert (point_inv h2 out /\
-    refl (as_seq h2 out) ==
-      LE.exp_four_fw S.mk_k256_comm_monoid
-        (refl (as_seq h0 q1)) 128 (qas_nat h0 r1)
-        (refl (as_seq h0 q2)) (qas_nat h0 r2)
-        (refl (as_seq h0 q3)) (qas_nat h0 r3)
-        (refl (as_seq h0 q4)) (qas_nat h0 r4) 4);
-
-  assert (modifies (loc table1 |+| loc table2 |+| loc out) h0 h2)
+    (to_const precomp_basepoint_table_w5)
+    (to_const precomp_basepoint_table_w5)
+    (to_const table2) (to_const table2) out
 
 
 inline_for_extraction noextract
-val point_mul_double_split_lambda_table:
+val point_mul_g_double_split_lambda_table:
     out:point
   -> r1:qelem -> q1:point
   -> r2:qelem -> q2:point
@@ -431,6 +271,7 @@ val point_mul_double_split_lambda_table:
     disjoint out p1  /\ disjoint out p2 /\
     point_inv h q1 /\ point_inv h q2 /\ point_inv h q3 /\ point_inv h q4 /\
     point_inv h p1 /\ point_inv h p2 /\
+    point_eval h p1 == S.g /\
     point_eval h q1==SG.point_negate_cond (point_eval h p1) is_negate1 /\
     point_eval h q2==SG.point_negate_cond (SG.point_mul_lambda (point_eval h p1)) is_negate2 /\
     point_eval h q3==SG.point_negate_cond (point_eval h p2) is_negate3 /\
@@ -446,28 +287,30 @@ val point_mul_double_split_lambda_table:
         (refl (as_seq h0 q1)) 128 (qas_nat h0 r1)
         (refl (as_seq h0 q2)) (qas_nat h0 r2)
         (refl (as_seq h0 q3)) (qas_nat h0 r3)
-        (refl (as_seq h0 q4)) (qas_nat h0 r4) 4)
+        (refl (as_seq h0 q4)) (qas_nat h0 r4) 5)
 
-let point_mul_double_split_lambda_table out r1 q1 r2 q2 r3 q3 r4 q4
+let point_mul_g_double_split_lambda_table out r1 q1 r2 q2 r3 q3 r4 q4
   p1 p2 is_negate1 is_negate2 is_negate3 is_negate4 =
   [@inline_let] let len = 15ul in
-  [@inline_let] let table_len = 16ul in
+  [@inline_let] let ctx_len = 0ul in
+  [@inline_let] let k = mk_k256_concrete_ops in
+  [@inline_let] let table_len = 32ul in
 
   let h0 = ST.get () in
   push_frame ();
-  let table1 = create (table_len *! len) (u64 0) in
   let table2 = create (table_len *! len) (u64 0) in
-  point_mul_double_split_lambda_table_noalloc out table1 table2 r1 q1 r2 q2 r3 q3 r4 q4
-  p1 p2 is_negate1 is_negate2 is_negate3 is_negate4;
+  PT.lprecomp_table len ctx_len k (null uint64) p2 table_len table2;
+  point_mul_g_double_split_lambda_table_noalloc out table2 r1 q1 r2 q2 r3 q3 r4 q4
+    p1 p2 is_negate1 is_negate2 is_negate3 is_negate4;
   let h1 = ST.get () in
-  assert (modifies (loc out |+| loc table1 |+| loc table2) h0 h1);
+  assert (modifies (loc out |+| loc table2) h0 h1);
   pop_frame ();
   let h2 = ST.get () in
   assert (modifies (loc out) h0 h2)
 
 
 inline_for_extraction noextract
-val point_mul_double_split_lambda_vartime_noalloc_12:
+val point_mul_g_double_split_lambda_vartime_endo_split:
     r1:qelem -> q1:point
   -> r2:qelem -> q2:point
   -> r3:qelem -> q3:point
@@ -528,7 +371,7 @@ val point_mul_double_split_lambda_vartime_noalloc_12:
     is_high3 == S.scalar_is_high r3_s0 /\
     is_high4 == S.scalar_is_high r4_s0))
 
-let point_mul_double_split_lambda_vartime_noalloc_12 r1 q1 r2 q2 r3 q3 r4 q4
+let point_mul_g_double_split_lambda_vartime_endo_split r1 q1 r2 q2 r3 q3 r4 q4
   scalar1 scalar2 p1 p2 =
   let is_high1, is_high2 = ecmult_endo_split r1 r2 q1 q2 scalar1 p1 in
   let is_high3, is_high4 = ecmult_endo_split r3 r4 q3 q4 scalar2 p2 in
@@ -536,7 +379,7 @@ let point_mul_double_split_lambda_vartime_noalloc_12 r1 q1 r2 q2 r3 q3 r4 q4
 
 
 inline_for_extraction noextract
-val point_mul_double_split_lambda_vartime_noalloc:
+val point_mul_g_double_split_lambda_vartime_noalloc:
     out:point
   -> r1:qelem -> q1:point
   -> r2:qelem -> q2:point
@@ -580,7 +423,7 @@ val point_mul_double_split_lambda_vartime_noalloc:
 
     disjoint q4 scalar1 /\ disjoint q4 scalar2 /\ disjoint q4 p1 /\ disjoint q4 p2 /\
 
-    point_inv h p1 /\ point_inv h p2 /\
+    point_inv h p1 /\ point_inv h p2 /\ point_eval h p1 == S.g /\
     qas_nat h scalar1 < S.q /\ qas_nat h scalar2 < S.q)
   (ensures  fun h0 _ h1 -> modifies (loc r1 |+| loc r2 |+| loc r3 |+| loc r4 |+|
     loc q1 |+| loc q2 |+| loc q3 |+| loc q4 |+| loc out) h0 h1 /\
@@ -590,12 +433,13 @@ val point_mul_double_split_lambda_vartime_noalloc:
       (S.aff_point_mul (qas_nat h0 scalar1) (S.to_aff_point (point_eval h0 p1)))
       (S.aff_point_mul (qas_nat h0 scalar2) (S.to_aff_point (point_eval h0 p2))))
 
-let point_mul_double_split_lambda_vartime_noalloc out r1 q1 r2 q2 r3 q3 r4 q4
+let point_mul_g_double_split_lambda_vartime_noalloc out r1 q1 r2 q2 r3 q3 r4 q4
   scalar1 scalar2 p1 p2 =
   let h0 = ST.get () in
   let is_high1, is_high2, is_high3, is_high4 =
-   point_mul_double_split_lambda_vartime_noalloc_12 r1 q1 r2 q2 r3 q3 r4 q4 scalar1 scalar2 p1 p2 in
-  point_mul_double_split_lambda_table out r1 q1 r2 q2 r3 q3 r4 q4
+   point_mul_g_double_split_lambda_vartime_endo_split
+     r1 q1 r2 q2 r3 q3 r4 q4 scalar1 scalar2 p1 p2 in
+  point_mul_g_double_split_lambda_table out r1 q1 r2 q2 r3 q3 r4 q4
     p1 p2 is_high1 is_high2 is_high3 is_high4;
   let h1 = ST.get () in
   assert (S.to_aff_point (point_eval h1 out) ==
@@ -608,7 +452,7 @@ let point_mul_double_split_lambda_vartime_noalloc out r1 q1 r2 q2 r3 q3 r4 q4
 
 
 inline_for_extraction noextract
-val point_mul_double_split_lambda_vartime_noalloc_aux:
+val point_mul_g_double_split_lambda_vartime_noalloc_aux:
     out:point
   -> r1234:lbuffer uint64 16ul
   -> q1234:lbuffer uint64 60ul
@@ -627,7 +471,7 @@ val point_mul_double_split_lambda_vartime_noalloc_aux:
 
     disjoint q1234 scalar1 /\ disjoint q1234 scalar2 /\ disjoint q1234 p1 /\ disjoint q1234 p2 /\
 
-    point_inv h p1 /\ point_inv h p2 /\
+    point_inv h p1 /\ point_inv h p2 /\ point_eval h p1 == S.g /\
     qas_nat h scalar1 < S.q /\ qas_nat h scalar2 < S.q)
   (ensures  fun h0 _ h1 -> modifies (loc r1234 |+| loc q1234 |+| loc out) h0 h1 /\
     point_inv h1 out /\
@@ -636,7 +480,7 @@ val point_mul_double_split_lambda_vartime_noalloc_aux:
       (S.aff_point_mul (qas_nat h0 scalar1) (S.to_aff_point (point_eval h0 p1)))
       (S.aff_point_mul (qas_nat h0 scalar2) (S.to_aff_point (point_eval h0 p2))))
 
-let point_mul_double_split_lambda_vartime_noalloc_aux out r1234 q1234 scalar1 scalar2 p1 p2 =
+let point_mul_g_double_split_lambda_vartime_noalloc_aux out r1234 q1234 scalar1 scalar2 p1 p2 =
   let r1 = sub r1234 0ul 4ul in
   let r2 = sub r1234 4ul 4ul in
   let r3 = sub r1234 8ul 4ul in
@@ -646,16 +490,18 @@ let point_mul_double_split_lambda_vartime_noalloc_aux out r1234 q1234 scalar1 sc
   let q2 = sub q1234 15ul 15ul in
   let q3 = sub q1234 30ul 15ul in
   let q4 = sub q1234 45ul 15ul in
-  point_mul_double_split_lambda_vartime_noalloc out r1 q1 r2 q2 r3 q3 r4 q4 scalar1 scalar2 p1 p2
+  point_mul_g_double_split_lambda_vartime_noalloc
+    out r1 q1 r2 q2 r3 q3 r4 q4 scalar1 scalar2 p1 p2
 
 
-val point_mul_double_split_lambda_vartime:
+inline_for_extraction noextract
+val point_mul_g_double_split_lambda_vartime_alloc:
   out:point -> scalar1:qelem -> p1:point -> scalar2:qelem -> p2:point -> Stack unit
   (requires fun h ->
     live h out /\ live h scalar1 /\ live h p1 /\ live h scalar2 /\ live h p2 /\
     disjoint p1 out /\ disjoint p2 out /\ eq_or_disjoint p1 p2 /\
     disjoint scalar1 out /\ disjoint scalar2 out /\
-    point_inv h p1 /\ point_inv h p2 /\
+    point_inv h p1 /\ point_inv h p2 /\ point_eval h p1 == S.g /\
     qas_nat h scalar1 < S.q /\ qas_nat h scalar2 < S.q)
   (ensures fun h0 _ h1 -> modifies (loc out) h0 h1 /\
     point_inv h1 out /\
@@ -664,27 +510,13 @@ val point_mul_double_split_lambda_vartime:
       (S.aff_point_mul (qas_nat h0 scalar1) (S.to_aff_point (point_eval h0 p1)))
       (S.aff_point_mul (qas_nat h0 scalar2) (S.to_aff_point (point_eval h0 p2))))
 
-[@CInline]
-let point_mul_double_split_lambda_vartime out scalar1 p1 scalar2 p2 =
+let point_mul_g_double_split_lambda_vartime_alloc out scalar1 p1 scalar2 p2 =
   push_frame ();
   let r1234 = create 16ul (u64 0) in
   let q1234 = create 60ul (u64 0) in
-  point_mul_double_split_lambda_vartime_noalloc_aux out r1234 q1234 scalar1 scalar2 p1 p2;
+  point_mul_g_double_split_lambda_vartime_noalloc_aux out r1234 q1234 scalar1 scalar2 p1 p2;
   pop_frame ()
 
-
-val point_mul_g_double_split_lambda_vartime:
-  out:point -> scalar1:qelem -> scalar2:qelem -> p2:point ->
-  Stack unit
-  (requires fun h ->
-    live h out /\ live h scalar1 /\ live h scalar2 /\ live h p2 /\
-    disjoint p2 out /\ disjoint out scalar1 /\ disjoint out scalar2 /\
-    point_inv h p2 /\ qas_nat h scalar1 < S.q /\ qas_nat h scalar2 < S.q)
-  (ensures fun h0 _ h1 -> modifies (loc out) h0 h1 /\
-    point_inv h1 out /\
-    S.to_aff_point (point_eval h1 out) ==
-    S.to_aff_point (S.point_mul_double_g
-      (qas_nat h0 scalar1) (qas_nat h0 scalar2) (point_eval h0 p2)))
 
 [@CInline]
 let point_mul_g_double_split_lambda_vartime out scalar1 scalar2 p2 =
@@ -697,5 +529,5 @@ let point_mul_g_double_split_lambda_vartime out scalar1 scalar2 p2 =
   push_frame ();
   let g = create 15ul (u64 0) in
   make_g g;
-  point_mul_double_split_lambda_vartime out scalar1 g scalar2 p2;
+  point_mul_g_double_split_lambda_vartime_alloc out scalar1 g scalar2 p2;
   pop_frame ()

--- a/code/k256/Hacl.Impl.K256.GLV.fst
+++ b/code/k256/Hacl.Impl.K256.GLV.fst
@@ -1,0 +1,701 @@
+module Hacl.Impl.K256.GLV
+
+open FStar.HyperStack
+open FStar.HyperStack.ST
+open FStar.Mul
+
+open Lib.IntTypes
+open Lib.Buffer
+
+module ST = FStar.HyperStack.ST
+module LSeq = Lib.Sequence
+
+module LE = Lib.Exponentiation
+module SE = Spec.Exponentiation
+module BE = Hacl.Impl.Exponentiation
+module ME = Hacl.Impl.MultiExponentiation
+module PT = Hacl.Impl.PrecompTable
+
+module S = Spec.K256
+module SL = Spec.K256.Lemmas
+module SG = Hacl.Spec.K256.GLV
+module SGL = Hacl.Spec.K256.GLV.Lemmas
+module PML = Hacl.Spec.K256.ECSM.Lemmas
+
+open Hacl.K256.Field
+open Hacl.K256.Scalar
+open Hacl.Impl.K256.Point
+
+open Hacl.Impl.K256.GLV.Constants
+include Hacl.Impl.K256.Group
+
+#set-options "--z3rlimit 50 --fuel 0 --ifuel 0"
+
+(**
+ Fast computation of [scalar]Q in projective coordinates
+*)
+
+inline_for_extraction noextract
+let table_neg_inv_precomp
+  (q:LSeq.lseq uint64 15) (is_negate:bool) : BE.table_inv_t U64 15ul 16ul =
+  fun a table ->
+    point_eval_lseq a == SG.point_negate_cond (point_eval_lseq q) is_negate /\
+    (forall (j:nat{j < 16}).
+      PT.precomp_table_inv 15ul 0ul mk_k256_concrete_ops q 16ul table j)
+
+// This function returns [r_small]Q or [r_small](-Q)
+// using a precomputed table [0; Q; 2Q; ...; 15Q]
+inline_for_extraction noextract
+val lprecomp_get_vartime_neg:
+    q:Ghost.erased (LSeq.lseq uint64 15){point_inv_lseq q} -> is_negate:bool ->
+  BE.pow_a_to_small_b_st U64 15ul 0ul mk_k256_concrete_ops 4ul 16ul
+    (table_neg_inv_precomp q is_negate)
+
+let lprecomp_get_vartime_neg q is_negate ctx lambda_q table r_small res =
+  let h0 = ST.get () in
+  assert (table_neg_inv_precomp q is_negate lambda_q (as_seq h0 table));
+  // table.[r_small] = [r_small]Q
+  BE.lprecomp_get_vartime 15ul 0ul mk_k256_concrete_ops 4ul 16ul ctx q table r_small res;
+  SE.pow_lemma S.mk_k256_concrete_ops (point_eval_lseq q) (v r_small);
+  let h1 = ST.get () in
+  assert (S.to_aff_point (point_eval h1 res) ==
+    S.to_aff_point (SE.pow S.mk_k256_concrete_ops (point_eval_lseq q) (v r_small)));
+
+  point_negate_conditional_vartime res is_negate;
+  let h2 = ST.get () in
+  assert (point_eval h2 res == SG.point_negate_cond (point_eval h1 res) is_negate);
+  SL.to_aff_point_negate_lemma (point_eval h1 res);
+  assert (S.to_aff_point (point_eval h2 res) ==
+    SG.aff_point_negate_cond (S.to_aff_point (point_eval h1 res)) is_negate);
+
+  // -[r_small]Q = [r_small](-Q)
+  SGL.aff_point_negate_cond_pow_lemma is_negate (point_eval_lseq q) (v r_small);
+  assert (S.to_aff_point (point_eval h2 res) ==
+    LE.pow S.mk_k256_comm_monoid
+      (S.to_aff_point (SG.point_negate_cond (point_eval_lseq q) is_negate)) (v r_small))
+
+
+inline_for_extraction noextract
+let table_lambda_neg_inv_precomp
+  (q:LSeq.lseq uint64 15) (is_negate:bool) : BE.table_inv_t U64 15ul 16ul =
+  fun a table ->
+    point_eval_lseq a ==
+      SG.point_negate_cond (SG.point_mul_lambda (point_eval_lseq q)) is_negate /\
+    (forall (j:nat{j < 16}).
+      PT.precomp_table_inv 15ul 0ul mk_k256_concrete_ops q 16ul table j)
+
+
+// This function returns [r_small]([lambda]Q) or [r_small](-[lambda]Q)
+// using a precomputed table [0; Q; 2Q; ...; 15Q]
+inline_for_extraction noextract
+val lprecomp_get_vartime_lambda_neg:
+    q:Ghost.erased (LSeq.lseq uint64 15){point_inv_lseq q} -> is_negate:bool ->
+  BE.pow_a_to_small_b_st U64 15ul 0ul mk_k256_concrete_ops 4ul 16ul
+    (table_lambda_neg_inv_precomp q is_negate)
+
+let lprecomp_get_vartime_lambda_neg q is_negate ctx lambda_q table r_small res =
+  let h0 = ST.get () in
+  assert (table_lambda_neg_inv_precomp q is_negate lambda_q (as_seq h0 table));
+  // table.[r_small] = [r_small]Q
+  BE.lprecomp_get_vartime 15ul 0ul mk_k256_concrete_ops 4ul 16ul ctx q table r_small res;
+  SE.pow_lemma S.mk_k256_concrete_ops (point_eval_lseq q) (v r_small);
+  let h1 = ST.get () in
+  assert (S.to_aff_point (point_eval h1 res) ==
+    S.to_aff_point (SE.pow S.mk_k256_concrete_ops (point_eval_lseq q) (v r_small)));
+
+  // -[r_small]Q = [r_small](-Q)
+  point_negate_conditional_vartime res is_negate;
+  let h2 = ST.get () in
+  assert (point_eval h2 res == SG.point_negate_cond (point_eval h1 res) is_negate);
+  SL.to_aff_point_negate_lemma (point_eval h1 res);
+  assert (S.to_aff_point (point_eval h2 res) ==
+    SG.aff_point_negate_cond (S.to_aff_point (point_eval h1 res)) is_negate);
+
+  // [lambda]([r_small]Q) or [lambda]([r_small](-Q))
+  point_mul_lambda_inplace res;
+  let h3 = ST.get () in
+  assert (point_eval h3 res == SG.point_mul_lambda (point_eval h2 res));
+  SGL.lemma_glv (point_eval h2 res);
+  assert (S.to_aff_point (point_eval h3 res) ==
+    SG.aff_point_mul SG.lambda (S.to_aff_point (point_eval h2 res)));
+
+  // [r_small]([lambda]Q) or [r_small](-[lambda]Q)
+  SGL.aff_point_negate_cond_lambda_pow_lemma is_negate (point_eval_lseq q) (v r_small);
+  assert (S.to_aff_point (point_eval h3 res) ==
+    LE.pow S.mk_k256_comm_monoid
+      (S.to_aff_point
+        (SG.point_negate_cond (SG.point_mul_lambda (point_eval_lseq q)) is_negate)) (v r_small))
+
+//------------------------------
+
+inline_for_extraction noextract
+val point_mul_split_lambda_table:
+  out:point -> r1:qelem -> q1:point -> r2:qelem -> q2:point
+  -> p:point -> is_negate1:bool -> is_negate2:bool -> Stack unit
+  (requires fun h ->
+    live h out /\ live h r1 /\ live h r2 /\
+    live h q1 /\ live h q2 /\ live h p /\
+    eq_or_disjoint q1 q2 /\ disjoint out q1 /\ disjoint out q2 /\
+    disjoint out r1 /\ disjoint out r2 /\ disjoint out p /\
+    point_inv h q1 /\ point_inv h q2 /\ point_inv h p /\
+    point_eval h q1 == SG.point_negate_cond (point_eval h p) is_negate1 /\
+    point_eval h q2 == SG.point_negate_cond (SG.point_mul_lambda (point_eval h p)) is_negate2 /\
+    qas_nat h r1 < S.q /\ qas_nat h r1 < pow2 128 /\
+    qas_nat h r2 < S.q /\ qas_nat h r2 < pow2 128)
+  (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
+    point_inv h1 out /\
+    refl (as_seq h1 out) ==
+      LE.exp_double_fw S.mk_k256_comm_monoid
+        (refl (as_seq h0 q1)) 128 (qas_nat h0 r1)
+        (refl (as_seq h0 q2)) (qas_nat h0 r2) 4)
+
+let point_mul_split_lambda_table out r1 q1 r2 q2 p is_negate1 is_negate2 =
+  [@inline_let] let len = 15ul in
+  [@inline_let] let ctx_len = 0ul in
+  [@inline_let] let k = mk_k256_concrete_ops in
+  [@inline_let] let l = 4ul in
+  [@inline_let] let table_len = 16ul in
+  [@inline_let] let bLen = 4ul in
+  [@inline_let] let bBits = 128ul in
+
+  let h0 = ST.get () in
+  push_frame ();
+  let table = create (table_len *! len) (u64 0) in
+  PT.lprecomp_table len ctx_len k (null uint64) p table_len table;
+  let h1 = ST.get () in
+  assert (forall (j:nat{j < v table_len}).
+    PT.precomp_table_inv len ctx_len k (as_seq h1 p) table_len (as_seq h1 table) j);
+
+  assert (point_eval_lseq (as_seq h1 q1) ==
+    SG.point_negate_cond (point_eval_lseq (as_seq h1 p)) is_negate1);
+  [@inline_let]
+  let table_inv1 : BE.table_inv_t U64 len table_len =
+    table_neg_inv_precomp (as_seq h0 p) is_negate1 in
+  assert (table_inv1 (as_seq h1 q1) (as_seq h1 table));
+
+  assert (point_eval_lseq (as_seq h1 q2) ==
+    SG.point_negate_cond (SG.point_mul_lambda (point_eval_lseq (as_seq h1 p))) is_negate2);
+  [@inline_let]
+  let table_inv2 : BE.table_inv_t U64 len table_len =
+    table_lambda_neg_inv_precomp (as_seq h0 p) is_negate2 in
+  assert (table_inv2 (as_seq h1 q2) (as_seq h1 table));
+
+  ME.mk_lexp_double_fw_tables len ctx_len k l table_len
+    table_inv1 table_inv2
+    (lprecomp_get_vartime_neg (as_seq h0 p) is_negate1)
+    (lprecomp_get_vartime_lambda_neg (as_seq h0 p) is_negate2)
+    (null uint64) q1 bLen bBits r1 q2 r2 (to_const table) (to_const table) out;
+  pop_frame ()
+
+
+// [scalar]Q = [(r1 + r2 * lambda) % S.q]Q = [r1]Q + [r2]([lambda]Q)
+inline_for_extraction noextract
+val point_mul_split_lambda_vartime: out:point -> scalar:qelem -> q:point -> Stack unit
+  (requires fun h ->
+    live h out /\ live h scalar /\ live h q /\
+    disjoint out q /\ disjoint out scalar /\ disjoint q scalar /\
+    point_inv h q /\ qas_nat h scalar < S.q)
+  (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
+    point_inv h1 out /\
+    S.to_aff_point (point_eval h1 out) ==
+      S.aff_point_mul (qas_nat h0 scalar) (S.to_aff_point (point_eval h0 q)))
+
+let point_mul_split_lambda_vartime out scalar q =
+  let h0 = ST.get () in
+  push_frame ();
+  let r1 = create_qelem () in
+  let r2 = create_qelem () in
+  let q1 = create_point () in
+  let q2 = create_point () in
+  let is_high1, is_high2 = ecmult_endo_split r1 r2 q1 q2 scalar q in
+  let h1 = ST.get () in
+  assert (modifies (loc r1 |+| loc r2 |+| loc q1 |+| loc q2) h0 h1);
+  point_mul_split_lambda_table out r1 q1 r2 q2 q is_high1 is_high2;
+  let h2 = ST.get () in
+  assert (modifies (loc out) h1 h2);
+  assert (modifies (loc r1 |+| loc r2 |+| loc q1 |+| loc q2 |+| loc out) h0 h2);
+  pop_frame ();
+  let h3 = ST.get () in
+  assert (modifies (loc out) h0 h3);
+  assert (S.to_aff_point (point_eval h3 out) ==
+    SGL.aff_proj_point_mul_split_lambda (qas_nat h0 scalar) (point_eval h0 q));
+  SGL.lemma_aff_proj_point_mul_split_lambda (qas_nat h0 scalar) (point_eval h0 q)
+
+
+// TODO: precompute a table [0; G; 2G; ..; 15G]?
+val point_mul_g_split_lambda_vartime: out:point -> scalar:qelem -> Stack unit
+  (requires fun h ->
+    live h out /\ live h scalar /\ disjoint out scalar /\
+    qas_nat h scalar < S.q)
+  (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
+    point_inv h1 out /\
+    S.to_aff_point (point_eval h1 out) ==
+      S.aff_point_mul (qas_nat h0 scalar) (S.g_x, S.g_y))
+
+[@CInline]
+let point_mul_g_split_lambda_vartime out scalar =
+  SL.lemma_proj_aff_id (S.g_x, S.g_y);
+  push_frame ();
+  let g = create 15ul (u64 0) in
+  make_g g;
+  point_mul_split_lambda_vartime out scalar g;
+  pop_frame ()
+
+
+(**
+ Fast computation of [scalar1]Q1 + [scalar2]Q2 in projective coordinates
+*)
+
+inline_for_extraction noextract
+val mk_two_tables:
+    table1:lbuffer uint64 (16ul *! 15ul)
+  -> table2:lbuffer uint64 (16ul *! 15ul)
+  -> p1:point -> p2:point ->
+  Stack unit
+  (requires fun h ->
+    live h table1 /\ live h table2 /\ live h p1 /\ live h p2 /\
+    disjoint table1 table2 /\ disjoint table1 p1 /\ disjoint table1 p2 /\
+    disjoint table2 p1 /\ disjoint table2 p2 /\
+    point_inv h p1 /\ point_inv h p2)
+  (ensures fun h0 _ h1 -> modifies (loc table1 |+| loc table2) h0 h1 /\
+   (let len = 15ul in
+    let ctx_len = 0ul in
+    let k = mk_k256_concrete_ops in
+    let l = 4ul in
+    let table_len = 16ul in
+    BE.table_inv_precomp len ctx_len k l table_len (as_seq h0 p1) (as_seq h1 table1) /\
+    BE.table_inv_precomp len ctx_len k l table_len (as_seq h0 p2) (as_seq h1 table2)))
+
+let mk_two_tables table1 table2 p1 p2 =
+  [@inline_let] let len = 15ul in
+  [@inline_let] let ctx_len = 0ul in
+  [@inline_let] let k = mk_k256_concrete_ops in
+  [@inline_let] let l = 4ul in
+  [@inline_let] let table_len = 16ul in
+
+  let h0 = ST.get () in
+  PT.lprecomp_table len ctx_len k (null uint64) p1 table_len table1;
+  let h1 = ST.get () in
+  assert (BE.table_inv_precomp len ctx_len k l table_len
+    (as_seq h1 p1) (as_seq h1 table1));
+
+  PT.lprecomp_table len ctx_len k (null uint64) p2 table_len table2;
+  let h2 = ST.get () in
+  assert (BE.table_inv_precomp len ctx_len k l table_len
+    (as_seq h2 p1) (as_seq h2 table1));
+  assert (BE.table_inv_precomp len ctx_len k l table_len
+    (as_seq h2 p2) (as_seq h2 table2))
+
+
+inline_for_extraction noextract
+val point_mul_double_split_lambda_table_noalloc:
+    out:point
+  -> table1:lbuffer uint64 (16ul *! 15ul)
+  -> table2:lbuffer uint64 (16ul *! 15ul)
+  -> r1:qelem -> q1:point
+  -> r2:qelem -> q2:point
+  -> r3:qelem -> q3:point
+  -> r4:qelem -> q4:point
+  -> p1:point -> p2:point
+  -> is_negate1:bool -> is_negate2:bool
+  -> is_negate3:bool -> is_negate4:bool ->
+  Stack unit
+  (requires fun h ->
+    live h out /\ live h r1 /\ live h r2 /\ live h r3 /\ live h r4 /\
+    live h q1 /\ live h q2 /\ live h q3 /\ live h q4 /\
+    live h p1 /\ live h p2 /\ live h table1 /\ live h table2 /\
+
+    eq_or_disjoint q1 q2 /\ eq_or_disjoint q1 q3 /\ eq_or_disjoint q1 q4 /\
+    eq_or_disjoint q2 q3 /\ eq_or_disjoint q2 q4 /\ eq_or_disjoint q3 q4 /\
+    disjoint out q1 /\ disjoint out q2 /\ disjoint out q3 /\ disjoint out q4 /\
+    disjoint out r1 /\ disjoint out r2 /\ disjoint out r3 /\ disjoint out r4 /\
+    disjoint out p1  /\ disjoint out p2 /\ disjoint table1 table2 /\
+
+    disjoint table1 out /\ disjoint table1 r1 /\ disjoint table1 r2 /\
+    disjoint table1 r3 /\ disjoint table1 r4 /\  disjoint table1 p1 /\
+    disjoint table1 p2 /\ disjoint table1 q1 /\ disjoint table1 q2 /\
+    disjoint table1 q3 /\ disjoint table1 q4 /\
+
+    disjoint table2 out /\ disjoint table2 r1 /\ disjoint table2 r2 /\
+    disjoint table2 r3 /\ disjoint table2 r4 /\  disjoint table2 p1 /\
+    disjoint table2 p2 /\ disjoint table2 q1 /\ disjoint table2 q2 /\
+    disjoint table2 q3 /\ disjoint table2 q4 /\
+
+    point_inv h q1 /\ point_inv h q2 /\ point_inv h q3 /\ point_inv h q4 /\
+    point_inv h p1 /\ point_inv h p2 /\
+    point_eval h q1==SG.point_negate_cond (point_eval h p1) is_negate1 /\
+    point_eval h q2==SG.point_negate_cond (SG.point_mul_lambda (point_eval h p1)) is_negate2 /\
+    point_eval h q3==SG.point_negate_cond (point_eval h p2) is_negate3 /\
+    point_eval h q4==SG.point_negate_cond (SG.point_mul_lambda (point_eval h p2)) is_negate4 /\
+    qas_nat h r1 < S.q /\ qas_nat h r1 < pow2 128 /\
+    qas_nat h r2 < S.q /\ qas_nat h r2 < pow2 128 /\
+    qas_nat h r3 < S.q /\ qas_nat h r3 < pow2 128 /\
+    qas_nat h r4 < S.q /\ qas_nat h r4 < pow2 128)
+  (ensures  fun h0 _ h1 -> modifies (loc out |+| loc table1 |+| loc table2) h0 h1 /\
+    point_inv h1 out /\
+    refl (as_seq h1 out) ==
+      LE.exp_four_fw S.mk_k256_comm_monoid
+        (refl (as_seq h0 q1)) 128 (qas_nat h0 r1)
+        (refl (as_seq h0 q2)) (qas_nat h0 r2)
+        (refl (as_seq h0 q3)) (qas_nat h0 r3)
+        (refl (as_seq h0 q4)) (qas_nat h0 r4) 4)
+
+let point_mul_double_split_lambda_table_noalloc out table1 table2 r1 q1 r2 q2 r3 q3 r4 q4
+  p1 p2 is_negate1 is_negate2 is_negate3 is_negate4 =
+  [@inline_let] let len = 15ul in
+  [@inline_let] let ctx_len = 0ul in
+  [@inline_let] let k = mk_k256_concrete_ops in
+  [@inline_let] let l = 4ul in
+  [@inline_let] let table_len = 16ul in
+  [@inline_let] let bLen = 4ul in
+  [@inline_let] let bBits = 128ul in
+
+  let h0 = ST.get () in
+  mk_two_tables table1 table2 p1 p2;
+  let h1 = ST.get () in
+  assert (forall (j:nat{j < v table_len}).
+    PT.precomp_table_inv len ctx_len k (as_seq h1 p1) table_len (as_seq h1 table1) j);
+  assert (forall (j:nat{j < v table_len}).
+    PT.precomp_table_inv len ctx_len k (as_seq h1 p2) table_len (as_seq h1 table2) j);
+
+  assert (point_eval_lseq (as_seq h1 q1) ==
+    SG.point_negate_cond (point_eval_lseq (as_seq h1 p1)) is_negate1);
+  [@inline_let]
+  let table_inv1 : BE.table_inv_t U64 len table_len =
+    table_neg_inv_precomp (as_seq h0 p1) is_negate1 in
+  assert (table_inv1 (as_seq h1 q1) (as_seq h1 table1));
+
+  assert (point_eval_lseq (as_seq h1 q2) ==
+    SG.point_negate_cond (SG.point_mul_lambda (point_eval_lseq (as_seq h1 p1))) is_negate2);
+  [@inline_let]
+  let table_inv2 : BE.table_inv_t U64 len table_len =
+    table_lambda_neg_inv_precomp (as_seq h0 p1) is_negate2 in
+  assert (table_inv2 (as_seq h1 q2) (as_seq h1 table1));
+
+  assert (point_eval_lseq (as_seq h1 q3) ==
+    SG.point_negate_cond (point_eval_lseq (as_seq h1 p2)) is_negate3);
+  [@inline_let]
+  let table_inv3 : BE.table_inv_t U64 len table_len =
+    table_neg_inv_precomp (as_seq h0 p2) is_negate3 in
+  assert (table_inv3 (as_seq h1 q3) (as_seq h1 table2));
+
+  assert (point_eval_lseq (as_seq h1 q4) ==
+    SG.point_negate_cond (SG.point_mul_lambda (point_eval_lseq (as_seq h1 p2))) is_negate4);
+  [@inline_let]
+  let table_inv4 : BE.table_inv_t U64 len table_len =
+    table_lambda_neg_inv_precomp (as_seq h0 p2) is_negate4 in
+  assert (table_inv4 (as_seq h1 q4) (as_seq h1 table2));
+
+  assert (modifies (loc table1 |+| loc table2) h0 h1);
+
+  ME.mk_lexp_four_fw_tables len ctx_len k l table_len
+    table_inv1 table_inv2 table_inv3 table_inv4
+    (lprecomp_get_vartime_neg (as_seq h0 p1) is_negate1)
+    (lprecomp_get_vartime_lambda_neg (as_seq h0 p1) is_negate2)
+    (lprecomp_get_vartime_neg (as_seq h0 p2) is_negate3)
+    (lprecomp_get_vartime_lambda_neg (as_seq h0 p2) is_negate4)
+    (null uint64) q1 bLen bBits r1 q2 r2 q3 r3 q4 r4
+    (to_const table1) (to_const table1) (to_const table2) (to_const table2) out;
+
+  let h2 = ST.get () in
+  assert (modifies (loc out) h1 h2);
+  assert (point_inv h2 out /\
+    refl (as_seq h2 out) ==
+      LE.exp_four_fw S.mk_k256_comm_monoid
+        (refl (as_seq h0 q1)) 128 (qas_nat h0 r1)
+        (refl (as_seq h0 q2)) (qas_nat h0 r2)
+        (refl (as_seq h0 q3)) (qas_nat h0 r3)
+        (refl (as_seq h0 q4)) (qas_nat h0 r4) 4);
+
+  assert (modifies (loc table1 |+| loc table2 |+| loc out) h0 h2)
+
+
+inline_for_extraction noextract
+val point_mul_double_split_lambda_table:
+    out:point
+  -> r1:qelem -> q1:point
+  -> r2:qelem -> q2:point
+  -> r3:qelem -> q3:point
+  -> r4:qelem -> q4:point
+  -> p1:point -> p2:point
+  -> is_negate1:bool -> is_negate2:bool
+  -> is_negate3:bool -> is_negate4:bool ->
+  Stack unit
+  (requires fun h ->
+    live h out /\ live h r1 /\ live h r2 /\ live h r3 /\ live h r4 /\
+    live h q1 /\ live h q2 /\ live h q3 /\ live h q4 /\ live h p1 /\ live h p2 /\
+    eq_or_disjoint q1 q2 /\ eq_or_disjoint q1 q3 /\ eq_or_disjoint q1 q4 /\
+    eq_or_disjoint q2 q3 /\ eq_or_disjoint q2 q4 /\ eq_or_disjoint q3 q4 /\
+    disjoint out q1 /\ disjoint out q2 /\ disjoint out q3 /\ disjoint out q4 /\
+    disjoint out r1 /\ disjoint out r2 /\ disjoint out r3 /\ disjoint out r4 /\
+    disjoint out p1  /\ disjoint out p2 /\
+    point_inv h q1 /\ point_inv h q2 /\ point_inv h q3 /\ point_inv h q4 /\
+    point_inv h p1 /\ point_inv h p2 /\
+    point_eval h q1==SG.point_negate_cond (point_eval h p1) is_negate1 /\
+    point_eval h q2==SG.point_negate_cond (SG.point_mul_lambda (point_eval h p1)) is_negate2 /\
+    point_eval h q3==SG.point_negate_cond (point_eval h p2) is_negate3 /\
+    point_eval h q4==SG.point_negate_cond (SG.point_mul_lambda (point_eval h p2)) is_negate4 /\
+    qas_nat h r1 < S.q /\ qas_nat h r1 < pow2 128 /\
+    qas_nat h r2 < S.q /\ qas_nat h r2 < pow2 128 /\
+    qas_nat h r3 < S.q /\ qas_nat h r3 < pow2 128 /\
+    qas_nat h r4 < S.q /\ qas_nat h r4 < pow2 128)
+  (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
+    point_inv h1 out /\
+    refl (as_seq h1 out) ==
+      LE.exp_four_fw S.mk_k256_comm_monoid
+        (refl (as_seq h0 q1)) 128 (qas_nat h0 r1)
+        (refl (as_seq h0 q2)) (qas_nat h0 r2)
+        (refl (as_seq h0 q3)) (qas_nat h0 r3)
+        (refl (as_seq h0 q4)) (qas_nat h0 r4) 4)
+
+let point_mul_double_split_lambda_table out r1 q1 r2 q2 r3 q3 r4 q4
+  p1 p2 is_negate1 is_negate2 is_negate3 is_negate4 =
+  [@inline_let] let len = 15ul in
+  [@inline_let] let table_len = 16ul in
+
+  let h0 = ST.get () in
+  push_frame ();
+  let table1 = create (table_len *! len) (u64 0) in
+  let table2 = create (table_len *! len) (u64 0) in
+  point_mul_double_split_lambda_table_noalloc out table1 table2 r1 q1 r2 q2 r3 q3 r4 q4
+  p1 p2 is_negate1 is_negate2 is_negate3 is_negate4;
+  let h1 = ST.get () in
+  assert (modifies (loc out |+| loc table1 |+| loc table2) h0 h1);
+  pop_frame ();
+  let h2 = ST.get () in
+  assert (modifies (loc out) h0 h2)
+
+
+inline_for_extraction noextract
+val point_mul_double_split_lambda_vartime_noalloc_12:
+    r1:qelem -> q1:point
+  -> r2:qelem -> q2:point
+  -> r3:qelem -> q3:point
+  -> r4:qelem -> q4:point
+  -> scalar1:qelem -> scalar2:qelem
+  -> p1:point -> p2:point ->
+  Stack (bool & bool & bool & bool)
+  (requires fun h ->
+    live h r1 /\ live h r2 /\ live h r3 /\ live h r4 /\
+    live h q1 /\ live h q2 /\ live h q3 /\ live h q4 /\
+    live h p1 /\ live h p2 /\ live h scalar1 /\ live h scalar2 /\
+
+    disjoint r1 q1 /\ disjoint r1 r2 /\ disjoint r1 q2 /\ disjoint r1 r3 /\
+    disjoint r1 q3 /\ disjoint r1 r4 /\ disjoint r1 q4 /\ disjoint r1 scalar1 /\
+    disjoint r1 scalar2 /\ disjoint r1 p1 /\ disjoint r1 p2 /\
+
+    disjoint q1 r2 /\ disjoint q1 q2 /\ disjoint q1 r3 /\ disjoint q1 q3 /\
+    disjoint q1 r4 /\ disjoint q1 q4 /\ disjoint q1 scalar1 /\ disjoint q1 scalar2 /\
+    disjoint q1 p1 /\ disjoint q1 p2 /\
+
+    disjoint r2 q2 /\ disjoint r2 r3 /\ disjoint r2 q3 /\ disjoint r2 r4 /\
+    disjoint r2 q4 /\ disjoint r2 scalar1 /\ disjoint r2 scalar2 /\ disjoint r2 p1 /\
+    disjoint r2 p2 /\
+
+    disjoint q2 r3 /\ disjoint q2 q3 /\ disjoint q2 r4 /\ disjoint q2 q4 /\
+    disjoint q2 scalar1 /\ disjoint q2 scalar2 /\ disjoint q2 p1 /\ disjoint q2 p2 /\
+
+    disjoint r3 q3 /\ disjoint r3 r4 /\ disjoint r3 q4 /\ disjoint r3 scalar1 /\
+    disjoint r3 scalar2 /\ disjoint r3 p1 /\ disjoint r3 p2 /\
+
+    disjoint q3 r4 /\ disjoint q3 q4 /\ disjoint q3 scalar1 /\ disjoint q3 scalar2 /\
+    disjoint q3 p1 /\ disjoint q3 p2 /\
+
+    disjoint r4 q4 /\ disjoint r4 scalar1 /\ disjoint r4 scalar2 /\ disjoint r4 p1 /\
+    disjoint r4 p2 /\
+
+    disjoint q4 scalar1 /\ disjoint q4 scalar2 /\ disjoint q4 p1 /\ disjoint q4 p2 /\
+
+    point_inv h p1 /\ point_inv h p2 /\
+    qas_nat h scalar1 < S.q /\ qas_nat h scalar2 < S.q)
+  (ensures  fun h0 (is_high1, is_high2, is_high3, is_high4) h1 ->
+    modifies (loc r1 |+| loc r2 |+| loc r3 |+| loc r4 |+|
+      loc q1 |+| loc q2 |+| loc q3 |+| loc q4) h0 h1 /\
+
+    point_inv h1 q1 /\ point_inv h1 q2 /\ point_inv h1 q3 /\ point_inv h1 q4 /\
+   (let r1_s0, r2_s0 = SG.scalar_split_lambda (qas_nat h0 scalar1) in
+    let r3_s0, r4_s0 = SG.scalar_split_lambda (qas_nat h0 scalar2) in
+    let r1_s, q1_s, r2_s, q2_s = SG.ecmult_endo_split (qas_nat h0 scalar1) (point_eval h0 p1) in
+    let r3_s, q3_s, r4_s, q4_s = SG.ecmult_endo_split (qas_nat h0 scalar2) (point_eval h0 p2) in
+    qas_nat h1 r1 == r1_s /\ r1_s < pow2 128 /\
+    qas_nat h1 r2 == r2_s /\ r2_s < pow2 128 /\
+    qas_nat h1 r3 == r3_s /\ r3_s < pow2 128 /\
+    qas_nat h1 r4 == r4_s /\ r4_s < pow2 128 /\
+    point_eval h1 q1 == q1_s /\ point_eval h1 q2 == q2_s /\
+    point_eval h1 q3 == q3_s /\ point_eval h1 q4 == q4_s /\
+    is_high1 == S.scalar_is_high r1_s0 /\
+    is_high2 == S.scalar_is_high r2_s0 /\
+    is_high3 == S.scalar_is_high r3_s0 /\
+    is_high4 == S.scalar_is_high r4_s0))
+
+let point_mul_double_split_lambda_vartime_noalloc_12 r1 q1 r2 q2 r3 q3 r4 q4
+  scalar1 scalar2 p1 p2 =
+  let is_high1, is_high2 = ecmult_endo_split r1 r2 q1 q2 scalar1 p1 in
+  let is_high3, is_high4 = ecmult_endo_split r3 r4 q3 q4 scalar2 p2 in
+  (is_high1, is_high2, is_high3, is_high4)
+
+
+inline_for_extraction noextract
+val point_mul_double_split_lambda_vartime_noalloc:
+    out:point
+  -> r1:qelem -> q1:point
+  -> r2:qelem -> q2:point
+  -> r3:qelem -> q3:point
+  -> r4:qelem -> q4:point
+  -> scalar1:qelem -> scalar2:qelem
+  -> p1:point -> p2:point ->
+  Stack unit
+  (requires fun h ->
+    live h out /\ live h r1 /\ live h r2 /\ live h r3 /\ live h r4 /\
+    live h q1 /\ live h q2 /\ live h q3 /\ live h q4 /\
+    live h p1 /\ live h p2 /\ live h scalar1 /\ live h scalar2 /\
+
+    disjoint out r1 /\ disjoint out q1 /\ disjoint out r2 /\ disjoint out q2 /\
+    disjoint out r3 /\ disjoint out q3 /\ disjoint out r4 /\ disjoint out q4 /\
+    disjoint out scalar1 /\ disjoint out scalar2 /\ disjoint out p1 /\ disjoint out p2 /\
+
+    disjoint r1 q1 /\ disjoint r1 r2 /\ disjoint r1 q2 /\ disjoint r1 r3 /\
+    disjoint r1 q3 /\ disjoint r1 r4 /\ disjoint r1 q4 /\ disjoint r1 scalar1 /\
+    disjoint r1 scalar2 /\ disjoint r1 p1 /\ disjoint r1 p2 /\
+
+    disjoint q1 r2 /\ disjoint q1 q2 /\ disjoint q1 r3 /\ disjoint q1 q3 /\
+    disjoint q1 r4 /\ disjoint q1 q4 /\ disjoint q1 scalar1 /\ disjoint q1 scalar2 /\
+    disjoint q1 p1 /\ disjoint q1 p2 /\
+
+    disjoint r2 q2 /\ disjoint r2 r3 /\ disjoint r2 q3 /\ disjoint r2 r4 /\
+    disjoint r2 q4 /\ disjoint r2 scalar1 /\ disjoint r2 scalar2 /\ disjoint r2 p1 /\
+    disjoint r2 p2 /\
+
+    disjoint q2 r3 /\ disjoint q2 q3 /\ disjoint q2 r4 /\ disjoint q2 q4 /\
+    disjoint q2 scalar1 /\ disjoint q2 scalar2 /\ disjoint q2 p1 /\ disjoint q2 p2 /\
+
+    disjoint r3 q3 /\ disjoint r3 r4 /\ disjoint r3 q4 /\ disjoint r3 scalar1 /\
+    disjoint r3 scalar2 /\ disjoint r3 p1 /\ disjoint r3 p2 /\
+
+    disjoint q3 r4 /\ disjoint q3 q4 /\ disjoint q3 scalar1 /\ disjoint q3 scalar2 /\
+    disjoint q3 p1 /\ disjoint q3 p2 /\
+
+    disjoint r4 q4 /\ disjoint r4 scalar1 /\ disjoint r4 scalar2 /\ disjoint r4 p1 /\
+    disjoint r4 p2 /\
+
+    disjoint q4 scalar1 /\ disjoint q4 scalar2 /\ disjoint q4 p1 /\ disjoint q4 p2 /\
+
+    point_inv h p1 /\ point_inv h p2 /\
+    qas_nat h scalar1 < S.q /\ qas_nat h scalar2 < S.q)
+  (ensures  fun h0 _ h1 -> modifies (loc r1 |+| loc r2 |+| loc r3 |+| loc r4 |+|
+    loc q1 |+| loc q2 |+| loc q3 |+| loc q4 |+| loc out) h0 h1 /\
+    point_inv h1 out /\
+    S.to_aff_point (point_eval h1 out) ==
+    S.aff_point_add
+      (S.aff_point_mul (qas_nat h0 scalar1) (S.to_aff_point (point_eval h0 p1)))
+      (S.aff_point_mul (qas_nat h0 scalar2) (S.to_aff_point (point_eval h0 p2))))
+
+let point_mul_double_split_lambda_vartime_noalloc out r1 q1 r2 q2 r3 q3 r4 q4
+  scalar1 scalar2 p1 p2 =
+  let h0 = ST.get () in
+  let is_high1, is_high2, is_high3, is_high4 =
+   point_mul_double_split_lambda_vartime_noalloc_12 r1 q1 r2 q2 r3 q3 r4 q4 scalar1 scalar2 p1 p2 in
+  point_mul_double_split_lambda_table out r1 q1 r2 q2 r3 q3 r4 q4
+    p1 p2 is_high1 is_high2 is_high3 is_high4;
+  let h1 = ST.get () in
+  assert (S.to_aff_point (point_eval h1 out) ==
+    SGL.aff_proj_point_mul_double_split_lambda
+      (qas_nat h0 scalar1) (point_eval h0 p1)
+      (qas_nat h0 scalar2) (point_eval h0 p2));
+  SGL.lemma_aff_proj_point_mul_double_split_lambda
+    (qas_nat h0 scalar1) (point_eval h0 p1)
+    (qas_nat h0 scalar2) (point_eval h0 p2)
+
+
+inline_for_extraction noextract
+val point_mul_double_split_lambda_vartime_noalloc_aux:
+    out:point
+  -> r1234:lbuffer uint64 16ul
+  -> q1234:lbuffer uint64 60ul
+  -> scalar1:qelem -> scalar2:qelem
+  -> p1:point -> p2:point ->
+  Stack unit
+  (requires fun h ->
+    live h out /\ live h r1234 /\ live h q1234 /\
+    live h p1 /\ live h p2 /\ live h scalar1 /\ live h scalar2 /\
+
+    disjoint out r1234 /\ disjoint out q1234 /\
+    disjoint out scalar1 /\ disjoint out scalar2 /\ disjoint out p1 /\ disjoint out p2 /\
+
+    disjoint r1234 q1234 /\ disjoint r1234 scalar1 /\ disjoint r1234 scalar2 /\
+    disjoint r1234 p1 /\ disjoint r1234 p2 /\
+
+    disjoint q1234 scalar1 /\ disjoint q1234 scalar2 /\ disjoint q1234 p1 /\ disjoint q1234 p2 /\
+
+    point_inv h p1 /\ point_inv h p2 /\
+    qas_nat h scalar1 < S.q /\ qas_nat h scalar2 < S.q)
+  (ensures  fun h0 _ h1 -> modifies (loc r1234 |+| loc q1234 |+| loc out) h0 h1 /\
+    point_inv h1 out /\
+    S.to_aff_point (point_eval h1 out) ==
+    S.aff_point_add
+      (S.aff_point_mul (qas_nat h0 scalar1) (S.to_aff_point (point_eval h0 p1)))
+      (S.aff_point_mul (qas_nat h0 scalar2) (S.to_aff_point (point_eval h0 p2))))
+
+let point_mul_double_split_lambda_vartime_noalloc_aux out r1234 q1234 scalar1 scalar2 p1 p2 =
+  let r1 = sub r1234 0ul 4ul in
+  let r2 = sub r1234 4ul 4ul in
+  let r3 = sub r1234 8ul 4ul in
+  let r4 = sub r1234 12ul 4ul in
+
+  let q1 = sub q1234 0ul 15ul in
+  let q2 = sub q1234 15ul 15ul in
+  let q3 = sub q1234 30ul 15ul in
+  let q4 = sub q1234 45ul 15ul in
+  point_mul_double_split_lambda_vartime_noalloc out r1 q1 r2 q2 r3 q3 r4 q4 scalar1 scalar2 p1 p2
+
+
+val point_mul_double_split_lambda_vartime:
+  out:point -> scalar1:qelem -> p1:point -> scalar2:qelem -> p2:point -> Stack unit
+  (requires fun h ->
+    live h out /\ live h scalar1 /\ live h p1 /\ live h scalar2 /\ live h p2 /\
+    disjoint p1 out /\ disjoint p2 out /\ eq_or_disjoint p1 p2 /\
+    disjoint scalar1 out /\ disjoint scalar2 out /\
+    point_inv h p1 /\ point_inv h p2 /\
+    qas_nat h scalar1 < S.q /\ qas_nat h scalar2 < S.q)
+  (ensures fun h0 _ h1 -> modifies (loc out) h0 h1 /\
+    point_inv h1 out /\
+    S.to_aff_point (point_eval h1 out) ==
+    S.aff_point_add
+      (S.aff_point_mul (qas_nat h0 scalar1) (S.to_aff_point (point_eval h0 p1)))
+      (S.aff_point_mul (qas_nat h0 scalar2) (S.to_aff_point (point_eval h0 p2))))
+
+[@CInline]
+let point_mul_double_split_lambda_vartime out scalar1 p1 scalar2 p2 =
+  push_frame ();
+  let r1234 = create 16ul (u64 0) in
+  let q1234 = create 60ul (u64 0) in
+  point_mul_double_split_lambda_vartime_noalloc_aux out r1234 q1234 scalar1 scalar2 p1 p2;
+  pop_frame ()
+
+
+val point_mul_g_double_split_lambda_vartime:
+  out:point -> scalar1:qelem -> scalar2:qelem -> p2:point ->
+  Stack unit
+  (requires fun h ->
+    live h out /\ live h scalar1 /\ live h scalar2 /\ live h p2 /\
+    disjoint p2 out /\ disjoint out scalar1 /\ disjoint out scalar2 /\
+    point_inv h p2 /\ qas_nat h scalar1 < S.q /\ qas_nat h scalar2 < S.q)
+  (ensures fun h0 _ h1 -> modifies (loc out) h0 h1 /\
+    point_inv h1 out /\
+    S.to_aff_point (point_eval h1 out) ==
+    S.to_aff_point (S.point_mul_double_g
+      (qas_nat h0 scalar1) (qas_nat h0 scalar2) (point_eval h0 p2)))
+
+[@CInline]
+let point_mul_g_double_split_lambda_vartime out scalar1 scalar2 p2 =
+  let h0 = ST.get () in
+  SE.exp_double_fw_lemma S.mk_k256_concrete_ops S.g 256
+    (qas_nat h0 scalar1) (point_eval h0 p2) (qas_nat h0 scalar2) 5;
+  LE.exp_double_fw_lemma S.mk_k256_comm_monoid
+    (S.to_aff_point S.g) 256 (qas_nat h0 scalar1)
+    (S.to_aff_point (point_eval h0 p2)) (qas_nat h0 scalar2) 5;
+  push_frame ();
+  let g = create 15ul (u64 0) in
+  make_g g;
+  point_mul_double_split_lambda_vartime out scalar1 g scalar2 p2;
+  pop_frame ()

--- a/code/k256/Hacl.Impl.K256.GLV.fsti
+++ b/code/k256/Hacl.Impl.K256.GLV.fsti
@@ -1,0 +1,29 @@
+module Hacl.Impl.K256.GLV
+
+open FStar.HyperStack
+open FStar.HyperStack.ST
+open FStar.Mul
+
+open Lib.IntTypes
+open Lib.Buffer
+
+module S = Spec.K256
+
+open Hacl.K256.Field
+open Hacl.K256.Scalar
+open Hacl.Impl.K256.Point
+
+#set-options "--z3rlimit 50 --fuel 0 --ifuel 0"
+
+val point_mul_g_double_split_lambda_vartime:
+  out:point -> scalar1:qelem -> scalar2:qelem -> p2:point ->
+  Stack unit
+  (requires fun h ->
+    live h out /\ live h scalar1 /\ live h scalar2 /\ live h p2 /\
+    disjoint p2 out /\ disjoint out scalar1 /\ disjoint out scalar2 /\
+    point_inv h p2 /\ qas_nat h scalar1 < S.q /\ qas_nat h scalar2 < S.q)
+  (ensures fun h0 _ h1 -> modifies (loc out) h0 h1 /\
+    point_inv h1 out /\
+    S.to_aff_point (point_eval h1 out) ==
+    S.to_aff_point (S.point_mul_double_g
+      (qas_nat h0 scalar1) (qas_nat h0 scalar2) (point_eval h0 p2)))

--- a/code/k256/Hacl.Impl.K256.Point.fst
+++ b/code/k256/Hacl.Impl.K256.Point.fst
@@ -63,6 +63,16 @@ let make_g g =
   set_one gz
 
 
+let copy_point out p =
+  let px, py, pz = getx p, gety p, getz p in
+  let ox, oy, oz = getx out, gety out, getz out in
+  copy_felem ox px;
+  copy_felem oy py;
+  copy_felem oz pz
+
+
+///  Conversion functions between affine and projective coordinates
+
 let to_proj_point p x y =
   let x1, y1, z1 = getx p, gety p, getz p in
   copy x1 x;

--- a/code/k256/Hacl.Impl.K256.Point.fst
+++ b/code/k256/Hacl.Impl.K256.Point.fst
@@ -194,6 +194,11 @@ let point_negate out p =
   assert (feval h2 oy == (- feval h0 py) % S.prime)
 
 
+[@CInline]
+let point_negate_conditional_vartime p is_negate =
+  if is_negate then point_negate p p
+
+
 val fmul_fmul_eq_vartime (a bz c dz: felem) : Stack bool
   (requires fun h ->
     live h a /\ live h bz /\ live h c /\ live h dz /\

--- a/code/k256/Hacl.Impl.K256.Point.fsti
+++ b/code/k256/Hacl.Impl.K256.Point.fsti
@@ -93,6 +93,17 @@ val make_g: g:point -> Stack unit
   (ensures  fun h0 _ h1 -> modifies (loc g) h0 h1 /\
     point_inv h1 g /\ point_eval h1 g == S.g)
 
+
+inline_for_extraction noextract
+val copy_point (out p:point) : Stack unit
+  (requires fun h ->
+    live h out /\ live h p /\ eq_or_disjoint out p /\
+    point_inv h p)
+  (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
+    point_inv h1 out /\
+    point_eval h1 out == point_eval h0 p)
+
+
 ///  Conversion functions between affine and projective coordinates
 
 inline_for_extraction noextract

--- a/code/k256/Hacl.Impl.K256.Point.fsti
+++ b/code/k256/Hacl.Impl.K256.Point.fsti
@@ -150,6 +150,14 @@ val point_negate (out p:point) : Stack unit
     point_inv h1 out /\ point_eval h1 out == S.point_negate (point_eval h0 p))
 
 
+val point_negate_conditional_vartime: p:point -> is_negate:bool -> Stack unit
+  (requires fun h -> live h p /\ point_inv h p)
+  (ensures  fun h0 _ h1 -> modifies (loc p) h0 h1 /\
+    point_inv h1 p /\
+    point_eval h1 p ==
+      (if is_negate then S.point_negate (point_eval h0 p) else point_eval h0 p))
+
+
 val point_eq (p q:point) : Stack bool
   (requires fun h ->
     live h p /\ live h q /\ eq_or_disjoint p q /\

--- a/code/k256/Hacl.Impl.K256.Verify.fst
+++ b/code/k256/Hacl.Impl.K256.Verify.fst
@@ -15,6 +15,7 @@ module KL = Spec.K256.Lemmas
 open Hacl.K256.Field
 open Hacl.Impl.K256.Point
 open Hacl.Impl.K256.PointMul
+open Hacl.Impl.K256.GLV
 
 module QA = Hacl.K256.Scalar
 module QI = Hacl.Impl.K256.Qinv
@@ -68,7 +69,8 @@ let ecdsa_verify_qelem res p z r s =
   QI.qinv sinv s;
   QA.qmul u1 z sinv;
   QA.qmul u2 r sinv;
-  point_mul_g_double_vartime res u1 u2 p;
+  //point_mul_g_double_vartime res u1 u2 p;
+  point_mul_g_double_split_lambda_vartime res u1 u2 p;
   pop_frame ()
 
 

--- a/code/k256/Hacl.K256.Scalar.fst
+++ b/code/k256/Hacl.K256.Scalar.fst
@@ -345,6 +345,18 @@ let is_qelem_le_q_halved_vartime f =
   is_qelem_le_q_halved_vartime4 (a0,a1,a2,a3)
 
 
+let is_qelem_lt_pow2_128_vartime f =
+  let open Lib.RawIntTypes in
+  let h0 = ST.get () in
+  KL.qas_nat4_is_qas_nat (as_seq h0 f);
+  let f0 = Ghost.hide (LSeq.index (as_seq h0 f) 0) in
+  let f1 = Ghost.hide (LSeq.index (as_seq h0 f) 1) in
+  let f2 = f.(2ul) in
+  let f3 = f.(3ul) in
+  KL.is_qelem_lt_pow2_128_vartime4_lemma (Ghost.reveal f0, Ghost.reveal f1,f2,f3);
+  u64_to_UInt64 f2 =. 0uL && u64_to_UInt64 f3 =. 0uL
+
+
 inline_for_extraction noextract
 val rshift_update_sub: res:qelem -> l:lbuffer uint64 8ul -> Stack unit
   (requires fun h -> live h res /\ live h l /\ disjoint res l /\

--- a/code/k256/Hacl.K256.Scalar.fsti
+++ b/code/k256/Hacl.K256.Scalar.fsti
@@ -10,7 +10,9 @@ open Lib.Buffer
 module ST = FStar.HyperStack.ST
 module LSeq = Lib.Sequence
 module BSeq = Lib.ByteSequence
+
 module S = Spec.K256
+module SG = Hacl.Spec.K256.GLV
 
 module BD = Hacl.Bignum.Definitions
 
@@ -164,3 +166,13 @@ val is_qelem_le_q_halved_vartime: f:qelem -> Stack bool
   (requires fun h -> live h f)
   (ensures  fun h0 b h1 -> modifies0 h0 h1 /\
     b == (qas_nat h0 f <= S.q / 2))
+
+
+val qmul_shift_384 (res a b: qelem) : Stack unit
+  (requires fun h ->
+    live h a /\ live h b /\ live h res /\
+    eq_or_disjoint a b /\ eq_or_disjoint a res /\ eq_or_disjoint b res /\
+    qas_nat h a < S.q /\ qas_nat h b < S.q)
+  (ensures  fun h0 _ h1 -> modifies (loc res) h0 h1 /\
+    qas_nat h1 res < S.q /\
+    qas_nat h1 res == SG.qmul_shift_384 (qas_nat h0 a) (qas_nat h0 b))

--- a/code/k256/Hacl.K256.Scalar.fsti
+++ b/code/k256/Hacl.K256.Scalar.fsti
@@ -168,6 +168,13 @@ val is_qelem_le_q_halved_vartime: f:qelem -> Stack bool
     b == (qas_nat h0 f <= S.q / 2))
 
 
+inline_for_extraction noextract
+val is_qelem_lt_pow2_128_vartime: f:qelem -> Stack bool
+  (requires fun h -> live h f)
+  (ensures  fun h0 b h1 -> modifies0 h0 h1 /\
+    b == (qas_nat h0 f < pow2 128))
+
+
 val qmul_shift_384 (res a b: qelem) : Stack unit
   (requires fun h ->
     live h a /\ live h b /\ live h res /\

--- a/code/k256/Hacl.Spec.K256.ECSM.Lemmas.fst
+++ b/code/k256/Hacl.Spec.K256.ECSM.Lemmas.fst
@@ -1,0 +1,74 @@
+module Hacl.Spec.K256.ECSM.Lemmas
+
+open FStar.Mul
+
+module M = Lib.NatMod
+module LE = Lib.Exponentiation
+module SE = Spec.Exponentiation
+
+module S = Spec.K256
+module LS = Spec.K256.Lemmas
+
+#set-options "--z3rlimit 50 --fuel 0 --ifuel 0"
+
+// [a]P in affine coordinates
+let aff_point_mul = S.aff_point_mul
+
+// [a]P in affine coordinates
+let aff_point_mul_neg (a:int) (p:S.aff_point) : S.aff_point =
+  LE.pow_neg S.mk_k256_abelian_group p a
+
+
+assume
+val lemma_order_of_curve_group (p:S.aff_point) :
+  Lemma (aff_point_mul S.q p == S.aff_point_at_inf)
+
+(**
+   Properties for Elliptic Curve Scalar Multiplication in affine coordinates
+*)
+
+val lemma_aff_point_mul_neg_add (a b:int) (p:S.aff_point) :
+  Lemma (aff_point_mul_neg (a + b) p ==
+    S.aff_point_add (aff_point_mul_neg a p) (aff_point_mul_neg b p))
+
+let lemma_aff_point_mul_neg_add a b p =
+  LE.lemma_pow_neg_add S.mk_k256_abelian_group p a b
+
+
+val lemma_aff_point_mul_neg_mul (a b:int) (p:S.aff_point) :
+  Lemma (aff_point_mul_neg (a * b) p == aff_point_mul_neg b (aff_point_mul_neg a p))
+
+let lemma_aff_point_mul_neg_mul a b p =
+  LE.lemma_pow_neg_mul S.mk_k256_abelian_group p a b
+
+
+val lemma_aff_point_mul_neg_mul_add (a b c:int) (p:S.aff_point) :
+  Lemma (aff_point_mul_neg (a * b + c) p ==
+    S.aff_point_add (aff_point_mul_neg b (aff_point_mul_neg a p)) (aff_point_mul_neg c p))
+
+let lemma_aff_point_mul_neg_mul_add a b c p =
+  lemma_aff_point_mul_neg_add (a * b) c p;
+  lemma_aff_point_mul_neg_mul a b p
+
+
+val lemma_aff_point_mul_neg_modq (a:int) (p:S.aff_point) :
+  Lemma (aff_point_mul_neg a p == aff_point_mul (a % S.q) p)
+
+let lemma_aff_point_mul_neg_modq a p =
+  calc (==) {
+    aff_point_mul_neg a p;
+    (==) { Math.Lemmas.euclidean_division_definition a S.q }
+    aff_point_mul_neg (a / S.q * S.q + a % S.q) p;
+    (==) { lemma_aff_point_mul_neg_add (a / S.q * S.q) (a % S.q) p }
+    S.aff_point_add (aff_point_mul_neg (a / S.q * S.q) p) (aff_point_mul_neg (a % S.q) p);
+    (==) { lemma_aff_point_mul_neg_mul (a / S.q) S.q p }
+    S.aff_point_add
+      (aff_point_mul S.q (aff_point_mul_neg (a / S.q) p))
+      (aff_point_mul (a % S.q) p);
+    (==) { lemma_order_of_curve_group (aff_point_mul_neg (a / S.q) p) }
+    S.aff_point_add S.aff_point_at_inf (aff_point_mul (a % S.q) p);
+    (==) { LS.aff_point_add_comm_lemma S.aff_point_at_inf (aff_point_mul (a % S.q) p) }
+    S.aff_point_add (aff_point_mul (a % S.q) p) S.aff_point_at_inf;
+    (==) { LS.aff_point_at_inf_lemma (aff_point_mul (a % S.q) p) }
+    aff_point_mul (a % S.q) p;
+  }

--- a/code/k256/Hacl.Spec.K256.ECSM.Lemmas.fst
+++ b/code/k256/Hacl.Spec.K256.ECSM.Lemmas.fst
@@ -11,10 +11,10 @@ module LS = Spec.K256.Lemmas
 
 #set-options "--z3rlimit 50 --fuel 0 --ifuel 0"
 
-// [a]P in affine coordinates
+// [a]P in affine coordinates for a >= 0
 let aff_point_mul = S.aff_point_mul
 
-// [a]P in affine coordinates
+// [a]P in affine coordinates for any a
 let aff_point_mul_neg (a:int) (p:S.aff_point) : S.aff_point =
   LE.pow_neg S.mk_k256_abelian_group p a
 
@@ -27,6 +27,7 @@ val lemma_order_of_curve_group (p:S.aff_point) :
    Properties for Elliptic Curve Scalar Multiplication in affine coordinates
 *)
 
+// [a + b]P = [a]P + [b]P
 val lemma_aff_point_mul_neg_add (a b:int) (p:S.aff_point) :
   Lemma (aff_point_mul_neg (a + b) p ==
     S.aff_point_add (aff_point_mul_neg a p) (aff_point_mul_neg b p))
@@ -35,6 +36,7 @@ let lemma_aff_point_mul_neg_add a b p =
   LE.lemma_pow_neg_add S.mk_k256_abelian_group p a b
 
 
+// [a * b]P = [b]([a]P)
 val lemma_aff_point_mul_neg_mul (a b:int) (p:S.aff_point) :
   Lemma (aff_point_mul_neg (a * b) p == aff_point_mul_neg b (aff_point_mul_neg a p))
 
@@ -42,6 +44,7 @@ let lemma_aff_point_mul_neg_mul a b p =
   LE.lemma_pow_neg_mul S.mk_k256_abelian_group p a b
 
 
+// [a * b + c]P = [b]([a]P) + [c]P
 val lemma_aff_point_mul_neg_mul_add (a b c:int) (p:S.aff_point) :
   Lemma (aff_point_mul_neg (a * b + c) p ==
     S.aff_point_add (aff_point_mul_neg b (aff_point_mul_neg a p)) (aff_point_mul_neg c p))
@@ -51,6 +54,7 @@ let lemma_aff_point_mul_neg_mul_add a b c p =
   lemma_aff_point_mul_neg_mul a b p
 
 
+// [a]P = [a % S.q]P
 val lemma_aff_point_mul_neg_modq (a:int) (p:S.aff_point) :
   Lemma (aff_point_mul_neg a p == aff_point_mul (a % S.q) p)
 
@@ -71,4 +75,71 @@ let lemma_aff_point_mul_neg_modq a p =
     S.aff_point_add (aff_point_mul (a % S.q) p) S.aff_point_at_inf;
     (==) { LS.aff_point_at_inf_lemma (aff_point_mul (a % S.q) p) }
     aff_point_mul (a % S.q) p;
+  }
+
+
+// [a]P = [(-a) % q](-P)
+val lemma_aff_point_mul_neg: a:S.qelem -> p:S.aff_point ->
+  Lemma (aff_point_mul ((- a) % S.q) (S.aff_point_negate p) == aff_point_mul a p)
+
+let lemma_aff_point_mul_neg a p =
+  let cm = S.mk_k256_comm_monoid in
+  let ag = S.mk_k256_abelian_group in
+  let p_neg = S.aff_point_negate p in
+  if a > 0 then begin
+    calc (==) {
+      aff_point_mul ((- a) % S.q) p_neg;
+      (==) { lemma_aff_point_mul_neg_modq (- a) p_neg }
+      aff_point_mul_neg (- a) p_neg;
+      (==) { }
+      S.aff_point_negate (aff_point_mul a p_neg);
+      (==) { LE.lemma_inverse_pow ag p a }
+      S.aff_point_negate (S.aff_point_negate (aff_point_mul a p));
+      (==) { LE.lemma_inverse_id ag (aff_point_mul a p) }
+      aff_point_mul a p;
+    } end
+  else begin
+    LE.lemma_pow0 cm p;
+    LE.lemma_pow0 cm p_neg end
+
+//--------------------------------------------
+
+// [a]([b]P) = [b]([a]P)
+val aff_point_mul_mul_lemma: a:nat -> b:nat -> p:S.aff_point ->
+  Lemma (aff_point_mul a (aff_point_mul b p) == aff_point_mul b (aff_point_mul a p))
+
+let aff_point_mul_mul_lemma a b p =
+  calc (==) {
+    aff_point_mul a (aff_point_mul b p);
+    (==) { LE.lemma_pow_mul S.mk_k256_comm_monoid p b a }
+    aff_point_mul (a * b) p;
+    (==) { LE.lemma_pow_mul S.mk_k256_comm_monoid p a b }
+    aff_point_mul b (aff_point_mul a p);
+  }
+
+
+// -[a]P = [a](-P)
+val aff_point_mul_neg_lemma: a:nat -> p:S.aff_point ->
+  Lemma (S.aff_point_negate (aff_point_mul a p) == aff_point_mul a (S.aff_point_negate p))
+
+let aff_point_mul_neg_lemma a p =
+  LE.lemma_inverse_pow S.mk_k256_abelian_group p a
+
+
+// [a](-[b]P) = [b](-[a]P)
+val aff_point_mul_mul_neg_lemma: a:nat -> b:nat -> p:S.aff_point ->
+  Lemma (aff_point_mul a (S.aff_point_negate (aff_point_mul b p)) ==
+    aff_point_mul b (S.aff_point_negate (aff_point_mul a p)))
+
+let aff_point_mul_mul_neg_lemma a b p =
+  let p_neg = S.aff_point_negate p in
+
+  calc (==) {
+    aff_point_mul a (S.aff_point_negate (aff_point_mul b p));
+    (==) { aff_point_mul_neg_lemma b p }
+    aff_point_mul a (aff_point_mul b p_neg);
+    (==) { aff_point_mul_mul_lemma a b p_neg }
+    aff_point_mul b (aff_point_mul a p_neg);
+    (==) { aff_point_mul_neg_lemma a p }
+    aff_point_mul b (S.aff_point_negate (aff_point_mul a p));
   }

--- a/code/k256/Hacl.Spec.K256.GLV.Lemmas.fst
+++ b/code/k256/Hacl.Spec.K256.GLV.Lemmas.fst
@@ -1,0 +1,570 @@
+module Hacl.Spec.K256.GLV.Lemmas
+
+open FStar.Mul
+
+module M = Lib.NatMod
+module LE = Lib.Exponentiation
+module SE = Spec.Exponentiation
+
+module S = Spec.K256
+module LS = Spec.K256.Lemmas
+module SM = Hacl.Spec.K256.ECSM.Lemmas
+
+open Hacl.Spec.K256.GLV
+
+#set-options "--z3rlimit 50 --fuel 0 --ifuel 0"
+
+// val lambda_is_primitive_cube_root_unity: unit -> Lemma
+//   (lambda <> 1 /\
+//   S.(lambda *^ lambda *^ lambda = 1) /\
+//   S.(lambda *^ lambda +^ lambda +^ 1 = 0))
+
+// let lambda_is_primitive_cube_root_unity () =
+//   assert (lambda <> 1);
+//   assert (S.(lambda *^ lambda *^ lambda = 1));
+//   assert (S.(lambda *^ lambda +^ lambda +^ 1 = 0))
+
+
+// val beta_is_primitive_cube_root_unity: unit -> Lemma
+//   (beta <> 1 /\
+//    S.(beta *% beta *% beta = 1) /\
+//    S.(beta *% beta +% beta +% 1 = 0))
+
+// let beta_is_primitive_cube_root_unity () =
+//   assert (beta <> 1);
+//   assert (S.(beta *% beta *% beta = 1));
+//   assert (S.(beta *% beta +% beta +% 1 = 0))
+
+//--------------------------------------------
+
+assume
+val lemma_glv_aff : p:S.aff_point -> Lemma (aff_point_mul lambda p == aff_point_mul_lambda p)
+
+val lemma_glv_g_aff : unit -> Lemma (aff_point_mul_g lambda == aff_point_mul_g_lambda ())
+let lemma_glv_g_aff () = lemma_glv_aff S.(g_x, g_y)
+// or, we can prove it by assert_norm
+
+
+val lemma_glv : p:S.proj_point ->
+  Lemma (S.to_aff_point (point_mul_lambda p) == aff_point_mul lambda (S.to_aff_point p))
+
+let lemma_glv p =
+  let (pX, pY, pZ) = p in
+  let (px, py) = S.to_aff_point p in
+  assert (px = S.(pX /% pZ) /\ py = S.(pY /% pZ));
+  let (qx, qy) = aff_point_mul lambda (px, py) in
+  lemma_glv_aff (px, py);
+  assert (qx = S.(beta *% px) /\ qy = py);
+  assert (qx = S.(beta *% (pX /% pZ)) /\ qy = S.(pY /% pZ));
+
+  let (rX, rY, rZ) = point_mul_lambda p in
+  assert (rX = S.(beta *% pX) /\ rY = pY /\ rZ = pZ);
+  let (rx, ry) = S.to_aff_point (rX, rY, rZ) in
+  assert (rx = S.(rX /% rZ) /\ ry = S.(rY /% rZ));
+  assert (rx = S.(beta *% pX /% pZ) /\ ry = S.(pY /% pZ));
+  assert (qy = ry);
+  // S.(beta *% pX /% rZ) = S.(beta *% (pX /% pZ))
+  assert (S.(beta *% pX /% pZ) = S.(beta *% pX *% S.finv pZ));
+  assert (S.(beta *% (pX /% pZ)) = S.(beta *% (pX *% S.finv pZ)));
+  M.lemma_mul_mod_assoc #S.prime beta pX (S.finv pZ);
+  assert (S.(beta *% pX *% S.finv pZ) = S.(beta *% (pX *% S.finv pZ)))
+
+
+// val lemma_glv_g : unit ->
+//   Lemma (S.to_aff_point (point_mul_g_lambda ()) == aff_point_mul_g lambda)
+
+// let lemma_glv_g () =
+//   SM.lemma_proj_aff_id (S.(beta *% S.g_x), S.g_y);
+//   lemma_glv_aff S.(g_x, g_y)
+
+//--------------------------------------------
+
+// val lemma_check_a_and_b : unit -> Lemma
+//   ((a1 + minus_b1 * minus_lambda) % S.q = 0 /\
+//    (a1 + b1 * lambda) % S.q = 0 /\
+//    (a2 + b2 * lambda) % S.q = 0 /\
+//     a1 * b2 + minus_b1 * a2 = S.q)
+
+// let lemma_check_a_and_b () =
+//   assert (a1 * b2 + minus_b1 * a2 = S.q)
+
+// // a1 = b2
+// val lemma_a_and_b_fits: unit -> Lemma
+//   (minus_b1 < pow2 128 /\
+//    minus_b2 < pow2 256 /\
+//    b1 < pow2 256 /\
+//    b2 < pow2 126 /\
+//    a2 < pow2 129)
+
+// let lemma_a_and_b_fits () =
+//   assert (minus_b1 < pow2 128);
+//   assert (minus_b2 < pow2 256);
+//   assert_norm (b2 < pow2 126);
+//   assert_norm (a2 < pow2 129);
+//   assert_norm ((a1 + a2) / 2 < pow2 128)
+
+//--------------------------------------------
+
+val lemma_scalar_split_lambda_eval (k:S.qelem) :
+  Lemma (let r1, r2 = scalar_split_lambda k in k == S.(r1 +^ r2 *^ lambda))
+
+let lemma_scalar_split_lambda_eval k =
+  assert_norm ((minus_lambda + lambda) % S.q = 0);
+
+  let r1, r2 = scalar_split_lambda k in
+  assert (r1 = S.(k +^ r2 *^ minus_lambda));
+  calc (==) {
+    (r1 + (r2 * lambda % S.q)) % S.q;
+    (==) { Math.Lemmas.lemma_mod_plus_distr_r r1 (r2 * lambda) S.q }
+    (r1 + r2 * lambda) % S.q;
+    (==) { }
+    ((k + (r2 * minus_lambda % S.q)) % S.q + r2 * lambda) % S.q;
+    (==) { Math.Lemmas.lemma_mod_plus_distr_r k (r2 * minus_lambda) S.q }
+    ((k + r2 * minus_lambda) % S.q + r2 * lambda) % S.q;
+    (==) { Math.Lemmas.lemma_mod_plus_distr_l (k + r2 * minus_lambda) (r2 * lambda) S.q }
+    (k + r2 * minus_lambda + r2 * lambda) % S.q;
+    (==) { Math.Lemmas.distributivity_add_right r2 minus_lambda lambda }
+    (k + r2 * (minus_lambda + lambda)) % S.q;
+    (==) { Math.Lemmas.lemma_mod_plus_distr_r k (r2 * (minus_lambda + lambda)) S.q }
+    (k + (r2 * (minus_lambda + lambda) % S.q)) % S.q;
+    (==) { Math.Lemmas.lemma_mod_mul_distr_r r2 (minus_lambda + lambda) S.q }
+    (k + (r2 * ((minus_lambda + lambda) % S.q) % S.q)) % S.q;
+    (==) { }
+    k % S.q;
+    (==) { Math.Lemmas.small_mod k S.q }
+    k;
+  }
+
+
+val lemma_mod_add_mul_zero (a b c d e:int) (n:pos) : Lemma
+  (requires (c * d + e) % n == 0)
+  (ensures  (a + b * c * d) % n == (a - e * b) % n)
+
+let lemma_mod_add_mul_zero a b c d e n =
+  calc (==) {
+    (a + b * c * d) % n;
+    (==) { assert ((c * d + e) % n * b % n = 0) }
+    (a + b * c * d - ((c * d + e) % n) * b % n) % n;
+    (==) { Math.Lemmas.lemma_mod_mul_distr_l (c * d + e) b n }
+    (a + b * c * d - (c * d + e) * b % n) % n;
+    (==) { Math.Lemmas.lemma_mod_sub_distr (a + b * c * d) ((c * d + e) * b) n }
+    (a + b * c * d - (c * d + e) * b) % n;
+    (==) { Math.Lemmas.distributivity_add_left (c * d) e b }
+    (a + b * c * d - (c * d * b + e * b)) % n;
+    (==) { Math.Lemmas.paren_mul_right b c d; Math.Lemmas.swap_mul b (c * d) }
+    (a + c * d * b - (c * d * b + e * b)) % n;
+    (==) { }
+    (a - e * b) % n;
+  }
+
+
+val lemma_scalar_split_lambda_r1_and_r2 (k:S.qelem) :
+  Lemma (let r1, r2 = scalar_split_lambda k in
+    let c1 = qmul_shift_384 k g1 in
+    let c2 = qmul_shift_384 k g2 in
+    let k1 = k - a1 * c1 - a2 * c2 in
+    let k2 = c1 * minus_b1 + c2 * minus_b2 in // or: k2 = - b1 * c1 - b2 * c2
+    r1 == k1 % S.q /\ r2 == k2 % S.q)
+
+let lemma_scalar_split_lambda_r1_and_r2 k =
+  qmul_shift_384_lemma k g1;
+  qmul_shift_384_lemma k g2;
+  let c1 : S.qelem = qmul_shift_384 k g1 in
+  let c2 : S.qelem = qmul_shift_384 k g2 in
+
+  let r1, r2 = scalar_split_lambda k in
+  assert (r2 = S.(c1 *^ minus_b1 +^ c2 *^ minus_b2));
+  assert (r1 = S.(k +^ r2 *^ minus_lambda));
+
+  // let k2 = - c1 * b1 - c2 * b2 in
+  // calc (==) { // r2
+  //   S.(c1 *^ minus_b1 +^ c2 *^ minus_b2);
+  //   (==) { assert_norm (minus_b1 = (-b1) % S.q) }
+  //   S.(c1 *^ ((-b1) % S.q) +^ c2 *^ minus_b2);
+  //   (==) { assert_norm (minus_b2 = (-b2) % S.q) }
+  //   S.(c1 *^ ((-b1) % S.q) +^ c2 *^ ((-b2) % S.q));
+  //   (==) { }
+  //   ((c1 * ((-b1) % S.q) % S.q) + (c2 * ((-b2) % S.q) % S.q)) % S.q;
+  //   (==) { Math.Lemmas.lemma_mod_mul_distr_r c1 (-b1) S.q }
+  //   ((c1 * (-b1) % S.q) + (c2 * ((-b2) % S.q) % S.q)) % S.q;
+  //   (==) { Math.Lemmas.lemma_mod_mul_distr_r c2 (-b2) S.q }
+  //   ((c1 * (-b1) % S.q) + (c2 * (-b2) % S.q)) % S.q;
+  //   (==) { Math.Lemmas.lemma_mod_plus_distr_l (c1 * (-b1)) (c2 * (-b2) % S.q) S.q }
+  //   (c1 * (-b1) + (c2 * (-b2) % S.q)) % S.q;
+  //   (==) { Math.Lemmas.lemma_mod_plus_distr_r (c1 * (-b1)) (c2 * (-b2)) S.q }
+  //   (c1 * (-b1) + c2 * (-b2)) % S.q;
+  //   (==) { Math.Lemmas.neg_mul_right c1 b1 }
+  //   (- c1 * b1 + c2 * (-b2)) % S.q;
+  //   (==) { Math.Lemmas.neg_mul_right c2 b2 }
+  //   (- c1 * b1 - c2 * b2) % S.q;
+  //   (==) { }
+  //   k2 % S.q;
+  //   };
+
+  // let k1 = k - a1 * c1 - a2 * c2 in
+  // calc (==) { // r1
+  //   S.(k +^ r2 *^ minus_lambda);
+  //   (==) { }
+  //   (k + ((k2 % S.q) * minus_lambda % S.q)) % S.q;
+  //   (==) { Math.Lemmas.lemma_mod_mul_distr_l k2 minus_lambda S.q }
+  //   (k + (k2 * minus_lambda % S.q)) % S.q;
+  //   (==) { assert_norm (minus_lambda = (- lambda) % S.q) }
+  //   (k + (k2 * ((- lambda) % S.q) % S.q)) % S.q;
+  //   (==) { Math.Lemmas.lemma_mod_mul_distr_r k2 (- lambda) S.q }
+  //   (k + (k2 * (- lambda) % S.q)) % S.q;
+  //   (==) { Math.Lemmas.lemma_mod_plus_distr_r k (k2 * (- lambda)) S.q }
+  //   (k + k2 * (- lambda)) % S.q;
+  //   (==) { Math.Lemmas.neg_mul_right k2 lambda }
+  //   (k - k2 * lambda) % S.q;
+  //   (==) { }
+  //   (k - (- c1 * b1 - c2 * b2) * lambda) % S.q;
+  //   (==) { Math.Lemmas.neg_mul_left (c1 * b1 + c2 * b2) lambda }
+  //   (k + (c1 * b1 + c2 * b2) * lambda) % S.q;
+  //   (==) { Math.Lemmas.distributivity_add_left (c1 * b1) (c2 * b2) lambda }
+  //   (k + c1 * b1 * lambda + c2 * b2 * lambda) % S.q;
+  //   (==) {
+  //     assert_norm ((b1 * lambda + a1) % S.q = 0);
+  //     lemma_mod_add_mul_zero (k + c2 * b2 * lambda) c1 b1 lambda a1 S.q }
+  //   (k + c2 * b2 * lambda - a1 * c1) % S.q;
+  //   (==) {
+  //     assert_norm ((b2 * lambda + a2) % S.q = 0);
+  //     lemma_mod_add_mul_zero (k - a1 * c1) c2 b2 lambda a2 S.q }
+  //   (k - a1 * c1 - a2 * c2) % S.q;
+  //   (==) { }
+  //   k1 % S.q;
+  // };
+
+  let k2 = c1 * minus_b1 + c2 * minus_b2 in
+  calc (==) { // r2
+    S.(c1 *^ minus_b1 +^ c2 *^ minus_b2);
+    (==) { }
+    ((c1 * minus_b1 % S.q) + (c2 * minus_b2 % S.q)) % S.q;
+    (==) { Math.Lemmas.lemma_mod_plus_distr_l (c1 * minus_b1) (c2 * minus_b2 % S.q) S.q }
+    (c1 * minus_b1 + (c2 * minus_b2 % S.q)) % S.q;
+    (==) { Math.Lemmas.lemma_mod_plus_distr_r (c1 * minus_b1) (c2 * minus_b2) S.q }
+    (c1 * minus_b1 + c2 * minus_b2) % S.q;
+    (==) { }
+    k2 % S.q;
+  };
+
+  let k1 = k - a1 * c1 - a2 * c2 in
+  calc (==) { // r1
+    S.(k +^ r2 *^ minus_lambda);
+    (==) { }
+    (k + ((k2 % S.q) * minus_lambda % S.q)) % S.q;
+    (==) { Math.Lemmas.lemma_mod_mul_distr_l k2 minus_lambda S.q }
+    (k + (k2 * minus_lambda % S.q)) % S.q;
+    (==) { Math.Lemmas.lemma_mod_plus_distr_r k (k2 * minus_lambda) S.q }
+    (k + (c1 * minus_b1 + c2 * minus_b2) * minus_lambda) % S.q;
+    (==) { Math.Lemmas.distributivity_add_left (c1 * minus_b1) (c2 * minus_b2) minus_lambda }
+    (k + c1 * minus_b1 * minus_lambda + c2 * minus_b2 * minus_lambda) % S.q;
+    (==) {
+      assert_norm ((minus_b1 * minus_lambda + a1) % S.q = 0);
+      lemma_mod_add_mul_zero (k + c2 * minus_b2 * minus_lambda) c1 minus_b1 minus_lambda a1 S.q }
+    (k + c2 * minus_b2 * minus_lambda - a1 * c1) % S.q;
+    (==) {
+      assert_norm ((minus_b2 * minus_lambda + a2) % S.q = 0);
+      lemma_mod_add_mul_zero (k - a1 * c1) c2 minus_b2 minus_lambda a2 S.q }
+    (k - a1 * c1 - a2 * c2) % S.q;
+    (==) { }
+    k1 % S.q;
+  }
+
+
+// val lemma_ecmult_endo_split: k:S.qelem -> p:S.proj_point ->
+//   Lemma (let r1, p1, r2, p2 = ecmult_endo_split k p in
+//     let lambda_p = point_mul_lambda p in
+//     let r1_0, r2_0 = scalar_split_lambda k in
+//     let is_high1 = S.scalar_is_high r1_0 in
+//     let is_high2 = S.scalar_is_high r2_0 in
+//     p1 == (if is_high1 then S.point_negate p else p) /\
+//     p2 == (if is_high2 then S.point_negate lambda_p else lambda_p))
+
+// let lemma_ecmult_endo_split k p = ()
+
+
+// TODO: prove that r1 and r2 are ~128 bits long
+assume
+val lemma_scalar_split_lambda_fits (k:S.qelem) (p:S.proj_point) :
+  Lemma (let r1, p1, r2, p2 = ecmult_endo_split k p in
+    r1 < pow2 128 /\ r2 < pow2 128)
+
+(**
+ Fast computation of [k]P in affine coordinates
+*)
+
+val lemma_aff_point_mul_split_lambda: k:S.qelem -> p:S.aff_point ->
+  Lemma (let r1, r2 = scalar_split_lambda k in aff_point_mul k p ==
+    S.aff_point_add (aff_point_mul r1 p) (aff_point_mul r2 (aff_point_mul_lambda p)))
+
+let lemma_aff_point_mul_split_lambda k p =
+  let r1, r2 = scalar_split_lambda k in
+  calc (==) {
+    aff_point_mul k p;
+    (==) { lemma_scalar_split_lambda_eval k }
+    aff_point_mul S.(r1 +^ r2 *^ lambda) p;
+    (==) { Math.Lemmas.lemma_mod_plus_distr_r r1 (r2 * lambda) S.q }
+    aff_point_mul ((r1 + r2 * lambda) % S.q) p;
+    (==) { SM.lemma_aff_point_mul_neg_modq (r1 + r2 * lambda) p }
+    aff_point_mul (r1 + r2 * lambda) p;
+    (==) { SM.lemma_aff_point_mul_neg_mul_add lambda r2 r1 p }
+    S.aff_point_add (aff_point_mul r2 (aff_point_mul lambda p)) (aff_point_mul r1 p);
+    (==) { lemma_glv_aff p }
+    S.aff_point_add (aff_point_mul r2 (aff_point_mul_lambda p)) (aff_point_mul r1 p);
+    (==) { LS.aff_point_add_comm_lemma (aff_point_mul r2 (aff_point_mul_lambda p)) (aff_point_mul r1 p) }
+    S.aff_point_add (aff_point_mul r1 p) (aff_point_mul r2 (aff_point_mul_lambda p));
+  }
+
+
+val lemma_aff_point_mul_neg: r:S.qelem -> p:S.aff_point ->
+  Lemma (aff_point_mul ((- r) % S.q) (S.aff_point_negate p) == aff_point_mul r p)
+
+let lemma_aff_point_mul_neg r p =
+  let cm = S.mk_k256_comm_monoid in
+  let ag = S.mk_k256_abelian_group in
+  let p_neg = S.aff_point_negate p in
+  if r > 0 then begin
+    calc (==) {
+      aff_point_mul ((- r) % S.q) p_neg;
+      (==) { SM.lemma_aff_point_mul_neg_modq (- r) p_neg }
+      SM.aff_point_mul_neg (- r) p_neg;
+      (==) { }
+      S.aff_point_negate (aff_point_mul r p_neg);
+      (==) { LE.lemma_inverse_pow ag p r }
+      S.aff_point_negate (S.aff_point_negate (aff_point_mul r p));
+      (==) { LE.lemma_inverse_id ag (aff_point_mul r p) }
+      aff_point_mul r p;
+    } end
+  else begin
+    LE.lemma_pow0 cm p;
+    LE.lemma_pow0 cm p_neg end
+
+
+// [k]P = [r1 + r2 * lambda]P = [r1]P + [r2]([lambda]P) = [r1](x,y) + [r2](beta*x,y)
+// which can be computed as a double exponentiation ([a]P + [b]Q)
+let aff_point_mul_endo_split (k:S.qelem) (p:S.aff_point) : S.aff_point =
+  let r1, p1, r2, p2 = aff_ecmult_endo_split k p in
+  S.aff_point_add (aff_point_mul r1 p1) (aff_point_mul r2 p2)
+
+val lemma_aff_point_mul_endo_split: k:S.qelem -> p:S.aff_point ->
+  Lemma (aff_point_mul_endo_split k p == aff_point_mul k p)
+
+let lemma_aff_point_mul_endo_split k p =
+  let r10, r20 = scalar_split_lambda k in
+  let lambda_p = aff_point_mul_lambda p in
+  let r1, p1 = aff_negate_point_and_scalar_cond r10 p in
+  let r2, p2 = aff_negate_point_and_scalar_cond r20 lambda_p in
+  assert ((r1, p1, r2, p2) == aff_ecmult_endo_split k p);
+  let is_high1 = S.scalar_is_high r10 in
+  let is_high2 = S.scalar_is_high r20 in
+
+  if is_high1 && is_high2 then begin
+    lemma_aff_point_mul_neg r10 p;
+    lemma_aff_point_mul_neg r20 lambda_p;
+    lemma_aff_point_mul_split_lambda k p end
+  else begin
+    if is_high1 && not is_high2 then begin
+      lemma_aff_point_mul_neg r10 p;
+      lemma_aff_point_mul_split_lambda k p end
+    else begin
+      if not is_high1 && is_high2 then begin
+      lemma_aff_point_mul_neg r20 lambda_p;
+      lemma_aff_point_mul_split_lambda k p end
+      else lemma_aff_point_mul_split_lambda k p
+    end
+  end
+
+
+(**
+ Fast computation of [k]P in projective coordinates
+*)
+
+val lemma_ecmult_endo_split_to_aff: k:S.qelem -> p:S.proj_point -> Lemma
+  (let r1, p1, r2, p2 = ecmult_endo_split k p in
+   let ar1, ap1, ar2, ap2 = aff_ecmult_endo_split k (S.to_aff_point p) in
+   r1 == ar1 /\ S.to_aff_point p1 == ap1 /\ r2 == ar2 /\ S.to_aff_point p2 == ap2)
+
+let lemma_ecmult_endo_split_to_aff k p =
+  let r1, p1, r2, p2 = ecmult_endo_split k p in
+  let ar1, ap1, ar2, ap2 = aff_ecmult_endo_split k (S.to_aff_point p) in
+  assert (r1 == ar1 /\ r2 == ar2);
+
+  let r10, r20 = scalar_split_lambda k in
+  let p_aff = S.to_aff_point p in
+
+  let lambda_p = point_mul_lambda p in
+  let lambda_p_aff = aff_point_mul_lambda p_aff in
+  lemma_glv p; lemma_glv_aff p_aff;
+  assert (S.to_aff_point lambda_p == lambda_p_aff);
+
+  let is_high1 = S.scalar_is_high r10 in
+  let is_high2 = S.scalar_is_high r20 in
+  if not is_high1 && not is_high2 then ()
+  else begin
+    if not is_high1 && is_high2 then
+      LS.to_aff_point_negate_lemma lambda_p
+    else begin
+      if is_high1 && not is_high2 then
+        LS.to_aff_point_negate_lemma p
+      else begin
+        LS.to_aff_point_negate_lemma p;
+        LS.to_aff_point_negate_lemma lambda_p
+      end
+    end
+  end
+
+
+// [k]P
+let aff_proj_point_mul_split_lambda (k:S.qelem) (p:S.proj_point) : S.aff_point =
+  let r1, p1, r2, p2 = ecmult_endo_split k p in
+  lemma_scalar_split_lambda_fits k p;
+  LE.exp_double_fw S.mk_k256_comm_monoid (S.to_aff_point p1) 128 r1 (S.to_aff_point p2) r2 4
+
+
+val lemma_aff_proj_point_mul_split_lambda: k:S.qelem -> p:S.proj_point ->
+  Lemma (aff_proj_point_mul_split_lambda k p == aff_point_mul k (S.to_aff_point p))
+
+let lemma_aff_proj_point_mul_split_lambda k p =
+  let r1, p1, r2, p2 = ecmult_endo_split k p in
+  lemma_scalar_split_lambda_fits k p;
+
+  let p_aff  = S.to_aff_point p in
+  let p1_aff = S.to_aff_point p1 in
+  let p2_aff = S.to_aff_point p2 in
+  calc (==) {
+    aff_proj_point_mul_split_lambda k p;
+    (==) { LE.exp_double_fw_lemma S.mk_k256_comm_monoid p1_aff 128 r1 p2_aff r2 4 }
+    S.aff_point_add (aff_point_mul r1 p1_aff) (aff_point_mul r2 p2_aff);
+    (==) { lemma_aff_point_mul_endo_split k p_aff; lemma_ecmult_endo_split_to_aff k p }
+    aff_point_mul k p_aff;
+  }
+
+
+(**
+  Fast computation of [k1]P1 + [k2]P2 in projective coordinates
+*)
+
+// [k1]P1 + [k2]P2 = [r11 + r12 * lambda]P1 + [r21 + r22 * lambda]P2
+// = [r11]P1 + [r12]([lambda]P1) + [r21]P2 + [r22]([lambda]P2)
+// = [r11](p1_x, p1_y) + [r12](beta * p1_x, p1_y) + [r21](p2_x, p2_y) + [r22](beta * p2_x, p2_y)
+let aff_proj_point_mul_double_split_lambda
+  (k1:S.qelem) (p1:S.proj_point) (k2:S.qelem) (p2:S.proj_point) : S.aff_point =
+  let r11, p11, r12, p12 = ecmult_endo_split k1 p1 in
+  let r21, p21, r22, p22 = ecmult_endo_split k2 p2 in
+  lemma_scalar_split_lambda_fits k1 p1;
+  lemma_scalar_split_lambda_fits k2 p2;
+  LE.exp_four_fw S.mk_k256_comm_monoid
+    (S.to_aff_point p11) 128 r11 (S.to_aff_point p12) r12
+    (S.to_aff_point p21) r21 (S.to_aff_point p22) r22 4
+
+
+val lemma_aff_proj_point_mul_double_split_lambda:
+  k1:S.qelem -> p1:S.proj_point -> k2:S.qelem -> p2:S.proj_point ->
+  Lemma (aff_proj_point_mul_double_split_lambda k1 p1 k2 p2 ==
+    S.aff_point_add (aff_point_mul k1 (S.to_aff_point p1)) (aff_point_mul k2 (S.to_aff_point p2)))
+
+let lemma_aff_proj_point_mul_double_split_lambda k1 p1 k2 p2 =
+  let r11, p11, r12, p12 = ecmult_endo_split k1 p1 in
+  let r21, p21, r22, p22 = ecmult_endo_split k2 p2 in
+  lemma_scalar_split_lambda_fits k1 p1;
+  lemma_scalar_split_lambda_fits k2 p2;
+
+  let p1_aff  = S.to_aff_point p1 in
+  let p2_aff  = S.to_aff_point p2 in
+  let p11_aff = S.to_aff_point p11 in
+  let p12_aff = S.to_aff_point p12 in
+  let p21_aff = S.to_aff_point p21 in
+  let p22_aff = S.to_aff_point p22 in
+
+  calc (==) {
+    aff_proj_point_mul_double_split_lambda k1 p1 k2 p2;
+  (==) {
+    LE.exp_four_fw_lemma S.mk_k256_comm_monoid
+      p11_aff 128 r11 p12_aff r12 p21_aff r21 p22_aff r22 4 }
+    S.aff_point_add
+      (S.aff_point_add
+        (S.aff_point_add (aff_point_mul r11 p11_aff) (aff_point_mul r12 p12_aff))
+        (aff_point_mul r21 p21_aff))
+      (aff_point_mul r22 p22_aff);
+    (==) { lemma_aff_point_mul_endo_split k1 p1_aff; lemma_ecmult_endo_split_to_aff k1 p1 }
+    S.aff_point_add
+      (S.aff_point_add (aff_point_mul k1 p1_aff) (aff_point_mul r21 p21_aff))
+      (aff_point_mul r22 p22_aff);
+    (==) { LS.aff_point_add_assoc_lemma
+      (aff_point_mul k1 p1_aff) (aff_point_mul r21 p21_aff) (aff_point_mul r22 p22_aff) }
+    S.aff_point_add (aff_point_mul k1 p1_aff)
+      (S.aff_point_add (aff_point_mul r21 p21_aff) (aff_point_mul r22 p22_aff));
+    (==) { lemma_aff_point_mul_endo_split k2 p2_aff; lemma_ecmult_endo_split_to_aff k2 p2 }
+    S.aff_point_add (aff_point_mul k1 p1_aff) (aff_point_mul k2 p2_aff);
+  }
+
+//-----------------------------------
+
+// [k]P or -[k]P = [k](-P)
+val aff_point_negate_cond_pow_lemma: is_negate:bool -> p:S.proj_point -> k:nat -> Lemma
+  (aff_point_negate_cond (S.to_aff_point (SE.pow S.mk_k256_concrete_ops p k)) is_negate ==
+   LE.pow S.mk_k256_comm_monoid (S.to_aff_point (point_negate_cond p is_negate)) k)
+
+let aff_point_negate_cond_pow_lemma is_negate p k =
+  let co = S.mk_k256_concrete_ops in
+  let cm = S.mk_k256_comm_monoid in
+  let p_aff = S.to_aff_point p in
+
+  if is_negate then
+    calc (==) {
+      S.aff_point_negate (S.to_aff_point (SE.pow co p k));
+      (==) { SE.pow_lemma co p k }
+      S.aff_point_negate (LE.pow cm p_aff k);
+      (==) { LE.lemma_inverse_pow S.mk_k256_abelian_group p_aff k }
+      LE.pow cm (S.aff_point_negate p_aff) k;
+      (==) { LS.to_aff_point_negate_lemma p }
+      LE.pow cm (S.to_aff_point (S.point_negate p)) k;
+    }
+  else
+    SE.pow_lemma S.mk_k256_concrete_ops p k
+
+
+// [k]([lambda]P) = [lambda]([k]P) or [k](-[lambda]P) = [lambda](-[k]P)
+val aff_point_negate_cond_lambda_pow_lemma: is_negate:bool -> p:S.proj_point -> k:nat ->
+  Lemma (let co = S.mk_k256_concrete_ops in let cm = S.mk_k256_comm_monoid in
+    aff_point_mul lambda (aff_point_negate_cond (S.to_aff_point (SE.pow co p k)) is_negate) ==
+    LE.pow cm (S.to_aff_point (point_negate_cond (point_mul_lambda p) is_negate)) k)
+
+let aff_point_negate_cond_lambda_pow_lemma is_negate p k =
+  let co = S.mk_k256_concrete_ops in
+  let cm = S.mk_k256_comm_monoid in
+  let ag = S.mk_k256_abelian_group in
+  let p_aff = S.to_aff_point p in
+  let p_lambda = point_mul_lambda p in
+  let p_lambda_aff = S.to_aff_point p_lambda in
+
+  if is_negate then
+    calc (==) {
+      aff_point_mul lambda (S.aff_point_negate (S.to_aff_point (SE.pow co p k)));
+      (==) { SE.pow_lemma co p k }
+      aff_point_mul lambda (S.aff_point_negate (LE.pow cm p_aff k));
+      (==) { LE.lemma_inverse_pow ag (LE.pow cm p_aff k) lambda }
+      S.aff_point_negate (LE.pow cm (LE.pow cm p_aff k) lambda);
+      (==) { LE.lemma_pow_mul cm p_aff k lambda }
+      S.aff_point_negate (LE.pow cm p_aff (k * lambda));
+      (==) { LE.lemma_pow_mul cm p_aff lambda k }
+      S.aff_point_negate (LE.pow cm (LE.pow cm p_aff lambda) k);
+      (==) { LE.lemma_inverse_pow ag (LE.pow cm p_aff lambda) k }
+      LE.pow cm (S.aff_point_negate (LE.pow cm p_aff lambda)) k;
+      (==) { lemma_glv p }
+      LE.pow cm (S.aff_point_negate (S.to_aff_point p_lambda)) k;
+      (==) { LS.to_aff_point_negate_lemma p_lambda }
+      LE.pow cm (S.to_aff_point (S.point_negate p_lambda)) k;
+    }
+  else
+    calc (==) {
+      aff_point_mul lambda (S.to_aff_point (SE.pow co p k));
+      (==) { SE.pow_lemma co p k }
+      aff_point_mul lambda (LE.pow cm p_aff k);
+      (==) { LE.lemma_pow_mul cm p_aff k lambda }
+      LE.pow cm p_aff (k * lambda);
+      (==) { LE.lemma_pow_mul cm p_aff lambda k }
+      LE.pow cm (LE.pow cm p_aff lambda) k;
+      (==) { lemma_glv p }
+      LE.pow cm p_lambda_aff k;
+    }

--- a/code/k256/Hacl.Spec.K256.GLV.Lemmas.fst
+++ b/code/k256/Hacl.Spec.K256.GLV.Lemmas.fst
@@ -418,7 +418,7 @@ let lemma_ecmult_endo_split_to_aff k p =
 let aff_proj_point_mul_split_lambda (k:S.qelem) (p:S.proj_point) : S.aff_point =
   let r1, p1, r2, p2 = ecmult_endo_split k p in
   lemma_scalar_split_lambda_fits k p;
-  LE.exp_double_fw S.mk_k256_comm_monoid (S.to_aff_point p1) 128 r1 (S.to_aff_point p2) r2 4
+  LE.exp_double_fw S.mk_k256_comm_monoid (S.to_aff_point p1) 128 r1 (S.to_aff_point p2) r2 5
 
 
 val lemma_aff_proj_point_mul_split_lambda: k:S.qelem -> p:S.proj_point ->
@@ -433,7 +433,7 @@ let lemma_aff_proj_point_mul_split_lambda k p =
   let p2_aff = S.to_aff_point p2 in
   calc (==) {
     aff_proj_point_mul_split_lambda k p;
-    (==) { LE.exp_double_fw_lemma S.mk_k256_comm_monoid p1_aff 128 r1 p2_aff r2 4 }
+    (==) { LE.exp_double_fw_lemma S.mk_k256_comm_monoid p1_aff 128 r1 p2_aff r2 5 }
     S.aff_point_add (aff_point_mul r1 p1_aff) (aff_point_mul r2 p2_aff);
     (==) { lemma_aff_point_mul_endo_split k p_aff; lemma_ecmult_endo_split_to_aff k p }
     aff_point_mul k p_aff;
@@ -455,7 +455,7 @@ let aff_proj_point_mul_double_split_lambda
   lemma_scalar_split_lambda_fits k2 p2;
   LE.exp_four_fw S.mk_k256_comm_monoid
     (S.to_aff_point p11) 128 r11 (S.to_aff_point p12) r12
-    (S.to_aff_point p21) r21 (S.to_aff_point p22) r22 4
+    (S.to_aff_point p21) r21 (S.to_aff_point p22) r22 5
 
 
 val lemma_aff_proj_point_mul_double_split_lambda:
@@ -480,7 +480,7 @@ let lemma_aff_proj_point_mul_double_split_lambda k1 p1 k2 p2 =
     aff_proj_point_mul_double_split_lambda k1 p1 k2 p2;
   (==) {
     LE.exp_four_fw_lemma S.mk_k256_comm_monoid
-      p11_aff 128 r11 p12_aff r12 p21_aff r21 p22_aff r22 4 }
+      p11_aff 128 r11 p12_aff r12 p21_aff r21 p22_aff r22 5 }
     S.aff_point_add
       (S.aff_point_add
         (S.aff_point_add (aff_point_mul r11 p11_aff) (aff_point_mul r12 p12_aff))

--- a/code/k256/Hacl.Spec.K256.GLV.fst
+++ b/code/k256/Hacl.Spec.K256.GLV.fst
@@ -1,0 +1,153 @@
+module Hacl.Spec.K256.GLV
+
+open FStar.Mul
+
+module S = Spec.K256
+
+#set-options "--z3rlimit 50 --fuel 0 --ifuel 0"
+
+// For more comments see https://github.com/bitcoin-core/secp256k1/blob/master/src/scalar_impl.h
+
+(**
+ Fast computation of [lambda]P as (beta * x, y) in affine and projective coordinates
+*)
+
+let lambda : S.qelem = 0x5363ad4cc05c30e0a5261c028812645a122e22ea20816678df02967c1b23bd72
+
+let beta : S.felem = 0x7ae96a2b657c07106e64479eac3434e99cf0497512f58995c1396c28719501ee
+
+// [a]P in affine coordinates
+let aff_point_mul = S.aff_point_mul
+
+// [a]G in affine coordinates
+let aff_point_mul_g (a:nat) : S.aff_point =
+  aff_point_mul a S.(g_x, g_y)
+
+// fast computation of [lambda]P in affine coordinates
+let aff_point_mul_lambda (p:S.aff_point) : S.aff_point =
+  let (px, py) = p in (S.(beta *% px), py)
+
+// fast computation of [lambda]G in affine coordinates
+let aff_point_mul_g_lambda () : S.aff_point =
+  (S.(beta *% S.g_x), S.g_y)
+
+// fast computation of [lambda]P in projective coordinates
+let point_mul_lambda (p:S.proj_point) : S.proj_point =
+  let (_X, _Y, _Z) = p in (S.(beta *% _X), _Y, _Z)
+
+// fast computation of [lambda]G in projective coordinates
+let point_mul_g_lambda () : S.proj_point =
+  (S.(beta *% S.g_x), S.g_y, S.one)
+
+(**
+  Representing a scalar k as (r1 + r2 * lambda) mod S.q,
+  s.t. r1 and r2 are ~128 bits long
+*)
+
+let a1 : S.qelem = 0x3086d221a7d46bcde86c90e49284eb15
+let minus_b1 : S.qelem = 0xe4437ed6010e88286f547fa90abfe4c3
+let a2 : S.qelem = 0x114ca50f7a8e2f3f657c1108d9d44cfd8
+let b2 : S.qelem = 0x3086d221a7d46bcde86c90e49284eb15
+
+let minus_lambda : S.qelem =
+  let x = 0xac9c52b33fa3cf1f5ad9e3fd77ed9ba4a880b9fc8ec739c2e0cfc810b51283cf in
+  assert_norm (x = (- lambda) % S.q);
+  x
+
+let b1 : S.qelem =
+  let x = 0xfffffffffffffffffffffffffffffffdd66b5e10ae3a1813507ddee3c5765c7e in
+  assert_norm (x = (- minus_b1) % S.q);
+  x
+
+let minus_b2 : S.qelem =
+  let x = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE8A280AC50774346DD765CDA83DB1562C in
+  assert_norm (x = (- b2) % S.q);
+  x
+
+let g1 : S.qelem =
+  let x = 0x3086D221A7D46BCDE86C90E49284EB153DAA8A1471E8CA7FE893209A45DBB031 in
+  assert_norm (pow2 384 * b2 / S.q + 1 = x);
+  x
+
+let g2 : S.qelem =
+  let x = 0xE4437ED6010E88286F547FA90ABFE4C4221208AC9DF506C61571B4AE8AC47F71 in
+  assert_norm (pow2 384 * minus_b1 / S.q = x);
+  x
+
+let qmul_shift_384 a b =
+  a * b / pow2 384 + (a * b / pow2 383 % 2)
+
+val qmul_shift_384_lemma (a b:S.qelem) : Lemma (qmul_shift_384 a b < S.q)
+let qmul_shift_384_lemma a b =
+  assert_norm (S.q < pow2 256);
+  Math.Lemmas.lemma_mult_lt_sqr a b (pow2 256);
+  Math.Lemmas.pow2_plus 256 256;
+  assert (a * b < pow2 512);
+  Math.Lemmas.lemma_div_lt_nat (a * b) 512 384;
+  assert (a * b / pow2 384 < pow2 128);
+  assert_norm (pow2 128 < S.q)
+
+
+let scalar_split_lambda (k:S.qelem) : S.qelem & S.qelem =
+  qmul_shift_384_lemma k g1;
+  qmul_shift_384_lemma k g2;
+  let c1 : S.qelem = qmul_shift_384 k g1 in
+  let c2 : S.qelem = qmul_shift_384 k g2 in
+
+  let c1 = S.(c1 *^ minus_b1) in
+  let c2 = S.(c2 *^ minus_b2) in
+
+  let r2 = S.(c1 +^ c2) in
+  let r1 = S.(k +^ r2 *^ minus_lambda) in
+  r1, r2
+
+
+(**
+ Fast computation of [k]P in affine coordinates
+*)
+
+let aff_point_negate_cond (p:S.aff_point) (is_negate:bool) : S.aff_point =
+  if is_negate then S.aff_point_negate p else p
+
+let aff_negate_point_and_scalar_cond (k:S.qelem) (p:S.aff_point) : S.qelem & S.aff_point =
+  if S.scalar_is_high k then begin
+    let k_neg = S.qnegate k in
+    let p_neg = S.aff_point_negate p in
+    k_neg, p_neg end
+  else k, p
+
+// https://github.com/bitcoin-core/secp256k1/blob/master/src/ecmult_impl.h
+// [k]P = [r1 + r2 * lambda]P = [r1]P + [r2]([lambda]P) = [r1](x,y) + [r2](beta*x,y)
+let aff_ecmult_endo_split (k:S.qelem) (p:S.aff_point) :
+  S.qelem & S.aff_point & S.qelem & S.aff_point
+ =
+  let r1, r2 = scalar_split_lambda k in
+  let lambda_p = aff_point_mul_lambda p in
+  let r1, p1 = aff_negate_point_and_scalar_cond r1 p in
+  let r2, p2 = aff_negate_point_and_scalar_cond r2 lambda_p in
+  (r1, p1, r2, p2)
+
+
+(**
+ Fast computation of [k]P in projective coordinates
+*)
+
+let point_negate_cond (p:S.proj_point) (is_negate:bool) : S.proj_point =
+  if is_negate then S.point_negate p else p
+
+let negate_point_and_scalar_cond (k:S.qelem) (p:S.proj_point) : S.qelem & S.proj_point =
+  if S.scalar_is_high k then begin
+    let k_neg = S.qnegate k in
+    let p_neg = S.point_negate p in
+    k_neg, p_neg end
+  else k, p
+
+
+let ecmult_endo_split (k:S.qelem) (p:S.proj_point) :
+  S.qelem & S.proj_point & S.qelem & S.proj_point
+ =
+  let r1, r2 = scalar_split_lambda k in
+  let lambda_p = point_mul_lambda p in
+  let r1, p1 = negate_point_and_scalar_cond r1 p in
+  let r2, p2 = negate_point_and_scalar_cond r2 lambda_p in
+  (r1, p1, r2, p2)

--- a/code/k256/Hacl.Spec.K256.GLV.fst
+++ b/code/k256/Hacl.Spec.K256.GLV.fst
@@ -19,25 +19,13 @@ let beta : S.felem = 0x7ae96a2b657c07106e64479eac3434e99cf0497512f58995c1396c287
 // [a]P in affine coordinates
 let aff_point_mul = S.aff_point_mul
 
-// [a]G in affine coordinates
-let aff_point_mul_g (a:nat) : S.aff_point =
-  aff_point_mul a S.(g_x, g_y)
-
 // fast computation of [lambda]P in affine coordinates
 let aff_point_mul_lambda (p:S.aff_point) : S.aff_point =
   let (px, py) = p in (S.(beta *% px), py)
 
-// fast computation of [lambda]G in affine coordinates
-let aff_point_mul_g_lambda () : S.aff_point =
-  (S.(beta *% S.g_x), S.g_y)
-
 // fast computation of [lambda]P in projective coordinates
 let point_mul_lambda (p:S.proj_point) : S.proj_point =
   let (_X, _Y, _Z) = p in (S.(beta *% _X), _Y, _Z)
-
-// fast computation of [lambda]G in projective coordinates
-let point_mul_g_lambda () : S.proj_point =
-  (S.(beta *% S.g_x), S.g_y, S.one)
 
 (**
   Representing a scalar k as (r1 + r2 * lambda) mod S.q,
@@ -127,6 +115,11 @@ let aff_ecmult_endo_split (k:S.qelem) (p:S.aff_point) :
   let r2, p2 = aff_negate_point_and_scalar_cond r2 lambda_p in
   (r1, p1, r2, p2)
 
+// [k]P = [r1 + r2 * lambda]P = [r1]P + [r2]([lambda]P) = [r1](x,y) + [r2](beta*x,y)
+// which can be computed as a double exponentiation ([a]P + [b]Q)
+let aff_point_mul_endo_split (k:S.qelem) (p:S.aff_point) : S.aff_point =
+  let r1, p1, r2, p2 = aff_ecmult_endo_split k p in
+  S.aff_point_add (aff_point_mul r1 p1) (aff_point_mul r2 p2)
 
 (**
  Fast computation of [k]P in projective coordinates

--- a/code/k256/Hacl.Spec.K256.Scalar.Lemmas.fst
+++ b/code/k256/Hacl.Spec.K256.Scalar.Lemmas.fst
@@ -422,3 +422,79 @@ let mod_lseq_lemma a =
     Math.Lemmas.lemma_mod_sub (pow2 256 + SD.bn_v r) S.q 1;
     assert (SD.bn_v res % S.q == SD.bn_v a % S.q);
     Math.Lemmas.small_mod (SD.bn_v res) S.q end
+
+
+val qmul_shift_383_mod_2_lemma : l:lseq uint64 8 ->
+  Lemma (v l.[5] / pow2 63 = SD.bn_v l / pow2 383 % 2)
+let qmul_shift_383_mod_2_lemma l =
+  calc (==) {
+    v l.[5] / pow2 63;
+    (==) { SD.bn_eval_index l 5 }
+    SD.bn_v l / pow2 320 % pow2 64 / pow2 63;
+    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 (SD.bn_v l) 320 384 }
+    SD.bn_v l % pow2 384 / pow2 320 / pow2 63;
+    (==) { Math.Lemmas.division_multiplication_lemma (SD.bn_v l % pow2 384) (pow2 320) (pow2 63) }
+    SD.bn_v l % pow2 384 / (pow2 320 * pow2 63);
+    (==) { Math.Lemmas.pow2_plus 320 63 }
+    SD.bn_v l % pow2 384 / pow2 383;
+    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 (SD.bn_v l) 383 384 }
+    SD.bn_v l / pow2 383 % pow2 1;
+    (==) { assert_norm (pow2 1 = 2) }
+    SD.bn_v l / pow2 383 % 2;
+  }
+
+
+val qmul_shift_384_lemma_eval_fits : l:lseq uint64 8 ->
+  Lemma (let res_b = SB.bn_rshift l 6 in
+    let res_b_padded = create 4 (u64 0) in
+    let res_b_padded = update_sub res_b_padded 0 2 res_b in
+    SD.bn_v res_b_padded < pow2 128 /\
+    SD.bn_v res_b_padded = SD.bn_v l / pow2 384)
+
+let qmul_shift_384_lemma_eval_fits l =
+  let res_b = SB.bn_rshift l 6 in
+  let res_b_padded = create 4 (u64 0) in
+  let res_b_padded = update_sub res_b_padded 0 2 res_b in
+  SD.bn_eval_update_sub 2 res_b 4;
+  assert (SD.bn_v res_b = SD.bn_v res_b_padded);
+  SB.bn_rshift_lemma l 6;
+
+  SD.bn_eval_bound res_b 2;
+  assert (SD.bn_v res_b_padded < pow2 128)
+
+
+val qmul_shift_384_lemma (a b:qelem_lseq) :
+  Lemma (let x = SD.bn_v a * SD.bn_v b / pow2 383 % 2 in
+    let res = SD.bn_v (qmul_shift_384 a b) in
+    res < S.q /\ res = SD.bn_v a * SD.bn_v b / pow2 384 + x)
+
+let qmul_shift_384_lemma a b =
+  let l = SB.bn_mul a b in
+  SB.bn_mul_lemma a b;
+  assert (SD.bn_v l = SD.bn_v a * SD.bn_v b);
+
+  let res_b = SB.bn_rshift l 6 in
+  let res_b_padded = create 4 (u64 0) in
+  let res_b_padded = update_sub res_b_padded 0 2 res_b in
+  qmul_shift_384_lemma_eval_fits l;
+  assert (SD.bn_v res_b_padded < pow2 128);
+  assert (SD.bn_v res_b_padded = SD.bn_v l / pow2 384);
+
+  let c, res1_b = SB.bn_add1 res_b_padded (u64 1) in
+  SB.bn_add1_lemma res_b_padded (u64 1);
+  assert (v c * pow2 256 + SD.bn_v res1_b = SD.bn_v res_b_padded + 1);
+  SD.bn_eval_bound res1_b 4;
+  Math.Lemmas.pow2_lt_compat 256 128;
+  carry_is_zero (v c) 256 (SD.bn_v res1_b) (SD.bn_v res_b_padded + 1);
+  assert (v c = 0 /\ SD.bn_v res1_b = SD.bn_v res_b_padded + 1);
+
+  let flag = l.[5] >>. 63ul in
+  assert (v flag = v l.[5] / pow2 63);
+  qmul_shift_383_mod_2_lemma l;
+  assert (v flag = SD.bn_v l / pow2 383 % 2);
+
+  let mask = u64 0 -. flag in
+  assert (v mask = (if v flag = 0 then 0 else ones_v U64));
+  let res = map2 (BB.mask_select mask) res1_b res_b_padded in
+  BB.lseq_mask_select_lemma res1_b res_b_padded mask;
+  assert (res == (if v flag = 0 then res_b_padded else res1_b))

--- a/code/k256/Hacl.Spec.K256.Scalar.Lemmas.fst
+++ b/code/k256/Hacl.Spec.K256.Scalar.Lemmas.fst
@@ -67,6 +67,19 @@ let is_qelem_eq_vartime4_lemma f1 f2 =
 #pop-options
 
 
+val is_qelem_lt_pow2_128_vartime4_lemma: f:qelem4 ->
+  Lemma (is_qelem_lt_pow2_128_vartime4 f == (qas_nat4 f < pow2 128))
+
+let is_qelem_lt_pow2_128_vartime4_lemma f =
+  let (f0, f1, f2, f3) = f in
+  assert (qas_nat4 f == v f0 + v f1 * pow2 64 + v f2 * pow2 128 + v f3 * pow2 192);
+  assert (v f0 + v f1 * pow2 64 < pow2 128);
+  if v f2 = 0 && v f3 = 0 then ()
+  else begin
+    Math.Lemmas.pow2_lt_compat 192 128;
+    assert (pow2 128 <= qas_nat4 f) end
+
+
 val lemma_check_overflow: b:nat{b < pow2 256} ->
   Lemma (let overflow = (b + (pow2 256 - S.q)) / pow2 256 in
     overflow = (if b < S.q then 0 else 1))

--- a/code/k256/Hacl.Spec.K256.Scalar.fst
+++ b/code/k256/Hacl.Spec.K256.Scalar.fst
@@ -170,3 +170,16 @@ let mod_lseq a =
 
   let mask = u64 0 -. (c0 +. c1) in
   map2 (BB.mask_select mask) out r
+
+
+noextract
+let qmul_shift_384 (a b:qelem_lseq) : qelem_lseq =
+  let l = SB.bn_mul a b in
+  let res_b = SB.bn_rshift l 6 in
+  let res_b_padded = create 4 (u64 0) in
+  let res_b_padded = update_sub res_b_padded 0 2 res_b in
+  let _, res1_b = SB.bn_add1 res_b_padded (u64 1) in
+
+  let flag = l.[5] >>. 63ul in
+  let mask = u64 0 -. flag in // mask = if flag is set then ones_v U64 else 0
+  map2 (BB.mask_select mask) res1_b res_b_padded // res = if flag is set then res1_b else res_b

--- a/code/k256/Hacl.Spec.K256.Scalar.fst
+++ b/code/k256/Hacl.Spec.K256.Scalar.fst
@@ -100,6 +100,12 @@ let is_qelem_eq_vartime4 ((a0,a1,a2,a3): qelem4) ((b0,b1,b2,b3): qelem4) : bool 
   u64_to_UInt64 a3 =. u64_to_UInt64 b3
 
 
+inline_for_extraction noextract
+let is_qelem_lt_pow2_128_vartime4 ((a0,a1,a2,a3): qelem4) : bool =
+  let open Lib.RawIntTypes in
+  u64_to_UInt64 a2 =. 0uL && u64_to_UInt64 a3 =. 0uL
+
+
 noextract
 val mod_short_lseq: a:qelem_lseq -> qelem_lseq
 let mod_short_lseq a =

--- a/dist/gcc-compatible/Hacl_Ed25519_PrecompTable.h
+++ b/dist/gcc-compatible/Hacl_Ed25519_PrecompTable.h
@@ -36,7 +36,7 @@ extern "C" {
 
 
 
-#include "evercrypt_targetconfig.h"
+
 static const
 uint64_t
 Hacl_Ed25519_PrecompTable_precomp_basepoint_table_w4[320U] =

--- a/dist/gcc-compatible/Hacl_K256_ECDSA.c
+++ b/dist/gcc-compatible/Hacl_K256_ECDSA.c
@@ -585,6 +585,37 @@ static inline bool is_qelem_le_q_halved_vartime(uint64_t *f)
   return a0 <= (uint64_t)0xdfe92f46681b20a0U;
 }
 
+static inline void qmul_shift_384(uint64_t *res, uint64_t *a, uint64_t *b)
+{
+  uint64_t l[8U] = { 0U };
+  mul4(a, b, l);
+  uint64_t res_b_padded[4U] = { 0U };
+  memcpy(res_b_padded, l + (uint32_t)6U, (uint32_t)2U * sizeof (uint64_t));
+  uint64_t
+  c0 = Lib_IntTypes_Intrinsics_add_carry_u64((uint64_t)0U, res_b_padded[0U], (uint64_t)1U, res);
+  uint64_t *a1 = res_b_padded + (uint32_t)1U;
+  uint64_t *res1 = res + (uint32_t)1U;
+  uint64_t c = c0;
+  KRML_MAYBE_FOR3(i,
+    (uint32_t)0U,
+    (uint32_t)3U,
+    (uint32_t)1U,
+    uint64_t t1 = a1[i];
+    uint64_t *res_i = res1 + i;
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, (uint64_t)0U, res_i););
+  uint64_t c1 = c;
+  uint64_t uu____0 = c1;
+  uint64_t flag = l[5U] >> (uint32_t)63U;
+  uint64_t mask = (uint64_t)0U - flag;
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    uint64_t *os = res;
+    uint64_t x = (mask & res[i]) | (~mask & res_b_padded[i]);
+    os[i] = x;);
+}
+
 static inline void qsquare_times_in_place(uint64_t *out, uint32_t b)
 {
   for (uint32_t i = (uint32_t)0U; i < b; i++)
@@ -736,6 +767,15 @@ void Hacl_Impl_K256_Point_point_negate(uint64_t *out, uint64_t *p)
   oy[3U] = f3;
   oy[4U] = f4;
   Hacl_K256_Field_fnormalize_weak(oy, oy);
+}
+
+static inline void point_negate_conditional_vartime(uint64_t *p, bool is_negate)
+{
+  if (is_negate)
+  {
+    Hacl_Impl_K256_Point_point_negate(p, p);
+    return;
+  }
 }
 
 static inline bool fmul_fmul_eq_vartime(uint64_t *a, uint64_t *bz, uint64_t *c, uint64_t *dz)
@@ -922,6 +962,109 @@ void Hacl_Impl_K256_PointAdd_point_add(uint64_t *out, uint64_t *p, uint64_t *q)
   Hacl_K256_Field_fmul(z3, z3, xy_pairs);
   Hacl_K256_Field_fadd(z3, tmp1, z3);
   Hacl_K256_Field_fnormalize_weak(z3, z3);
+}
+
+static inline void scalar_split_lambda(uint64_t *r1, uint64_t *r2, uint64_t *k)
+{
+  uint64_t tmp1[4U] = { 0U };
+  uint64_t tmp2[4U] = { 0U };
+  tmp1[0U] = (uint64_t)0xe893209a45dbb031U;
+  tmp1[1U] = (uint64_t)0x3daa8a1471e8ca7fU;
+  tmp1[2U] = (uint64_t)0xe86c90e49284eb15U;
+  tmp1[3U] = (uint64_t)0x3086d221a7d46bcdU;
+  tmp2[0U] = (uint64_t)0x1571b4ae8ac47f71U;
+  tmp2[1U] = (uint64_t)0x221208ac9df506c6U;
+  tmp2[2U] = (uint64_t)0x6f547fa90abfe4c4U;
+  tmp2[3U] = (uint64_t)0xe4437ed6010e8828U;
+  qmul_shift_384(r1, k, tmp1);
+  qmul_shift_384(r2, k, tmp2);
+  tmp1[0U] = (uint64_t)0x6f547fa90abfe4c3U;
+  tmp1[1U] = (uint64_t)0xe4437ed6010e8828U;
+  tmp1[2U] = (uint64_t)0x0U;
+  tmp1[3U] = (uint64_t)0x0U;
+  tmp2[0U] = (uint64_t)0xd765cda83db1562cU;
+  tmp2[1U] = (uint64_t)0x8a280ac50774346dU;
+  tmp2[2U] = (uint64_t)0xfffffffffffffffeU;
+  tmp2[3U] = (uint64_t)0xffffffffffffffffU;
+  qmul(r1, r1, tmp1);
+  qmul(r2, r2, tmp2);
+  tmp1[0U] = (uint64_t)0xe0cfc810b51283cfU;
+  tmp1[1U] = (uint64_t)0xa880b9fc8ec739c2U;
+  tmp1[2U] = (uint64_t)0x5ad9e3fd77ed9ba4U;
+  tmp1[3U] = (uint64_t)0xac9c52b33fa3cf1fU;
+  qadd(r2, r1, r2);
+  qmul(tmp2, r2, tmp1);
+  qadd(r1, k, tmp2);
+}
+
+static inline void point_mul_lambda(uint64_t *res, uint64_t *p)
+{
+  uint64_t *rx = res;
+  uint64_t *ry = res + (uint32_t)5U;
+  uint64_t *rz = res + (uint32_t)10U;
+  uint64_t *px = p;
+  uint64_t *py = p + (uint32_t)5U;
+  uint64_t *pz = p + (uint32_t)10U;
+  uint64_t beta[5U] = { 0U };
+  beta[0U] = (uint64_t)0x96c28719501eeU;
+  beta[1U] = (uint64_t)0x7512f58995c13U;
+  beta[2U] = (uint64_t)0xc3434e99cf049U;
+  beta[3U] = (uint64_t)0x7106e64479eaU;
+  beta[4U] = (uint64_t)0x7ae96a2b657cU;
+  Hacl_K256_Field_fmul(rx, beta, px);
+  ry[0U] = py[0U];
+  ry[1U] = py[1U];
+  ry[2U] = py[2U];
+  ry[3U] = py[3U];
+  ry[4U] = py[4U];
+  rz[0U] = pz[0U];
+  rz[1U] = pz[1U];
+  rz[2U] = pz[2U];
+  rz[3U] = pz[3U];
+  rz[4U] = pz[4U];
+}
+
+static inline void point_mul_lambda_inplace(uint64_t *res)
+{
+  uint64_t *rx = res;
+  uint64_t beta[5U] = { 0U };
+  beta[0U] = (uint64_t)0x96c28719501eeU;
+  beta[1U] = (uint64_t)0x7512f58995c13U;
+  beta[2U] = (uint64_t)0xc3434e99cf049U;
+  beta[3U] = (uint64_t)0x7106e64479eaU;
+  beta[4U] = (uint64_t)0x7ae96a2b657cU;
+  Hacl_K256_Field_fmul(rx, beta, rx);
+}
+
+typedef struct __bool_bool_s
+{
+  bool fst;
+  bool snd;
+}
+__bool_bool;
+
+static inline __bool_bool
+ecmult_endo_split(
+  uint64_t *r1,
+  uint64_t *r2,
+  uint64_t *q1,
+  uint64_t *q2,
+  uint64_t *scalar,
+  uint64_t *q
+)
+{
+  scalar_split_lambda(r1, r2, scalar);
+  point_mul_lambda(q2, q);
+  memcpy(q1, q, (uint32_t)15U * sizeof (uint64_t));
+  bool b0 = is_qelem_le_q_halved_vartime(r1);
+  qnegate_conditional_vartime(r1, !b0);
+  point_negate_conditional_vartime(q1, !b0);
+  bool is_high1 = !b0;
+  bool b = is_qelem_le_q_halved_vartime(r2);
+  qnegate_conditional_vartime(r2, !b);
+  point_negate_conditional_vartime(q2, !b);
+  bool is_high2 = !b;
+  return ((__bool_bool){ .fst = is_high1, .snd = is_high2 });
 }
 
 void Hacl_Impl_K256_PointMul_point_mul(uint64_t *out, uint64_t *scalar, uint64_t *q)
@@ -1183,6 +1326,317 @@ point_mul_g_double_vartime(uint64_t *out, uint64_t *scalar1, uint64_t *scalar2, 
   }
 }
 
+static inline void
+point_mul_g_double_split_lambda_table(
+  uint64_t *out,
+  uint64_t *r1,
+  uint64_t *r2,
+  uint64_t *r3,
+  uint64_t *r4,
+  uint64_t *p2,
+  bool is_negate1,
+  bool is_negate2,
+  bool is_negate3,
+  bool is_negate4
+)
+{
+  uint64_t table2[480U] = { 0U };
+  uint64_t tmp[15U] = { 0U };
+  uint64_t *t0 = table2;
+  uint64_t *t1 = table2 + (uint32_t)15U;
+  Hacl_Impl_K256_Point_make_point_at_inf(t0);
+  memcpy(t1, p2, (uint32_t)15U * sizeof (uint64_t));
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
+    uint64_t *t11 = table2 + (i + (uint32_t)1U) * (uint32_t)15U;
+    Hacl_Impl_K256_PointDouble_point_double(tmp, t11);
+    memcpy(table2 + ((uint32_t)2U * i + (uint32_t)2U) * (uint32_t)15U,
+      tmp,
+      (uint32_t)15U * sizeof (uint64_t));
+    uint64_t *t2 = table2 + ((uint32_t)2U * i + (uint32_t)2U) * (uint32_t)15U;
+    Hacl_Impl_K256_PointAdd_point_add(tmp, p2, t2);
+    memcpy(table2 + ((uint32_t)2U * i + (uint32_t)3U) * (uint32_t)15U,
+      tmp,
+      (uint32_t)15U * sizeof (uint64_t)););
+  uint64_t tmp0[15U] = { 0U };
+  uint64_t tmp1[15U] = { 0U };
+  uint64_t mask_l0 = (uint64_t)31U;
+  uint32_t i0 = (uint32_t)1U;
+  uint32_t j0 = (uint32_t)61U;
+  uint64_t p110 = r1[i0] >> j0;
+  uint64_t ite0;
+  if (i0 + (uint32_t)1U < (uint32_t)4U && (uint32_t)0U < j0)
+  {
+    ite0 = p110 | r1[i0 + (uint32_t)1U] << ((uint32_t)64U - j0);
+  }
+  else
+  {
+    ite0 = p110;
+  }
+  uint64_t bits_c = ite0 & mask_l0;
+  uint32_t bits_l320 = (uint32_t)bits_c;
+  const
+  uint64_t
+  *a_bits_l0 = Hacl_K256_PrecompTable_precomp_basepoint_table_w5 + bits_l320 * (uint32_t)15U;
+  memcpy(out, (uint64_t *)a_bits_l0, (uint32_t)15U * sizeof (uint64_t));
+  point_negate_conditional_vartime(out, is_negate1);
+  uint64_t mask_l1 = (uint64_t)31U;
+  uint32_t i2 = (uint32_t)1U;
+  uint32_t j1 = (uint32_t)61U;
+  uint64_t p111 = r2[i2] >> j1;
+  uint64_t ite1;
+  if (i2 + (uint32_t)1U < (uint32_t)4U && (uint32_t)0U < j1)
+  {
+    ite1 = p111 | r2[i2 + (uint32_t)1U] << ((uint32_t)64U - j1);
+  }
+  else
+  {
+    ite1 = p111;
+  }
+  uint64_t bits_c0 = ite1 & mask_l1;
+  uint32_t bits_l321 = (uint32_t)bits_c0;
+  const
+  uint64_t
+  *a_bits_l1 = Hacl_K256_PrecompTable_precomp_basepoint_table_w5 + bits_l321 * (uint32_t)15U;
+  memcpy(tmp1, (uint64_t *)a_bits_l1, (uint32_t)15U * sizeof (uint64_t));
+  point_negate_conditional_vartime(tmp1, is_negate2);
+  point_mul_lambda_inplace(tmp1);
+  Hacl_Impl_K256_PointAdd_point_add(out, out, tmp1);
+  uint64_t tmp10[15U] = { 0U };
+  uint64_t mask_l2 = (uint64_t)31U;
+  uint32_t i3 = (uint32_t)1U;
+  uint32_t j2 = (uint32_t)61U;
+  uint64_t p112 = r3[i3] >> j2;
+  uint64_t ite2;
+  if (i3 + (uint32_t)1U < (uint32_t)4U && (uint32_t)0U < j2)
+  {
+    ite2 = p112 | r3[i3 + (uint32_t)1U] << ((uint32_t)64U - j2);
+  }
+  else
+  {
+    ite2 = p112;
+  }
+  uint64_t bits_c1 = ite2 & mask_l2;
+  uint32_t bits_l322 = (uint32_t)bits_c1;
+  const uint64_t *a_bits_l2 = table2 + bits_l322 * (uint32_t)15U;
+  memcpy(tmp0, (uint64_t *)a_bits_l2, (uint32_t)15U * sizeof (uint64_t));
+  point_negate_conditional_vartime(tmp0, is_negate3);
+  uint64_t mask_l3 = (uint64_t)31U;
+  uint32_t i = (uint32_t)1U;
+  uint32_t j3 = (uint32_t)61U;
+  uint64_t p113 = r4[i] >> j3;
+  uint64_t ite3;
+  if (i + (uint32_t)1U < (uint32_t)4U && (uint32_t)0U < j3)
+  {
+    ite3 = p113 | r4[i + (uint32_t)1U] << ((uint32_t)64U - j3);
+  }
+  else
+  {
+    ite3 = p113;
+  }
+  uint64_t bits_c2 = ite3 & mask_l3;
+  uint32_t bits_l323 = (uint32_t)bits_c2;
+  const uint64_t *a_bits_l3 = table2 + bits_l323 * (uint32_t)15U;
+  memcpy(tmp10, (uint64_t *)a_bits_l3, (uint32_t)15U * sizeof (uint64_t));
+  point_negate_conditional_vartime(tmp10, is_negate4);
+  point_mul_lambda_inplace(tmp10);
+  Hacl_Impl_K256_PointAdd_point_add(tmp0, tmp0, tmp10);
+  Hacl_Impl_K256_PointAdd_point_add(out, out, tmp0);
+  for (uint32_t i4 = (uint32_t)0U; i4 < (uint32_t)25U; i4++)
+  {
+    KRML_MAYBE_FOR5(i1,
+      (uint32_t)0U,
+      (uint32_t)5U,
+      (uint32_t)1U,
+      Hacl_Impl_K256_PointDouble_point_double(out, out););
+    uint32_t bk = (uint32_t)125U;
+    uint64_t mask_l4 = (uint64_t)31U;
+    uint32_t i10 = (bk - (uint32_t)5U * i4 - (uint32_t)5U) / (uint32_t)64U;
+    uint32_t j4 = (bk - (uint32_t)5U * i4 - (uint32_t)5U) % (uint32_t)64U;
+    uint64_t p114 = r4[i10] >> j4;
+    uint64_t ite4;
+    if (i10 + (uint32_t)1U < (uint32_t)4U && (uint32_t)0U < j4)
+    {
+      ite4 = p114 | r4[i10 + (uint32_t)1U] << ((uint32_t)64U - j4);
+    }
+    else
+    {
+      ite4 = p114;
+    }
+    uint64_t bits_l = ite4 & mask_l4;
+    uint64_t a_bits_l4[15U] = { 0U };
+    uint32_t bits_l324 = (uint32_t)bits_l;
+    const uint64_t *a_bits_l10 = table2 + bits_l324 * (uint32_t)15U;
+    memcpy(a_bits_l4, (uint64_t *)a_bits_l10, (uint32_t)15U * sizeof (uint64_t));
+    point_negate_conditional_vartime(a_bits_l4, is_negate4);
+    point_mul_lambda_inplace(a_bits_l4);
+    Hacl_Impl_K256_PointAdd_point_add(out, out, a_bits_l4);
+    uint32_t bk0 = (uint32_t)125U;
+    uint64_t mask_l5 = (uint64_t)31U;
+    uint32_t i11 = (bk0 - (uint32_t)5U * i4 - (uint32_t)5U) / (uint32_t)64U;
+    uint32_t j5 = (bk0 - (uint32_t)5U * i4 - (uint32_t)5U) % (uint32_t)64U;
+    uint64_t p115 = r3[i11] >> j5;
+    uint64_t ite5;
+    if (i11 + (uint32_t)1U < (uint32_t)4U && (uint32_t)0U < j5)
+    {
+      ite5 = p115 | r3[i11 + (uint32_t)1U] << ((uint32_t)64U - j5);
+    }
+    else
+    {
+      ite5 = p115;
+    }
+    uint64_t bits_l0 = ite5 & mask_l5;
+    uint64_t a_bits_l5[15U] = { 0U };
+    uint32_t bits_l325 = (uint32_t)bits_l0;
+    const uint64_t *a_bits_l11 = table2 + bits_l325 * (uint32_t)15U;
+    memcpy(a_bits_l5, (uint64_t *)a_bits_l11, (uint32_t)15U * sizeof (uint64_t));
+    point_negate_conditional_vartime(a_bits_l5, is_negate3);
+    Hacl_Impl_K256_PointAdd_point_add(out, out, a_bits_l5);
+    uint32_t bk1 = (uint32_t)125U;
+    uint64_t mask_l6 = (uint64_t)31U;
+    uint32_t i12 = (bk1 - (uint32_t)5U * i4 - (uint32_t)5U) / (uint32_t)64U;
+    uint32_t j6 = (bk1 - (uint32_t)5U * i4 - (uint32_t)5U) % (uint32_t)64U;
+    uint64_t p116 = r2[i12] >> j6;
+    uint64_t ite6;
+    if (i12 + (uint32_t)1U < (uint32_t)4U && (uint32_t)0U < j6)
+    {
+      ite6 = p116 | r2[i12 + (uint32_t)1U] << ((uint32_t)64U - j6);
+    }
+    else
+    {
+      ite6 = p116;
+    }
+    uint64_t bits_l1 = ite6 & mask_l6;
+    uint64_t a_bits_l6[15U] = { 0U };
+    uint32_t bits_l326 = (uint32_t)bits_l1;
+    const
+    uint64_t
+    *a_bits_l12 = Hacl_K256_PrecompTable_precomp_basepoint_table_w5 + bits_l326 * (uint32_t)15U;
+    memcpy(a_bits_l6, (uint64_t *)a_bits_l12, (uint32_t)15U * sizeof (uint64_t));
+    point_negate_conditional_vartime(a_bits_l6, is_negate2);
+    point_mul_lambda_inplace(a_bits_l6);
+    Hacl_Impl_K256_PointAdd_point_add(out, out, a_bits_l6);
+    uint32_t bk2 = (uint32_t)125U;
+    uint64_t mask_l = (uint64_t)31U;
+    uint32_t i1 = (bk2 - (uint32_t)5U * i4 - (uint32_t)5U) / (uint32_t)64U;
+    uint32_t j = (bk2 - (uint32_t)5U * i4 - (uint32_t)5U) % (uint32_t)64U;
+    uint64_t p11 = r1[i1] >> j;
+    uint64_t ite;
+    if (i1 + (uint32_t)1U < (uint32_t)4U && (uint32_t)0U < j)
+    {
+      ite = p11 | r1[i1 + (uint32_t)1U] << ((uint32_t)64U - j);
+    }
+    else
+    {
+      ite = p11;
+    }
+    uint64_t bits_l2 = ite & mask_l;
+    uint64_t a_bits_l[15U] = { 0U };
+    uint32_t bits_l32 = (uint32_t)bits_l2;
+    const
+    uint64_t
+    *a_bits_l13 = Hacl_K256_PrecompTable_precomp_basepoint_table_w5 + bits_l32 * (uint32_t)15U;
+    memcpy(a_bits_l, (uint64_t *)a_bits_l13, (uint32_t)15U * sizeof (uint64_t));
+    point_negate_conditional_vartime(a_bits_l, is_negate1);
+    Hacl_Impl_K256_PointAdd_point_add(out, out, a_bits_l);
+  }
+}
+
+static inline bool
+check_ecmult_endo_split(uint64_t *r1, uint64_t *r2, uint64_t *r3, uint64_t *r4)
+{
+  uint64_t f20 = r1[2U];
+  uint64_t f30 = r1[3U];
+  bool b1 = f20 == (uint64_t)0U && f30 == (uint64_t)0U;
+  uint64_t f21 = r2[2U];
+  uint64_t f31 = r2[3U];
+  bool b2 = f21 == (uint64_t)0U && f31 == (uint64_t)0U;
+  uint64_t f22 = r3[2U];
+  uint64_t f32 = r3[3U];
+  bool b3 = f22 == (uint64_t)0U && f32 == (uint64_t)0U;
+  uint64_t f2 = r4[2U];
+  uint64_t f3 = r4[3U];
+  bool b4 = f2 == (uint64_t)0U && f3 == (uint64_t)0U;
+  return b1 && b2 && b3 && b4;
+}
+
+typedef struct __bool_bool_bool_bool_s
+{
+  bool fst;
+  bool snd;
+  bool thd;
+  bool f3;
+}
+__bool_bool_bool_bool;
+
+static inline void
+point_mul_g_double_split_lambda_vartime(
+  uint64_t *out,
+  uint64_t *scalar1,
+  uint64_t *scalar2,
+  uint64_t *p2
+)
+{
+  uint64_t g[15U] = { 0U };
+  uint64_t *gx = g;
+  uint64_t *gy = g + (uint32_t)5U;
+  uint64_t *gz = g + (uint32_t)10U;
+  gx[0U] = (uint64_t)0x2815b16f81798U;
+  gx[1U] = (uint64_t)0xdb2dce28d959fU;
+  gx[2U] = (uint64_t)0xe870b07029bfcU;
+  gx[3U] = (uint64_t)0xbbac55a06295cU;
+  gx[4U] = (uint64_t)0x79be667ef9dcU;
+  gy[0U] = (uint64_t)0x7d08ffb10d4b8U;
+  gy[1U] = (uint64_t)0x48a68554199c4U;
+  gy[2U] = (uint64_t)0xe1108a8fd17b4U;
+  gy[3U] = (uint64_t)0xc4655da4fbfc0U;
+  gy[4U] = (uint64_t)0x483ada7726a3U;
+  memset(gz, 0U, (uint32_t)5U * sizeof (uint64_t));
+  gz[0U] = (uint64_t)1U;
+  uint64_t r1234[16U] = { 0U };
+  uint64_t q1234[60U] = { 0U };
+  uint64_t *r1 = r1234;
+  uint64_t *r2 = r1234 + (uint32_t)4U;
+  uint64_t *r3 = r1234 + (uint32_t)8U;
+  uint64_t *r4 = r1234 + (uint32_t)12U;
+  uint64_t *q1 = q1234;
+  uint64_t *q2 = q1234 + (uint32_t)15U;
+  uint64_t *q3 = q1234 + (uint32_t)30U;
+  uint64_t *q4 = q1234 + (uint32_t)45U;
+  __bool_bool scrut0 = ecmult_endo_split(r1, r2, q1, q2, scalar1, g);
+  bool is_high10 = scrut0.fst;
+  bool is_high20 = scrut0.snd;
+  __bool_bool scrut = ecmult_endo_split(r3, r4, q3, q4, scalar2, p2);
+  bool is_high30 = scrut.fst;
+  bool is_high40 = scrut.snd;
+  __bool_bool_bool_bool
+  scrut1 = { .fst = is_high10, .snd = is_high20, .thd = is_high30, .f3 = is_high40 };
+  bool is_high1 = scrut1.fst;
+  bool is_high2 = scrut1.snd;
+  bool is_high3 = scrut1.thd;
+  bool is_high4 = scrut1.f3;
+  bool is_r1234_valid = check_ecmult_endo_split(r1, r2, r3, r4);
+  if (is_r1234_valid)
+  {
+    point_mul_g_double_split_lambda_table(out,
+      r1,
+      r2,
+      r3,
+      r4,
+      p2,
+      is_high1,
+      is_high2,
+      is_high3,
+      is_high4);
+  }
+  else
+  {
+    point_mul_g_double_vartime(out, scalar1, scalar2, p2);
+  }
+}
+
 static inline bool load_public_key(uint8_t *pk, uint64_t *fpk_x, uint64_t *fpk_y)
 {
   uint8_t *pk_x = pk;
@@ -1370,7 +1824,7 @@ Hacl_K256_ECDSA_ecdsa_verify_hashed_msg(uint8_t *m, uint8_t *public_key, uint8_t
   qinv(sinv1, s_q);
   qmul(u11, z, sinv1);
   qmul(u21, r_q, sinv1);
-  point_mul_g_double_vartime(res, u11, u21, p);
+  point_mul_g_double_split_lambda_vartime(res, u11, u21, p);
   uint64_t tmp[5U] = { 0U };
   uint64_t *pz = res + (uint32_t)10U;
   Hacl_K256_Field_fnormalize(tmp, pz);

--- a/dist/gcc-compatible/Hacl_K256_PrecompTable.h
+++ b/dist/gcc-compatible/Hacl_K256_PrecompTable.h
@@ -36,7 +36,7 @@ extern "C" {
 
 
 
-#include "evercrypt_targetconfig.h"
+
 static const
 uint64_t
 Hacl_K256_PrecompTable_precomp_basepoint_table_w4[240U] =

--- a/specs/Spec.K256.PointOps.fst
+++ b/specs/Spec.K256.PointOps.fst
@@ -93,8 +93,36 @@ let g : proj_point = (g_x, g_y, one)
 
 ///  Point addition in affine coordinates
 
-assume
-val aff_point_add (p:aff_point) (y:aff_point) : aff_point
+let aff_point_double (p:aff_point) : aff_point =
+  let (px, py) = p in
+  if is_aff_point_at_inf p then p
+  else begin
+    if py = 0 then aff_point_at_inf
+    else begin
+      let lambda = 3 *% px *% px /% (2 *% py) in
+      let rx = lambda *% lambda -% px -% px in
+      let ry = lambda *% (px -% rx) -% py in
+      (rx, ry) end
+  end
+
+let aff_point_add (p:aff_point) (q:aff_point) : aff_point =
+  let (px, py) = p in let (qx, qy) = q in
+  if is_aff_point_at_inf p then q
+  else begin
+    if is_aff_point_at_inf q then p
+    else begin
+      if p = q then aff_point_double p
+      else begin
+        if qx = px then aff_point_at_inf
+        else begin
+          let lambda = (qy -% py) /% (qx -% px) in
+          let rx = lambda *% lambda -% px -% qx in
+          let ry = lambda *% (px -% rx) -% py in
+          (rx, ry)
+        end
+      end
+    end
+  end
 
 let aff_point_negate (p:aff_point) : aff_point =
   let x, y = p in x, (-y) % prime

--- a/specs/Spec.K256.fst
+++ b/specs/Spec.K256.fst
@@ -28,6 +28,12 @@ let mk_k256_comm_monoid : LE.comm_monoid aff_point = {
   LE.lemma_mul_comm = KL.aff_point_add_comm_lemma;
 }
 
+let mk_k256_abelian_group : LE.abelian_group aff_point = {
+  LE.cm = mk_k256_comm_monoid;
+  LE.inverse = aff_point_negate;
+  LE.lemma_inverse = KL.aff_point_negate_lemma;
+}
+
 let mk_to_k256_comm_monoid : SE.to_comm_monoid proj_point = {
   SE.a_spec = aff_point;
   SE.comm_monoid = mk_k256_comm_monoid;

--- a/specs/lemmas/Spec.K256.Lemmas.fst
+++ b/specs/lemmas/Spec.K256.Lemmas.fst
@@ -11,6 +11,7 @@ module M = Lib.NatMod
 
 assume val prime_lemma: unit -> Lemma (Euclid.is_prime prime)
 
+
 val mul_zero_lemma: n:pos{Euclid.is_prime n} -> x:int -> y:int ->
   Lemma (x * y % n == 0 <==> (x % n == 0 \/ y % n == 0))
 
@@ -91,18 +92,52 @@ let lemma_proj_aff_id p =
   M.lemma_div_mod_prime_one #prime pY;
   assert (rx = pX /\ ry = pY)
 
-let aff_point_at_inf_lemma p = admit()
+let aff_point_at_inf_lemma p = ()
 
 let aff_point_add_assoc_lemma p q s = admit()
 
 let aff_point_add_comm_lemma p q = admit()
 
-let to_aff_point_at_infinity_lemma () = admit()
+let aff_point_negate_lemma p =
+  let p_neg = aff_point_negate p in
+  let px, py = p in
+  let qx, qy = p_neg in
+  assert (qx = px /\ qy = (-py) % prime);
+  assert (aff_point_add p_neg p == aff_point_at_inf)
+
+
+let to_aff_point_at_infinity_lemma () =
+  let px, py = to_aff_point point_at_inf in
+  assert (px == zero /% zero /\ py == one /% zero);
+  assert (px == zero *% M.pow_mod #prime zero (prime - 2));
+  M.lemma_pow_mod #prime zero (prime - 2);
+  assert (px == zero *% (M.pow zero (prime - 2) % prime));
+  M.lemma_pow_zero (prime - 2);
+  assert (px == zero /\ py == zero)
 
 let to_aff_point_add_lemma p q = admit()
 
 let to_aff_point_double_lemma p = admit()
 
+let to_aff_point_negate_lemma p =
+  let px, py, pz = p in
+  let qx, qy = to_aff_point (point_negate p) in
+  assert (qx == px /% pz /\ qy == (- py) % prime /% pz);
+  let ax, ay = aff_point_negate (to_aff_point p) in
+  assert (ax == px /% pz /\ ay == (- py /% pz) % prime);
+  let pz_inv = M.pow_mod #prime pz (prime - 2) in
+
+  calc (==) { // (-py) % prime /% pz;
+    ((- py) % prime * pz_inv) % prime;
+    (==) { Math.Lemmas.lemma_mod_mul_distr_l (- py) pz_inv prime }
+    (- py * pz_inv) % prime;
+    (==) { Math.Lemmas.neg_mul_left py pz_inv }
+    (- (py * pz_inv)) % prime;
+    (==) { Math.Lemmas.lemma_mod_sub_distr 0 (py * pz_inv) prime }
+    (- (py * pz_inv) % prime) % prime; // (- py /% pz) % prime;
+  }
+
+//----------------------------------
 
 val lemma_div_mod_eq_mul_mod (a b c:felem) : Lemma
   (requires b <> 0)

--- a/specs/lemmas/Spec.K256.Lemmas.fsti
+++ b/specs/lemmas/Spec.K256.Lemmas.fsti
@@ -29,6 +29,10 @@ val aff_point_add_comm_lemma (p q:aff_point) :
   Lemma (aff_point_add p q = aff_point_add q p)
 
 
+val aff_point_negate_lemma (p:aff_point) :
+  Lemma (aff_point_add (aff_point_negate p) p == aff_point_at_inf)
+
+
 val to_aff_point_at_infinity_lemma: unit ->
   Lemma (to_aff_point point_at_inf == aff_point_at_inf)
 
@@ -39,6 +43,10 @@ val to_aff_point_add_lemma (p q:proj_point) :
 
 val to_aff_point_double_lemma (p:proj_point) :
   Lemma (to_aff_point (point_double p) == aff_point_add (to_aff_point p) (to_aff_point p))
+
+
+val to_aff_point_negate_lemma (p:proj_point) :
+  Lemma (to_aff_point (point_negate p) == aff_point_negate (to_aff_point p))
 
 
 // works when q < prime /\ prime < 2 * q


### PR DESCRIPTION
This PR improves the performance of `secp256k1-ecdsa-verify` from 298379 to 237964 CPU cycles, i.e., by 1.25x.