### PR TITLE
OCaml API: finer-grained passing of buffers in NaCl functions

### DIFF
--- a/bindings/ocaml/Hacl.ml
+++ b/bindings/ocaml/Hacl.ml
@@ -251,14 +251,11 @@ module NaCl = struct
     assert (C.disjoint pt ct);
     assert (C.disjoint n pt);
     assert (C.disjoint n ct)
-  let check_detached pt ct tag n =
-    assert (C.size ct = C.size pt);
+  let check_detached buf tag n =
     assert (C.size tag = 16);
     assert (C.size n = 24);
-    assert (C.disjoint tag ct);
-    assert (C.disjoint tag pt);
-    assert (C.disjoint n pt);
-    assert (C.disjoint n ct)
+    assert (C.disjoint tag buf);
+    assert (C.disjoint n buf);
   module Noalloc = struct
     let box_beforenm ~pk ~sk ~ck =
       check_key_sizes pk sk;
@@ -293,30 +290,30 @@ module NaCl = struct
         get_result @@ hacl_NaCl_crypto_secretbox_open_easy (C.ctypes_buf pt) (C.ctypes_buf ct) (C.size_uint32 ct) (C.ctypes_buf n) (C.ctypes_buf key)
     end
     module Detached = struct
-      let box ~pt ~n ~pk ~sk ~ct ~tag =
+      let box ~buf ~tag ~n ~pk ~sk =
         check_key_sizes pk sk;
-        check_detached pt ct tag n;
-        get_result @@ hacl_NaCl_crypto_box_detached (C.ctypes_buf ct) (C.ctypes_buf tag) (C.ctypes_buf pt) (C.size_uint32 pt) (C.ctypes_buf n) (C.ctypes_buf pk) (C.ctypes_buf sk)
-      let box_open ~ct ~tag ~n ~pk ~sk ~pt =
+        check_detached buf tag n;
+        get_result @@ hacl_NaCl_crypto_box_detached (C.ctypes_buf buf) (C.ctypes_buf tag) (C.ctypes_buf buf) (C.size_uint32 buf) (C.ctypes_buf n) (C.ctypes_buf pk) (C.ctypes_buf sk)
+      let box_open ~buf ~tag ~n ~pk ~sk =
         check_key_sizes pk sk;
-        check_detached pt ct tag n;
-        get_result @@ hacl_NaCl_crypto_box_open_detached (C.ctypes_buf pt) (C.ctypes_buf ct) (C.ctypes_buf tag) (C.size_uint32 ct) (C.ctypes_buf n) (C.ctypes_buf pk) (C.ctypes_buf sk)
-      let box_afternm ~pt ~n ~ck ~ct ~tag =
+        check_detached buf tag n;
+        get_result @@ hacl_NaCl_crypto_box_open_detached (C.ctypes_buf buf) (C.ctypes_buf buf) (C.ctypes_buf tag) (C.size_uint32 buf) (C.ctypes_buf n) (C.ctypes_buf pk) (C.ctypes_buf sk)
+      let box_afternm ~buf ~tag ~n ~ck =
         assert (C.size ck = 32);
-        check_detached pt ct tag n;
-        get_result @@ hacl_NaCl_crypto_box_detached_afternm (C.ctypes_buf ct) (C.ctypes_buf tag) (C.ctypes_buf pt) (C.size_uint32 pt) (C.ctypes_buf n) (C.ctypes_buf ck)
-      let box_open_afternm ~ct ~tag ~n ~ck ~pt =
+        check_detached buf tag n;
+        get_result @@ hacl_NaCl_crypto_box_detached_afternm (C.ctypes_buf buf) (C.ctypes_buf tag) (C.ctypes_buf buf) (C.size_uint32 buf) (C.ctypes_buf n) (C.ctypes_buf ck)
+      let box_open_afternm ~buf ~tag ~n ~ck =
         assert (C.size ck = 32);
-        check_detached pt ct tag n;
-        get_result @@ hacl_NaCl_crypto_box_open_detached_afternm (C.ctypes_buf pt) (C.ctypes_buf ct) (C.ctypes_buf tag) (C.size_uint32 ct) (C.ctypes_buf n) (C.ctypes_buf ck)
-      let secretbox ~pt ~n ~key ~ct ~tag =
+        check_detached buf tag n;
+        get_result @@ hacl_NaCl_crypto_box_open_detached_afternm (C.ctypes_buf buf) (C.ctypes_buf buf) (C.ctypes_buf tag) (C.size_uint32 buf) (C.ctypes_buf n) (C.ctypes_buf ck)
+      let secretbox ~buf ~tag ~n ~key =
         assert (C.size key = 32);
-        check_detached pt ct tag n;
-        get_result @@ hacl_NaCl_crypto_secretbox_detached (C.ctypes_buf ct) (C.ctypes_buf tag) (C.ctypes_buf pt) (C.size_uint32 pt) (C.ctypes_buf n) (C.ctypes_buf key)
-      let secretbox_open ~ct ~tag ~n ~key ~pt =
+        check_detached buf tag n;
+        get_result @@ hacl_NaCl_crypto_secretbox_detached (C.ctypes_buf buf) (C.ctypes_buf tag) (C.ctypes_buf buf) (C.size_uint32 buf) (C.ctypes_buf n) (C.ctypes_buf key)
+      let secretbox_open ~buf ~tag ~n ~key =
         assert (C.size key = 32);
-        check_detached pt ct tag n;
-        get_result @@ hacl_NaCl_crypto_secretbox_open_detached (C.ctypes_buf pt) (C.ctypes_buf ct) (C.ctypes_buf tag) (C.size_uint32 ct) (C.ctypes_buf n) (C.ctypes_buf key)
+        check_detached buf tag n;
+        get_result @@ hacl_NaCl_crypto_secretbox_open_detached (C.ctypes_buf buf) (C.ctypes_buf buf) (C.ctypes_buf tag) (C.size_uint32 buf) (C.ctypes_buf n) (C.ctypes_buf key)
     end
   end
   let box ~pt ~n ~pk ~sk =

--- a/bindings/ocaml/Hacl.mli
+++ b/bindings/ocaml/Hacl.mli
@@ -455,45 +455,47 @@ module NaCl : sig
       (** {1 Box}
           {2 One-shot interface} *)
 
-      val box : pt:bytes -> n:bytes -> pk:bytes -> sk:bytes -> ct:bytes -> tag:bytes -> bool
-      (** [box pt n pk sk ct tag] authenticates and encrypts plaintext [pt] using public key [pk],
-          secret key [sk], and nonce [n] and writes the ciphertext in [ct] and
-          the message authentication tag in [tag].
+      val box : buf:bytes -> tag:bytes -> n:bytes -> pk:bytes -> sk:bytes -> bool
+      (** [box buf tag n pk sk] authenticates and encrypts in-place the plaintext
+          in [buf] using public key [pk], secret key [sk], and nonce [n] and
+          writes the message authentication tag in [tag].
           Returns true if successful. *)
 
-      val box_open : ct:bytes -> tag:bytes -> n:bytes -> pk:bytes -> sk:bytes -> pt:bytes -> bool
-      (** [box_open ct tag n pk sk pt] attempts to verify and decrypt ciphertext [ct] and
-          message authentication tag [tag] using public key [pk],
-          secret key [sk], and nonce [n] and if successful writes the plaintext in [pt]
-          and returns true. *)
+      val box_open : buf:bytes -> tag:bytes -> n:bytes -> pk:bytes -> sk:bytes-> bool
+      (** [box_open buf tag n pk sk] attempts to verify and decrypt in-place the
+          ciphertext in [ct] and message authentication tag [tag] using public
+          key [pk], secret key [sk], and nonce [n].
+          Returns true if successful.  *)
 
       (** {2 Precomputation interface }
-          The shared key [ck] is obtained using {!NaCl.box_beforenm} or {!NaCl.Noalloc.box_beforenm}. *)
+          The shared key [ck] is obtained using {!NaCl.box_beforenm} or
+          {!NaCl.Noalloc.box_beforenm}. *)
 
-      val box_afternm : pt:bytes -> n:bytes -> ck:bytes -> ct:bytes -> tag:bytes -> bool
-      (** [box_afternm pt n ck ct tag] authenticates and encrypts [pt] using shared key [ck] and
-          nonce [n] and writes the ciphertext in [ct] and the message authentication tag in [tag].
+      val box_afternm : buf:bytes -> tag:bytes -> n:bytes -> ck:bytes -> bool
+      (** [box buf tag n pk sk] authenticates and encrypts in-place the plaintext
+          in [buf] using shared key [ck] and nonce [n] and writes the message
+          authentication tag in [tag].
           Returns true if successful. *)
 
-      val box_open_afternm : ct:bytes -> tag:bytes -> n:bytes -> ck:bytes -> pt:bytes -> bool
-      (** [box_open_afternm ct tag n ck pt] attempts to verify and decrypt ciphertext [ct] and
-          message authentication tag [tag] using
-          shared key [ck] and nonce [n] and if successful writes the plaintext in [pt]
-          and returns true. *)
+      val box_open_afternm : buf:bytes -> tag:bytes -> n:bytes -> ck:bytes -> bool
+      (** [box_open buf tag n pk sk] attempts to verify and decrypt in-place the
+          ciphertext in [ct] and message authentication tag [tag] using shared
+          key [ck] and nonce [n].
+          Returns true if successful.  *)
 
       (** {1 Secretbox} *)
 
-      val secretbox : pt:bytes -> n:bytes -> key:bytes -> ct:bytes -> tag:bytes -> bool
-      (** [secretbox pt n key ct tag] authenticates and encrypts plaintext [pt] using
-          secret key [key] and nonce [n] and writes the ciphertext in [ct]
-          and the message authentication tag in [tag].
+      val secretbox : buf:bytes -> tag:bytes -> n:bytes -> key:bytes -> bool
+      (** [secretbox buf tag n key] authenticates and encrypts in-place the
+          plaintext in [buf] using secret key [key] and nonce [n] and writes
+          the message authentication tag in [tag].
           Returns true if successful. *)
 
-      val secretbox_open : ct:bytes -> tag:bytes -> n:bytes -> key:bytes -> pt:bytes -> bool
-      (** [secretbox_open ct tag n key pt] attempts to verify and decrypt ciphertext [ct] and
-          message authentication tag [tag] using
-          secret key [key] and nonce [n] and if successful writes the plaintext in [pt]
-          and returns true. *)
+      val secretbox_open : buf:bytes -> tag:bytes -> n:bytes -> key:bytes -> bool
+      (** [secretbox_open buf tag n key] attempts to verify and decrypt in-place
+          the ciphertext in [buf] and message authentication tag [tag] using
+          secret key [key] and nonce [n].
+          Returns true if successful. *)
     end
     (** The {i detached} interface uses 2 separate buffers for the ciphertext and
         the message authentication tag. This allows users to encrypt and decrypt data in-place,

--- a/bindings/ocaml/SharedDefs.ml
+++ b/bindings/ocaml/SharedDefs.ml
@@ -10,6 +10,7 @@ module type Buffer = sig
   val empty: bytes
   val size_uint32 : bytes -> uint32
   val ctypes_buf : bytes -> buf
+  val ctypes_buf_with_offset : bytes -> int -> buf
   val size : bytes -> int
   val equal : bytes -> bytes -> bool
   val make : int -> bytes
@@ -20,11 +21,15 @@ end
 (** Abstract representation of buffers *)
 
 module CBytes : Buffer with type t = Bytes.t and type buf = Bytes.t Ctypes.ocaml = struct
+  open Ctypes
   type t = Bytes.t
   type buf = Bytes.t Ctypes.ocaml
   let empty = Bytes.empty
   let size_uint32 b = Unsigned.UInt32.of_int (Bytes.length b)
-  let ctypes_buf = Ctypes.ocaml_bytes_start
+  let ctypes_buf = ocaml_bytes_start
+  let ctypes_buf_with_offset bytes offset =
+    let buf = ocaml_bytes_start bytes in
+    buf +@ offset
   let size = Bytes.length
   let equal = Bytes.equal
   let make l = Bytes.make l '\x00'

--- a/bindings/ocaml/hacl-star.opam
+++ b/bindings/ocaml/hacl-star.opam
@@ -18,6 +18,7 @@ depends: [
   "hacl-star-raw" {= version}
   "zarith"
   "cppo" {build}
+  "alcotest" {with-test & >= "1.1.0"}
   "odoc" {with-doc}
 ]
 available: [

--- a/bindings/ocaml/tests/dune
+++ b/bindings/ocaml/tests/dune
@@ -10,7 +10,7 @@
         nacl_test
         drbg_test
         p256_test)
- (libraries hacl-star)
+ (libraries hacl-star alcotest)
  (preprocessor_deps config.h)
  (preprocess (action (run %{bin:cppo} %{input-file})))
  (flags (:standard -open Hacl_star -warn-error -3)))

--- a/bindings/ocaml/tests/nacl_test.ml
+++ b/bindings/ocaml/tests/nacl_test.ml
@@ -1,246 +1,231 @@
 open Test_utils
 
 type 'a box_test =
-  { name: string ; pk: 'a ; sk: 'a ; n: 'a ; pt: 'a ; expected_ct: 'a }
+  { pk: 'a ; sk: 'a ; n: 'a ; pt: 'a ; expected_ct: 'a }
 
 type 'a secretbox_test =
-  { name: string; key: 'a ; n: 'a ; pt: 'a; expected_ct: 'a }
+  { key: 'a ; n: 'a ; pt: 'a; expected_ct: 'a }
 
-let box_tests = [
-  { name = "Test 1";
-    pk = Bytes.of_string "\xfe\x38\x04\x02\x70\x14\xcf\x0c\x89\x68\x11\xd5\x23\x40\x32\xe5\xeb\x6c\xa1\x78\x6f\x64\x8c\x64\x86\xf3\xfa\xdd\x26\x4d\x17\x41";
-    sk = Bytes.of_string "\xd5\x7d\xff\xb8\x10\xeb\x32\xff\xaa\x87\x93\x24\x46\xa0\xc6\xe3\x6e\xb9\x54\xa7\x37\xe9\xcc\x3a\xc0\xd9\x80\x34\x41\xe2\xbe\xac";
-    n = init_bytes 24;
-    pt = Bytes.of_string "\x17\x8c\xb3\x11\xd2\x0f\x0a";
-    expected_ct = Bytes.of_string "\x06\x2f\x0c\x61\x1b\x5a\xd3\x2d\xf8\xd4\x2f\xea\x32\x6e\xb9\xc5\xb9\x2a\xda\x4d\x98\xea\x08"
-  };
-  { name = "Test 2";
-    pk = Bytes.of_string "\xc7\x99\xe1\xb6\xa1\x0c\x60\x9e\x44\x9b\xa3\x48\x38\xec\xc7\x94\x04\x98\x9c\x69\xac\xb3\x63\xd9\x52\x7f\x78\x66\xe5\x7b\xa6\x4a";
-    sk = Bytes.of_string "\x07\xbb\x38\xf5\xb2\xdb\x98\xae\xe6\x02\x1b\x5e\xb1\xe8\x08\xe3\xe4\x67\x70\x20\xa2\x60\x9f\xa7\xd0\x89\xb5\x23\xc1\x35\xf5\xdf";
-    n = init_bytes 24;
-    pt = Bytes.of_string "\x93\xc6\x9d\x5b\xce\xea\xd5\x24\x03\x4e\x5c\x50";
-    expected_ct = Bytes.of_string "\x77\x87\x8b\x2b\xce\x5a\xbf\x2f\xac\x5a\x14\xec\xd9\x58\x09\x68\xa6\x97\x6a\x8a\xf3\x41\x15\xce\x02\x3c\x95\x0e"
-  }
-]
+let box_tests =
+  [
+    { pk = Bytes.of_string "\xfe\x38\x04\x02\x70\x14\xcf\x0c\x89\x68\x11\xd5\x23\x40\x32\xe5\xeb\x6c\xa1\x78\x6f\x64\x8c\x64\x86\xf3\xfa\xdd\x26\x4d\x17\x41";
+      sk = Bytes.of_string "\xd5\x7d\xff\xb8\x10\xeb\x32\xff\xaa\x87\x93\x24\x46\xa0\xc6\xe3\x6e\xb9\x54\xa7\x37\xe9\xcc\x3a\xc0\xd9\x80\x34\x41\xe2\xbe\xac";
+      n = init_bytes 24;
+      pt = Bytes.of_string "\x17\x8c\xb3\x11\xd2\x0f\x0a";
+      expected_ct = Bytes.of_string "\x06\x2f\x0c\x61\x1b\x5a\xd3\x2d\xf8\xd4\x2f\xea\x32\x6e\xb9\xc5\xb9\x2a\xda\x4d\x98\xea\x08"
+    };
+    { pk = Bytes.of_string "\xc7\x99\xe1\xb6\xa1\x0c\x60\x9e\x44\x9b\xa3\x48\x38\xec\xc7\x94\x04\x98\x9c\x69\xac\xb3\x63\xd9\x52\x7f\x78\x66\xe5\x7b\xa6\x4a";
+      sk = Bytes.of_string "\x07\xbb\x38\xf5\xb2\xdb\x98\xae\xe6\x02\x1b\x5e\xb1\xe8\x08\xe3\xe4\x67\x70\x20\xa2\x60\x9f\xa7\xd0\x89\xb5\x23\xc1\x35\xf5\xdf";
+      n = init_bytes 24;
+      pt = Bytes.of_string "\x93\xc6\x9d\x5b\xce\xea\xd5\x24\x03\x4e\x5c\x50";
+      expected_ct = Bytes.of_string "\x77\x87\x8b\x2b\xce\x5a\xbf\x2f\xac\x5a\x14\xec\xd9\x58\x09\x68\xa6\x97\x6a\x8a\xf3\x41\x15\xce\x02\x3c\x95\x0e"
+    }
+  ]
 
-let secretbox_tests = [
-  { name = "Test 1";
-    key = Bytes.of_string "\x82\x2b\xca\x3c\x7e\x05\xfd\xe0\xdc\x20\x45\x19\x73\x0b\x35\xf8\x12\x16\xa9\xc9\xf1\xdf\x95\x25\xe2\xa9\x00\xec\x89\x71\x8f\x57";
-    n = Bytes.of_string "\x72\xb9\x02\x08\xd2\x80\x0e\x36\xad\x16\xc7\x30\x94\x1a\x03\x8d\x7c\x3a\xd9\xd8\x70\x30\xd3\x29";
-    pt = Bytes.of_string "";
-    expected_ct =Bytes.of_string "\x79\xb3\x45\x51\xed\x22\x4f\xa1\x7c\xb6\x46\x0c\xcb\x90\xa0\xd9"
-  };
-  { name = "Test 2";
-    key = Bytes.of_string "\x49\xd1\x3a\x96\x6a\x76\x1a\x6a\xcf\xfe\xd8\x92\x3b\x5e\xe5\x0c\x29\x71\xba\x7e\x12\xc0\x1f\xd9\x9e\x0d\x70\xde\x91\x32\xf6\xd7";
-    n = Bytes.of_string "\x66\x1d\x42\xc4\x8f\x71\xb3\x1c\x30\xd5\xc2\x65\xb1\x68\x51\x1a\xfd\x58\xb8\x70\xbf\x35\x4f\x4f";
-    pt = Bytes.of_string "\xa9\x4d\x36\x5d\x0f\x3a\x0a\x50\x4c\x8c\x12\x76\x25\x31";
-    expected_ct = Bytes.of_string "\x00\x21\xf4\x17\x24\xbe\x3a\xc9\xa4\x6b\xd5\x6c\x19\x64\x4d\x32\x0e\xb9\xcb\x66\x30\x3b\x98\xed\xa2\x9e\x22\x81\xed\x5e"
-  }
-]
+let secretbox_tests =
+  [
+    { key = Bytes.of_string "\x82\x2b\xca\x3c\x7e\x05\xfd\xe0\xdc\x20\x45\x19\x73\x0b\x35\xf8\x12\x16\xa9\xc9\xf1\xdf\x95\x25\xe2\xa9\x00\xec\x89\x71\x8f\x57";
+      n = Bytes.of_string "\x72\xb9\x02\x08\xd2\x80\x0e\x36\xad\x16\xc7\x30\x94\x1a\x03\x8d\x7c\x3a\xd9\xd8\x70\x30\xd3\x29";
+      pt = Bytes.of_string "";
+      expected_ct =Bytes.of_string "\x79\xb3\x45\x51\xed\x22\x4f\xa1\x7c\xb6\x46\x0c\xcb\x90\xa0\xd9"
+    };
+    { key = Bytes.of_string "\x49\xd1\x3a\x96\x6a\x76\x1a\x6a\xcf\xfe\xd8\x92\x3b\x5e\xe5\x0c\x29\x71\xba\x7e\x12\xc0\x1f\xd9\x9e\x0d\x70\xde\x91\x32\xf6\xd7";
+      n = Bytes.of_string "\x66\x1d\x42\xc4\x8f\x71\xb3\x1c\x30\xd5\xc2\x65\xb1\x68\x51\x1a\xfd\x58\xb8\x70\xbf\x35\x4f\x4f";
+      pt = Bytes.of_string "\xa9\x4d\x36\x5d\x0f\x3a\x0a\x50\x4c\x8c\x12\x76\x25\x31";
+      expected_ct = Bytes.of_string "\x00\x21\xf4\x17\x24\xbe\x3a\xc9\xa4\x6b\xd5\x6c\x19\x64\x4d\x32\x0e\xb9\xcb\x66\x30\x3b\x98\xed\xa2\x9e\x22\x81\xed\x5e"
+    }
+  ]
 
-
-let test_box (v: Bytes.t box_test) =
-  let test_result = Test_utils.test_result ("Hacl.NaCl.box " ^ v.name) in
-  (match Hacl.NaCl.box ~pt:v.pt ~n:v.n ~pk:v.pk ~sk:v.sk with
-  | Some ct -> (
-      if not (Bytes.equal ct v.expected_ct) then
-        test_result Failure "Ciphertext mismatch"
-      else
-        match Hacl.NaCl.box_open ~ct ~n:v.n ~pk:v.pk ~sk:v.sk with
-        | Some pt ->
-          if not (Bytes.equal pt v.pt) then
-            test_result Failure "Decrypted plaintext mismatch"
-          else
-            test_result Success ""
+let box =
+  let test_box () =
+    List.iter (fun (v: Bytes.t box_test) ->
+        match Hacl.NaCl.box ~pt:v.pt ~n:v.n ~pk:v.pk ~sk:v.sk with
+        | Some ct -> (
+            Alcotest.(check bytes "Ciphertext" ct v.expected_ct);
+            match Hacl.NaCl.box_open ~ct ~n:v.n ~pk:v.pk ~sk:v.sk with
+            | Some pt ->
+              Alcotest.(check bytes "Decrypted plaintext" pt v.pt);
+            | None ->
+              Alcotest.fail "Decryption")
         | None ->
-          test_result Failure "Decryption failed"
-    )
-  | None ->
-    test_result Failure "Encryption failed");
+          Alcotest.fail "Encryption") box_tests
+  in
 
-  let test_result = Test_utils.test_result ("Hacl.NaCl.box_beforenm " ^ v.name) in
-  match Hacl.NaCl.box_beforenm ~pk:v.pk ~sk:v.sk with
-  | Some ck -> (
-    test_result Success "";
-    let test_result = Test_utils.test_result ("Hacl.NaCl.box_afternm " ^ v.name) in
-    match Hacl.NaCl.box_afternm ~pt:v.pt ~n:v.n ~ck with
-    | Some ct -> (
-      if not (Bytes.equal ct v.expected_ct) then
-        test_result Failure "Ciphertext mismatch"
-      else
-        match Hacl.NaCl.box_open_afternm ~ct ~n:v.n ~ck with
-        | Some pt ->
-          if not (Bytes.equal pt v.pt) then
-            test_result Failure "Decrypted plaintext mismatch"
-          else
-            test_result Success ""
+  let test_box_afternm () =
+    List.iter (fun (v: Bytes.t box_test) ->
+        match Hacl.NaCl.box_beforenm ~pk:v.pk ~sk:v.sk with
+        | Some ck -> (
+            match Hacl.NaCl.box_afternm ~pt:v.pt ~n:v.n ~ck with
+            | Some ct -> (
+                Alcotest.(check bytes "Ciphertext" ct v.expected_ct);
+                match Hacl.NaCl.box_open_afternm ~ct ~n:v.n ~ck with
+                | Some pt ->
+                  Alcotest.(check bytes "Decrypted plaintext" pt v.pt);
+                | None ->
+                  Alcotest.fail "Decryption"
+              )
+            | None ->
+              Alcotest.fail "Encryption"
+          )
         | None ->
-          test_result Failure "Decryption failed"
-    )
-    | None ->
-      test_result Failure "Encryption failed"
-  )
-  | None ->
-    test_result Failure ""
+          Alcotest.fail "Generating combined key") box_tests
+  in
+  [
+    ("Box (one-shot)", `Quick, test_box);
+    ("Box (precomputation)", `Quick, test_box_afternm);
+  ]
 
+let box_noalloc =
+  let test_box_noalloc_easy () =
+    List.iter (fun (v: Bytes.t box_test) ->
+        let ct = Test_utils.init_bytes (Bytes.length v.pt + 16) in
+        let pt = Test_utils.init_bytes (Bytes.length v.pt) in
+        Alcotest.(check bool "Encryption" (Hacl.NaCl.Noalloc.Easy.box ~pt:v.pt ~n:v.n ~pk:v.pk ~sk:v.sk ~ct) true);
+        Alcotest.(check bytes "Ciphertext" ct v.expected_ct);
+        Alcotest.(check bool "Decryption" (Hacl.NaCl.Noalloc.Easy.box_open ~ct ~n:v.n ~pk:v.pk ~sk:v.sk ~pt) true);
+        Alcotest.(check bytes "Decrypted plaintext" pt v.pt)
+      ) box_tests
+  in
+  let test_box_noalloc_detached ~offset () =
+    List.iter (fun (v: Bytes.t box_test) ->
+        let tag = Test_utils.init_bytes 16 in
+        let buf = Bytes.cat (Bytes.make offset '\x00') v.pt in
+        Alcotest.(check bool "Encryption" (Hacl.NaCl.Noalloc.Detached.box ~buf ~tag ~offset ~n:v.n ~pk:v.pk ~sk:v.sk ()) true);
+        let combined_ct = Bytes.(cat tag (sub buf offset (length v.pt))) in
+        Alcotest.(check bytes "Ciphertext" combined_ct v.expected_ct);
+        Alcotest.(check bool "Decryption" (Hacl.NaCl.Noalloc.Detached.box_open ~buf ~tag ~offset ~n:v.n ~pk:v.pk ~sk:v.sk ()) true);
+        Alcotest.(check bytes "Decrypted plaintext" Bytes.(sub buf offset (length v.pt)) v.pt)
+      ) box_tests
+  in
+  let test_box_noalloc_detached_with_len ~offset () =
+    List.iter (fun (v: Bytes.t box_test) ->
+        let tag = Test_utils.init_bytes 16 in
+        let buf = Bytes.(concat empty [make offset '\x00'; v.pt; v.pt]) in
+        let len = Bytes.length v.pt in
+        Alcotest.(check bool "Encryption" (Hacl.NaCl.Noalloc.Detached.box ~buf ~tag ~offset ~len ~n:v.n ~pk:v.pk ~sk:v.sk ()) true);
+        let combined_ct = Bytes.(cat tag (sub buf offset (length v.pt))) in
+        Alcotest.(check bytes "Ciphertext" combined_ct v.expected_ct);
+        Alcotest.(check bool "Decryption" (Hacl.NaCl.Noalloc.Detached.box_open ~buf ~tag ~offset ~len ~n:v.n ~pk:v.pk ~sk:v.sk ()) true);
+        Alcotest.(check bytes "Decrypted plaintext" Bytes.(sub buf offset (length v.pt)) v.pt)
+      ) box_tests
+  in
+  let test_box_noalloc_easy_afternm () =
+    List.iter (fun (v: Bytes.t box_test) ->
+        let ck = Test_utils.init_bytes 32 in
+        Alcotest.(check bool "Generating combined key" (Hacl.NaCl.Noalloc.box_beforenm ~pk:v.pk ~sk:v.sk ~ck) true);
+        let ct = Test_utils.init_bytes (Bytes.length v.pt + 16) in
+        let pt = Test_utils.init_bytes (Bytes.length v.pt) in
+        Alcotest.(check bool "Encryption" (Hacl.NaCl.Noalloc.Easy.box_afternm ~pt:v.pt ~n:v.n ~ck ~ct) true);
+        Alcotest.(check bytes "Ciphertext" ct v.expected_ct);
+        Alcotest.(check bool "Decryption" (Hacl.NaCl.Noalloc.Easy.box_open_afternm ~ct ~n:v.n ~ck ~pt) true);
+        Alcotest.(check bytes "Decrypted plaintext" pt v.pt)
+      ) box_tests
+  in
+  let test_box_noalloc_detached_afternm ~offset () =
+    List.iter (fun (v: Bytes.t box_test) ->
+        let ck = Test_utils.init_bytes 32 in
+        Alcotest.(check bool "Generating combined key" (Hacl.NaCl.Noalloc.box_beforenm ~pk:v.pk ~sk:v.sk ~ck) true);
+        let tag = Test_utils.init_bytes 16 in
+        let buf = Bytes.cat (Bytes.make offset '\x00') v.pt in
+        Alcotest.(check bool "Encryption" (Hacl.NaCl.Noalloc.Detached.box_afternm ~buf ~tag ~offset ~n:v.n ~ck ()) true);
+        let combined_ct = Bytes.(cat tag (sub buf offset (length v.pt))) in
+        Alcotest.(check bytes "Ciphertext" combined_ct v.expected_ct);
+        Alcotest.(check bool "Decryption" (Hacl.NaCl.Noalloc.Detached.box_open_afternm ~buf ~tag ~offset ~n:v.n ~ck ()) true);
+        Alcotest.(check bytes "Decrypted plaintext" Bytes.(sub buf offset (length v.pt)) v.pt)
+      ) box_tests
+  in
+  let test_box_noalloc_detached_afternm_with_len ~offset () =
+    List.iter (fun (v: Bytes.t box_test) ->
+        let ck = Test_utils.init_bytes 32 in
+        Alcotest.(check bool "Generating combined key" (Hacl.NaCl.Noalloc.box_beforenm ~pk:v.pk ~sk:v.sk ~ck) true);
+        let tag = Test_utils.init_bytes 16 in
+        let buf = Bytes.(concat empty [make offset '\x00'; v.pt; v.pt]) in
+        let len = Bytes.length v.pt in
+        Alcotest.(check bool "Encryption" (Hacl.NaCl.Noalloc.Detached.box_afternm ~buf ~tag ~offset ~len ~n:v.n ~ck ()) true);
+        let combined_ct = Bytes.(cat tag (sub buf offset (length v.pt))) in
+        Alcotest.(check bytes "Ciphertext" combined_ct v.expected_ct);
+        Alcotest.(check bool "Decryption" (Hacl.NaCl.Noalloc.Detached.box_open_afternm ~buf ~tag ~offset ~len ~n:v.n ~ck ()) true);
+        Alcotest.(check bytes "Decrypted plaintext" Bytes.(sub buf offset (length v.pt)) v.pt)
+      ) box_tests
+  in
+  [
+    ("Easy (one-shot)", `Quick, test_box_noalloc_easy);
+    ("Detached (one-shot)", `Quick, test_box_noalloc_detached ~offset:0);
+    ("Detached (one-shot) w/ offset", `Quick, test_box_noalloc_detached ~offset:2);
+    ("Detached (one-shot) truncated", `Quick, test_box_noalloc_detached_with_len ~offset:0);
+    ("Detached (one-shot) w/ offset, truncated", `Quick, test_box_noalloc_detached_with_len ~offset:8);
+    ("Easy (precomputed)", `Quick, test_box_noalloc_easy_afternm);
+    ("Detached (precomputed)", `Quick, test_box_noalloc_detached_afternm ~offset:0);
+    ("Detached (precomputed) w/ offset", `Quick, test_box_noalloc_detached_afternm ~offset:5);
+    ("Detached (precomputed) truncated", `Quick, test_box_noalloc_detached_afternm_with_len ~offset:0);
+    ("Detached (precomputed) w/ offset, truncated", `Quick, test_box_noalloc_detached_afternm_with_len ~offset:14);
+  ]
 
-let test_box_noalloc (v: Bytes.t box_test) =
-  let test_result = Test_utils.test_result ("Hacl.NaCl.Noalloc.Easy.box " ^ v.name) in
-  let ct = Test_utils.init_bytes (Bytes.length v.pt + 16) in
-  let pt = Test_utils.init_bytes (Bytes.length v.pt) in
-  if Hacl.NaCl.Noalloc.Easy.box ~pt:v.pt ~n:v.n ~pk:v.pk ~sk:v.sk ~ct then
-    if not (Bytes.equal ct v.expected_ct) then
-      test_result Failure "ciphertext mismatch"
-    else
-    if Hacl.NaCl.Noalloc.Easy.box_open ~ct ~n:v.n ~pk:v.pk ~sk:v.sk ~pt then
-      if not (Bytes.equal pt v.pt) then
-        test_result Failure "decrypted plaintext mismatch"
-      else
-        test_result Success ""
-    else
-      test_result Failure "Decryption failed"
-  else
-    test_result Failure "Encryption failed";
-
-  let test_result = Test_utils.test_result ("Hacl.NaCl.Noalloc.Detached.box " ^ v.name) in
-  let buf = Bytes.copy v.pt in
-  let tag = Test_utils.init_bytes 16 in
-  if Hacl.NaCl.Noalloc.Detached.box ~buf ~tag ~n:v.n ~pk:v.pk ~sk:v.sk () then
-    let combined_ct = Bytes.(cat tag buf) in
-    if not (Bytes.equal combined_ct v.expected_ct) then
-      test_result Failure "ciphertext mismatch"
-    else
-    if Hacl.NaCl.Noalloc.Detached.box_open ~buf ~tag ~n:v.n ~pk:v.pk ~sk:v.sk () then
-      if not (Bytes.equal pt v.pt) then
-        test_result Failure "decrypted plaintext mismatch"
-      else
-        test_result Success ""
-    else
-      test_result Failure "Decryption failed"
-  else
-    test_result Failure "Encryption failed";
-
-  let test_result = Test_utils.test_result ("Hacl.NaCl.Noalloc.box_beforenm " ^ v.name) in
-  let ck = Test_utils.init_bytes 32 in
-  if Hacl.NaCl.Noalloc.box_beforenm ~pk:v.pk ~sk:v.sk ~ck then
-    test_result Success ""
-  else
-    test_result Failure "";
-
-  let test_result = Test_utils.test_result ("Hacl.NaCl.Noalloc.Easy.box_afternm " ^ v.name) in
-  Bytes.fill ct 0 (Bytes.length ct) '\x00';
-  Bytes.fill pt 0 (Bytes.length pt) '\x00';
-  if Hacl.NaCl.Noalloc.Easy.box_afternm ~pt:v.pt ~n:v.n ~ck ~ct then
-    if not (Bytes.equal ct v.expected_ct) then
-      test_result Failure "ciphertext mismatch"
-    else
-    if Hacl.NaCl.Noalloc.Easy.box_open_afternm ~ct ~n:v.n ~ck ~pt then
-      if not (Bytes.equal pt v.pt) then
-        test_result Failure "decrypted plaintext mismatch"
-      else
-        test_result Success ""
-    else
-      test_result Failure "Decryption failed"
-  else
-    test_result Failure "Encryption failed";
-
-  let test_result = Test_utils.test_result ("Hacl.NaCl.Noalloc.Detached.box_afternm " ^ v.name) in
-  Bytes.fill tag 0 (Bytes.length tag) '\x00';
-  let buf = Bytes.copy v.pt in
-  if Hacl.NaCl.Noalloc.Detached.box_afternm ~buf ~tag ~n:v.n ~ck then
-    let combined_ct = Bytes.(cat tag buf) in
-    if not (Bytes.equal combined_ct v.expected_ct) then
-      test_result Failure "ciphertext mismatch"
-    else
-    if Hacl.NaCl.Noalloc.Detached.box_open_afternm ~buf ~tag ~n:v.n ~ck then
-      if not (Bytes.equal pt v.pt) then
-        test_result Failure "decrypted plaintext mismatch"
-      else
-        test_result Success ""
-    else
-      test_result Failure "Decryption failed"
-  else
-    test_result Failure "Encryption failed";
-
-  (* TODO test wit non-zero len, integrate with box tests *)
-  let test_result = Test_utils.test_result ("Hacl.NaCl.Noalloc.Detached.box (with offset) " ^ v.name) in
-  let offset = 10 in
-  Bytes.fill tag 0 (Bytes.length tag) '\x00';
-  let buf = Bytes.cat (Bytes.make offset '\x00') v.pt in
-  if Hacl.NaCl.Noalloc.Detached.box ~buf ~tag ~offset ~n:v.n ~pk:v.pk ~sk:v.sk () then
-    let combined_ct = Bytes.(cat tag (sub buf offset (length v.pt))) in
-    if not (Bytes.equal combined_ct v.expected_ct) then
-      test_result Failure "ciphertext mismatch"
-    else
-    if Hacl.NaCl.Noalloc.Detached.box_open ~buf ~tag ~offset ~n:v.n ~pk:v.pk ~sk:v.sk () then
-      if not Bytes.(equal (sub buf offset (length v.pt)) v.pt) then
-        test_result Failure "decrypted plaintext mismatch"
-      else
-        test_result Success ""
-    else
-      test_result Failure "Decryption failed"
-  else
-    test_result Failure "Encryption failed"
-
-let test_secretbox (v: Bytes.t secretbox_test) =
-  let test_result = Test_utils.test_result ("Hacl.NaCl.secretbox " ^ v.name) in
-  match Hacl.NaCl.secretbox ~pt:v.pt ~n:v.n ~key:v.key with
-  | Some ct -> (
-      if not (Bytes.equal ct v.expected_ct) then
-        test_result Failure "ciphertext mismatch"
-      else
-        match Hacl.NaCl.secretbox_open ~ct ~n:v.n ~key:v.key with
-        | Some pt ->
-          if not (Bytes.equal pt v.pt) then
-            test_result Failure "decrypted plaintext mismatch"
-          else
-            test_result Success ""
+let secretbox =
+  let test_secretbox () =
+    List.iter (fun (v: Bytes.t secretbox_test) ->
+        match Hacl.NaCl.secretbox ~pt:v.pt ~n:v.n ~key:v.key with
+        | Some ct -> (
+            Alcotest.(check bytes "Ciphertext" ct v.expected_ct);
+            match Hacl.NaCl.secretbox_open ~ct ~n:v.n ~key:v.key with
+            | Some pt ->
+              Alcotest.(check bytes "Decrypted plaintext" pt v.pt)
+            | None ->
+              Alcotest.fail "Decryption")
         | None ->
-          test_result Failure "Decryption failed"
-    )
-  | None ->
-    test_result Failure "Encryption failed"
+          Alcotest.fail "Encryption") secretbox_tests
+  in
+  [ ("Secretbox", `Quick, test_secretbox); ]
 
+let secretbox_noalloc =
+  let test_secretbox_noalloc_easy () =
+    List.iter (fun (v: Bytes.t secretbox_test) ->
+        let ct = Test_utils.init_bytes (Bytes.length v.pt + 16) in
+        let pt = Test_utils.init_bytes (Bytes.length v.pt) in
+        Alcotest.(check bool "Encryption" (Hacl.NaCl.Noalloc.Easy.secretbox ~pt:v.pt ~n:v.n ~key:v.key ~ct) true);
+        Alcotest.(check bytes "Ciphertext" ct v.expected_ct);
+        Alcotest.(check bool "Decryption" (Hacl.NaCl.Noalloc.Easy.secretbox_open ~ct ~n:v.n ~key:v.key ~pt) true);
+        Alcotest.(check bytes "Decrypted plaintext" pt v.pt)
+      ) secretbox_tests
+  in
+  let test_secretbox_noalloc_detached ~offset () =
+    List.iter (fun (v: Bytes.t secretbox_test) ->
+        let tag = Test_utils.init_bytes 16 in
+        let buf = Bytes.cat (Bytes.make offset '\x00') v.pt in
+        Alcotest.(check bool "Encryption" (Hacl.NaCl.Noalloc.Detached.secretbox ~buf ~tag ~offset ~n:v.n ~key:v.key ()) true);
+        let combined_ct = Bytes.(cat tag (sub buf offset (length v.pt))) in
+        Alcotest.(check bytes "Ciphertext" combined_ct v.expected_ct);
+        Alcotest.(check bool "Decryption" (Hacl.NaCl.Noalloc.Detached.secretbox_open ~buf ~tag ~offset ~n:v.n ~key:v.key ()) true);
+        Alcotest.(check bytes "Decrypted plaintext" Bytes.(sub buf offset (length v.pt)) v.pt)
+      ) secretbox_tests
+  in
+  let test_secretbox_noalloc_detached_with_len ~offset () =
+    List.iter (fun (v: Bytes.t secretbox_test) ->
+        let tag = Test_utils.init_bytes 16 in
+        let buf = Bytes.(concat empty [make offset '\x00'; v.pt; v.pt]) in
+        let len = Bytes.length v.pt in
+        Alcotest.(check bool "Encryption" (Hacl.NaCl.Noalloc.Detached.secretbox ~buf ~tag ~offset ~len ~n:v.n ~key:v.key ()) true);
+        let combined_ct = Bytes.(cat tag (sub buf offset (length v.pt))) in
+        Alcotest.(check bytes "Ciphertext" combined_ct v.expected_ct);
+        Alcotest.(check bool "Decryption" (Hacl.NaCl.Noalloc.Detached.secretbox_open ~buf ~tag ~offset ~len ~n:v.n ~key:v.key ()) true);
+        Alcotest.(check bytes "Decrypted plaintext" Bytes.(sub buf offset (length v.pt)) v.pt)
+      ) secretbox_tests
+  in
+  [
+    ("Easy", `Quick, test_secretbox_noalloc_easy);
+    ("Detached", `Quick, test_secretbox_noalloc_detached ~offset:0);
+    ("Detached w/ offset", `Quick, test_secretbox_noalloc_detached ~offset:10);
+    ("Detached truncated", `Quick, test_secretbox_noalloc_detached_with_len ~offset:0);
+    ("Detached w/ offset, truncated", `Quick, test_secretbox_noalloc_detached_with_len ~offset:17);
 
-let test_secretbox_noalloc (v: Bytes.t secretbox_test) =
-  let test_result = Test_utils.test_result ("Hacl.NaCl.Noalloc.Easy.secretbox " ^ v.name) in
-  let ct = Test_utils.init_bytes (Bytes.length v.pt + 16) in
-  let pt = Test_utils.init_bytes (Bytes.length v.pt) in
-  if Hacl.NaCl.Noalloc.Easy.secretbox ~pt:v.pt ~n:v.n ~key:v.key ~ct then
-    if not (Bytes.equal ct v.expected_ct) then
-      test_result Failure "ciphertext mismatch"
-    else
-    if Hacl.NaCl.Noalloc.Easy.secretbox_open ~ct ~n:v.n ~key:v.key ~pt then
-      if not (Bytes.equal pt v.pt) then
-        test_result Failure "decrypted plaintext mismatch"
-      else
-        test_result Success ""
-    else
-      test_result Failure "Decryption failed"
-  else
-    test_result Failure "Encryption failed";
+  ]
 
-  let test_result = Test_utils.test_result ("Hacl.NaCl.Noalloc.Detached.secretbox " ^ v.name) in
-  let tag = Test_utils.init_bytes 16 in
-  let buf = Bytes.copy v.pt in
-  if Hacl.NaCl.Noalloc.Detached.secretbox ~buf ~tag ~n:v.n ~key:v.key then
-    let combined_ct = Bytes.(cat tag buf) in
-    if not (Bytes.equal combined_ct v.expected_ct) then
-      test_result Failure "ciphertext mismatch"
-    else
-    if Hacl.NaCl.Noalloc.Detached.secretbox_open ~buf ~tag ~n:v.n ~key:v.key then
-      if not (Bytes.equal pt v.pt) then
-        test_result Failure "decrypted plaintext mismatch"
-      else
-        test_result Success ""
-    else
-      test_result Failure "Decryption failed"
-  else
-    test_result Failure "Encryption failed"
+let tests =
+  [
+    ("Box", box);
+    ("Box Noalloc", box_noalloc);
+    ("Secretbox", secretbox);
+    ("Secretbox Noalloc", secretbox_noalloc);
+  ]
 
-
-let _ =
-  List.iter test_box box_tests;
-  List.iter test_box_noalloc box_tests;
-  List.iter test_secretbox secretbox_tests;
-  List.iter test_secretbox_noalloc secretbox_tests;
+let () = Alcotest.run "NaCl" tests


### PR DESCRIPTION
This PR makes the following changes to the `Detached` functions of the OCaml NaCl API:
- Since the use case supported by these functions is to use the same buffer for both plaintext and ciphertext, thus allowing in-place encryption and decryption, the `pt` and `ct` arguments are replaced by a single `buf` argument.
- Following a feature request, users can now optionally only pass portions of `buf` through optional arguments `offset`, which gives a starting position in `buf`, and `len`, which specifies how many bytes to take. This saves a copy on the OCaml side if the buffer needs to contain additional data.

The NaCl tests have also been expanded to test this additional functionality and have been rewritten using the Alcotest library.

I plan to create a follow-up PR to rewrite all test to use Alcotest.