### PR TITLE
Replace deprecated C.Failure in tests

### DIFF
--- a/providers/test/Test.NoHeap.fst
+++ b/providers/test/Test.NoHeap.fst
@@ -20,7 +20,7 @@ noextract unfold inline_for_extraction
 let (!$) = C.String.((!$))
 
 noextract unfold inline_for_extraction
-let failwith = C.Failure.failwith
+let failwith = LowStar.Failure.failwith
 
 /// Using meta-evaluated Low* test vectors from Test.Vectors
 /// ========================================================
@@ -36,11 +36,11 @@ let test_one_hash vec =
   let input_len = C.String.strlen input in
   let tlen = Hacl.Hash.Definitions.hash_len a in
   if expected_len <> tlen then
-    failwith !$"Wrong length of expected tag\n"
+    failwith "Wrong length of expected tag\n"
   else if repeat = 0ul then
-    failwith !$"Repeat must be non-zero\n"
+    failwith "Repeat must be non-zero\n"
   else if not (input_len <= (0xfffffffful - 1ul) / repeat) then
-    failwith !$"Repeated input is too large\n"
+    failwith "Repeated input is too large\n"
   else begin
     push_frame();
     let computed = B.alloca 0uy tlen in
@@ -83,11 +83,11 @@ val test_one_hmac: hmac_vector -> Stack unit (fun _ -> True) (fun _ _ _ -> True)
 let test_one_hmac vec =
   let ha, (LB keylen key), (LB datalen data), (LB expectedlen expected) = vec in
   if expectedlen <> Hacl.Hash.Definitions.hash_len ha then
-    failwith !$"Wrong length of expected tag\n"
+    failwith "Wrong length of expected tag\n"
   else if not (keysized ha keylen) then
-    failwith !$"Keysized predicate not satisfied\n"
+    failwith "Keysized predicate not satisfied\n"
   else if not (datalen <= 0xfffffffful - Hacl.Hash.Definitions.block_len ha) then
-    failwith !$"Datalen predicate not satisfied\n"
+    failwith "Datalen predicate not satisfied\n"
   else if EverCrypt.HMAC.is_supported_alg ha then
     begin
     push_frame();
@@ -173,18 +173,18 @@ let test_one_hkdf vec =
   let ha, (LB ikmlen ikm), (LB saltlen salt),
     (LB infolen info), (LB prklen expected_prk), (LB okmlen expected_okm) = vec in
   if prklen <> Hacl.Hash.Definitions.hash_len ha then
-    failwith !$"Wrong length of expected PRK\n"
+    failwith "Wrong length of expected PRK\n"
   else if okmlen > 255ul * Hacl.Hash.Definitions.hash_len ha then
-    failwith !$"Wrong output length\n"
+    failwith "Wrong output length\n"
   else if not (keysized ha saltlen) then
-    failwith !$"Saltlen is not keysized\n"
+    failwith "Saltlen is not keysized\n"
   else if not (keysized ha prklen) then
-    failwith !$"Prklen is not keysized\n"
+    failwith "Prklen is not keysized\n"
   else if not (ikmlen <= 0xfffffffful - Hacl.Hash.Definitions.block_len ha) then
-    failwith !$"ikmlen is too large\n"
+    failwith "ikmlen is too large\n"
   else if not (infolen <= 0xfffffffful -
     Hacl.Hash.Definitions.(block_len ha + hash_len ha + 1ul)) then
-    failwith !$"infolen is too large\n"
+    failwith "infolen is too large\n"
   else if EverCrypt.HMAC.is_supported_alg ha then begin
     push_frame();
     assert (Spec.Agile.HMAC.keysized ha (v saltlen));
@@ -218,15 +218,15 @@ friend Lib.IntTypes
 let test_one_chacha20 (v: chacha20_vector): Stack unit (fun _ -> True) (fun _ _ _ -> True) =
   let (LB key_len key), (LB iv_len iv), ctr, (LB plain_len plain), (LB cipher_len cipher) = v in
   if cipher_len = 0xfffffffful then
-    failwith !$"Cipher too long"
+    failwith "Cipher too long"
   else if cipher_len <> plain_len then
-    failwith !$"Cipher len and plain len don't match"
+    failwith "Cipher len and plain len don't match"
   else if key_len <> 32ul then
-    failwith !$"invalid key len"
+    failwith "invalid key len"
   else if iv_len <> 12ul then
-    failwith !$"invalid iv len"
+    failwith "invalid iv len"
   else if not (ctr <= 0xfffffffful - cipher_len / 64ul) then
-    failwith !$"invalid len"
+    failwith "invalid len"
   else begin
     push_frame ();
     B.recall key;
@@ -254,7 +254,7 @@ let test_one_poly1305 (v: Test.Vectors.Poly1305.vector): Stack unit (fun _ -> Tr
   push_frame ();
   if not (4294967295ul `U32.sub` 16ul `U32.gte` input_len)
   then
-      C.Failure.failwith !$"Error: skipping a test_poly1305 instance because bounds do not hold\n"
+      failwith "Error: skipping a test_poly1305 instance because bounds do not hold\n"
   else begin
     B.recall key;
     B.recall tag;
@@ -310,15 +310,15 @@ let test_curve25519 () : Stack unit (fun _ -> True) (fun _ _ _ -> True) =
 let test_one_chacha20poly1305 (v: Test.Vectors.Chacha20Poly1305.vector): Stack unit (fun _ -> True) (fun _ _ _ -> True) =
   let Test.Vectors.Chacha20Poly1305.Vector cipher_and_tag cipher_and_tag_len plain plain_len aad aad_len nonce nonce_len key key_len = v in
   if not (key_len = 32ul)
-  then C.Failure.failwith !$"chacha20poly1305: not (key_len = 32ul)"
+  then failwith "chacha20poly1305: not (key_len = 32ul)"
   else if not (nonce_len = 12ul)
-  then C.Failure.failwith !$"chacha20poly1305: not (nonce_len = 12ul)"
+  then failwith "chacha20poly1305: not (nonce_len = 12ul)"
   else if not ((4294967295ul `U32.sub` 16ul) `U32.gte` plain_len)
-  then C.Failure.failwith !$"chacha20poly1305: not ((4294967295ul `U32.sub` 16ul) `U32.gte` plain_len)"
+  then failwith "chacha20poly1305: not ((4294967295ul `U32.sub` 16ul) `U32.gte` plain_len)"
   else if not ((plain_len `U32.div` 64ul) `U32.lte` (4294967295ul `U32.sub` aad_len))
-  then C.Failure.failwith !$"chacha20poly1305: not ((plain_len `U32.div` 64ul) `U32.lte` (4294967295ul `U32.sub` aad_len))"
+  then failwith "chacha20poly1305: not ((plain_len `U32.div` 64ul) `U32.lte` (4294967295ul `U32.sub` aad_len))"
   else if not (cipher_and_tag_len = plain_len `U32.add` 16ul)
-  then C.Failure.failwith !$"chacha20poly1305: not (cipher_and_tag_len = plain_len `U32.add` 16ul)"
+  then failwith "chacha20poly1305: not (cipher_and_tag_len = plain_len `U32.add` 16ul)"
   else begin
     B.recall plain;
     B.recall cipher_and_tag;
@@ -338,7 +338,7 @@ let test_one_chacha20poly1305 (v: Test.Vectors.Chacha20Poly1305.vector): Stack u
     then
       TestLib.compare_and_print !$"chacha20poly1305 plain" plain tmp_msg' plain_len
     else
-      C.Failure.failwith !$"Failure: chacha20poly1305 aead_decrypt returned nonzero value";
+      failwith "Failure: chacha20poly1305 aead_decrypt returned nonzero value";
     pop_frame ()
   end
 

--- a/providers/test/Test.fst
+++ b/providers/test/Test.fst
@@ -148,22 +148,22 @@ let test_aead_st alg key key_len iv iv_len aad aad_len tag tag_len plaintext pla
     Spec.Agile.AEAD.is_supported_alg alg
   )
   then
-    C.Failure.failwith !$"Error: skipping a test_aead_st instance because algo unsupported etc.\n"
+    LowStar.Failure.failwith "Error: skipping a test_aead_st instance because algo unsupported etc.\n"
   else
   if not (key_len = aead_key_length32 alg)
-  then C.Failure.failwith !$"test_aead_st: not (key_len = aead_key_length32 alg)"
+  then LowStar.Failure.failwith "test_aead_st: not (key_len = aead_key_length32 alg)"
   else if not (tag_len = aead_tag_length32 alg)
-  then C.Failure.failwith !$"test_aead_st: not (tag_len = aead_tag_length32 alg)"
+  then LowStar.Failure.failwith "test_aead_st: not (tag_len = aead_tag_length32 alg)"
   else if not (ciphertext_len = plaintext_len)
-  then C.Failure.failwith !$"test_aead_st: not (ciphertext_len = plaintext_len)"
+  then LowStar.Failure.failwith "test_aead_st: not (ciphertext_len = plaintext_len)"
   else if not (aead_iv_length32 alg iv_len)
-  then C.Failure.failwith !$"test_aead_st: not (iv_len = aead_iv_length32 alg)"
+  then LowStar.Failure.failwith "test_aead_st: not (iv_len = aead_iv_length32 alg)"
   else if not (aad_len `U32.lte` max_len)
-  then C.Failure.failwith !$"test_aead_st: not (aad_len `U32.lte` max_len)"
+  then LowStar.Failure.failwith "test_aead_st: not (aad_len `U32.lte` max_len)"
   else if not (aad_len `U32.lte` 2147483648ul)
-  then C.Failure.failwith !$"test_aead_st: not (aad_len `U32.lte` 2147483648ul)"
+  then LowStar.Failure.failwith "test_aead_st: not (aad_len `U32.lte` 2147483648ul)"
   else if not ((max_len `U32.sub` tag_len) `U32.gte` ciphertext_len)
-  then C.Failure.failwith !$"test_aead_st: not ((max_len `U32.sub` tag_len) `U32.gte` ciphertext_len)"
+  then LowStar.Failure.failwith "test_aead_st: not ((max_len `U32.sub` tag_len) `U32.gte` ciphertext_len)"
   else begin
     push_frame();
     B.recall key;
@@ -173,7 +173,7 @@ let test_aead_st alg key key_len iv iv_len aad aad_len tag tag_len plaintext pla
     let st = B.alloca B.null 1ul in
     let e = EverCrypt.AEAD.create_in #alg HyperStack.root st key in
     begin match e with
-    | UnsupportedAlgorithm -> () // Non-fatal since, say, some CI machines may not have AESNI. Was: C.Failure.failwith !$"Failure: AEAD create_in UnsupportedAlgorithm"
+    | UnsupportedAlgorithm -> () // Non-fatal since, say, some CI machines may not have AESNI. Was: LowStar.Failure.failwith "Failure: AEAD create_in UnsupportedAlgorithm"
     | Success ->
       let h1 = HST.get () in
       let st = B.index st 0ul in
@@ -192,7 +192,7 @@ let test_aead_st alg key key_len iv iv_len aad aad_len tag tag_len plaintext pla
       EverCrypt.AEAD.frame_invariant B.loc_none st h1 h2;
 
       if EverCrypt.AEAD.(encrypt #(G.hide alg) st iv iv_len aad aad_len plaintext plaintext_len ciphertext' tag' <> Success) then
-        C.Failure.failwith !$"Failure AEAD encrypt\n";
+        LowStar.Failure.failwith "Failure AEAD encrypt\n";
       let h3 = HST.get () in
       (match EverCrypt.AEAD.decrypt #(G.hide alg) st iv iv_len aad aad_len ciphertext' ciphertext_len tag' plaintext' with
       | Success ->
@@ -202,7 +202,7 @@ let test_aead_st alg key key_len iv iv_len aad aad_len tag tag_len plaintext pla
         B.recall tag;
         TestLib.compare_and_print !$"of AEAD tag" tag tag' tag_len
       | _ ->
-        C.Failure.failwith !$"Failure AEAD decrypt\n");
+        LowStar.Failure.failwith "Failure AEAD decrypt\n");
       pop_frame ()
     end;
     //EverCrypt.aead_free st;
@@ -309,15 +309,15 @@ let rec test_ctr_st (a: Spec.Agile.Cipher.cipher_alg)
   let open EverCrypt.CTR in
 
   if not (k_len = key_len a) then
-    C.Failure.failwith !$"test_ctr_st: not (key_len = key_len a)"
+    LowStar.Failure.failwith "test_ctr_st: not (key_len = key_len a)"
   else if not (counter_len = 4ul) then
-    C.Failure.failwith !$"test_ctr_st: not (counter_len = 4)"
+    LowStar.Failure.failwith "test_ctr_st: not (counter_len = 4)"
   else if not (nonce_bound a nonce_len) then
-    C.Failure.failwith !$"test_ctr_st: not (nonce_bound a nonce_len)"
+    LowStar.Failure.failwith "test_ctr_st: not (nonce_bound a nonce_len)"
   else if not (input_len = output_len) then
-    C.Failure.failwith !$"test_ctr_st: not (input_len = output_len)"
+    LowStar.Failure.failwith "test_ctr_st: not (input_len = output_len)"
   else if not (input_len `U32.gte` block_len a) then
-    C.Failure.failwith !$"test_ctr_st: not (input_len >= block_len a)"
+    LowStar.Failure.failwith "test_ctr_st: not (input_len >= block_len a)"
 
   else begin
     B.recall k;
@@ -328,7 +328,7 @@ let rec test_ctr_st (a: Spec.Agile.Cipher.cipher_alg)
     // Might only be correct for AES
     let ctr = LowStar.Endianness.load32_be counter in
     if ctr = 0xfffffffful then
-      C.Failure.failwith !$"test_ctr_st: ctr = max_uint32"
+      LowStar.Failure.failwith "test_ctr_st: ctr = max_uint32"
     else begin
       push_frame ();
       let output' = B.alloca 0uy (block_len a) in
@@ -336,7 +336,7 @@ let rec test_ctr_st (a: Spec.Agile.Cipher.cipher_alg)
       let s = B.alloca B.null 1ul in
       let r = EverCrypt.CTR.create_in a HyperStack.root s k nonce nonce_len ctr in
       if r <> Success then
-        C.Failure.failwith !$"test_ctr_st: create_in <> Success"
+        LowStar.Failure.failwith "test_ctr_st: create_in <> Success"
       else begin
         let s = B.index s 0ul in
         let input_block = B.sub input 0ul (block_len a) in
@@ -372,7 +372,7 @@ let rec test_chacha20_ctr_loop (vs: lbuffer chacha20_vector): St unit =
     B.recall key;
     B.recall iv;
     if cipher_len <> plain_len then
-      failwith !$"chacha-ctr: cipher len and plain len don't match"
+      LowStar.Failure.failwith "chacha-ctr: cipher len and plain len don't match"
     else begin
       let plain = B.sub plain 0ul round_len in
       let cipher = B.sub cipher 0ul round_len in


### PR DESCRIPTION
Following the warning message, replace its occurences by LowStar.Failure