### PR TITLE
Avoid a needless proof step and solve it with a tactic

### DIFF
--- a/code/ecdsap256/Hacl.Impl.P256.PointDouble.fst
+++ b/code/ecdsap256/Hacl.Impl.P256.PointDouble.fst
@@ -161,6 +161,8 @@ let y3_lemma_0 x y z t0 =
 val y3_lemma_1: x: int ->  y: int -> z: int ->  
   Lemma (3 * (x - (z * z % prime)) * (x + (z * z % prime)) % prime == 3 * (x + z * z) * (x - z * z)  % prime)
 
+let sym_decidable (#a:eqtype) (x y:a) : Lemma (requires y = x) (ensures x == y) = ()
+
 let y3_lemma_1 x y z = 
   let open FStar.Tactics.Canon in 
   calc (==)
@@ -178,10 +180,8 @@ let y3_lemma_1 x y z =
       3 * (x + z * z) * ((x - (z * z % prime))  % prime)  % prime;
     (==) {lemma_mod_sub_distr x (z * z) prime}
       3 * (x + z * z) * ((x - z * z) % prime)  % prime;
-    (==) {lemma_mod_mul_distr_r (3 * (x + z * z)) (x - z * z) prime}
-      3 * (x - z * z) * (x + z * z)  % prime;
-    (==) {assert_by_tactic (3 * (x + z * z) * (x - z * z) == 3 * (x - z * z) * (x + z * z)) canon}
-      3 * (x + z * z) * (x - z * z)  % prime; 
+    (==) { _ by FStar.Tactics.(mapply (`sym_decidable); mapply (`lemma_mod_mul_distr_r)) }
+      3 * (x + z * z) * (x - z * z)  % prime;
     }
 
 


### PR DESCRIPTION
The additional step in the calc is unnecessary ... and the goal can be solved directly with a simple tactic, rather than relying on SMT to complete it.