### PR TITLE
remove extra copies for ed25519

### DIFF
--- a/code/ed25519/Hacl.Bignum25519.fst
+++ b/code/ed25519/Hacl.Bignum25519.fst
@@ -60,13 +60,13 @@ let make_one b =
 
 
 [@CInline]
-let fsum a b =
-  BN.fadd a a b
+let fsum out a b =
+  BN.fadd out a b
 
 
 [@CInline]
-let fdifference a b =
-  BN.fsub a b a
+let fdifference out a b =
+  BN.fsub out a b
 
 
 inline_for_extraction noextract

--- a/code/ed25519/Hacl.Bignum25519.fsti
+++ b/code/ed25519/Hacl.Bignum25519.fsti
@@ -99,29 +99,33 @@ val make_one:
     )
 
 val fsum:
-    a:felem
+    out:felem
+  -> a:felem
   -> b:felem ->
   Stack unit
-    (requires fun h -> live h a /\ live h b /\ disjoint a b /\
+    (requires fun h -> live h a /\ live h b /\ live h out /\
+      eq_or_disjoint a b /\ eq_or_disjoint a out /\ eq_or_disjoint b out /\
       F51.felem_fits h a (1, 2, 1, 1, 1) /\
       F51.felem_fits h b (1, 2, 1, 1, 1)
     )
-    (ensures  fun h0 _ h1 -> modifies (loc a) h0 h1 /\
-      F51.felem_fits h1 a (2, 4, 2, 2, 2) /\
-      F51.fevalh h1 a == F51.fevalh h0 a `SC.fadd` F51.fevalh h0 b
+    (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
+      F51.felem_fits h1 out (2, 4, 2, 2, 2) /\
+      F51.fevalh h1 out == F51.fevalh h0 a `SC.fadd` F51.fevalh h0 b
     )
 
 val fdifference:
-    a:felem
+    out:felem
+  -> a:felem
   -> b:felem ->
   Stack unit
-    (requires fun h -> live h a /\ live h b /\ disjoint a b /\
+    (requires fun h -> live h a /\ live h b /\ live h out /\
+      eq_or_disjoint a b /\ eq_or_disjoint a out /\ eq_or_disjoint b out /\
       F51.felem_fits h a (1, 2, 1, 1, 1) /\
       F51.felem_fits h b (1, 2, 1, 1, 1)
     )
-    (ensures  fun h0 _ h1 -> modifies (loc a) h0 h1 /\
-      F51.felem_fits h1 a (9, 10, 9, 9, 9) /\
-      F51.fevalh h1 a == F51.fevalh h0 b `SC.fsub` F51.fevalh h0 a
+    (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
+      F51.felem_fits h1 out (9, 10, 9, 9, 9) /\
+      F51.fevalh h1 out == F51.fevalh h0 a `SC.fsub` F51.fevalh h0 b
     )
 
 val reduce_513:
@@ -187,7 +191,7 @@ val fsquare:
     out:felem
   -> a:felem ->
   Stack unit
-    (requires fun h -> live h out /\ live h a /\ disjoint a out /\
+    (requires fun h -> live h out /\ live h a /\ eq_or_disjoint a out /\
       F51.felem_fits h a (9, 10, 9, 9, 9)
     )
     (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\

--- a/code/ed25519/Hacl.Impl.Ed25519.PointAdd.fst
+++ b/code/ed25519/Hacl.Impl.Ed25519.PointAdd.fst
@@ -11,168 +11,132 @@ open Hacl.Bignum25519
 module F51 = Hacl.Impl.Ed25519.Field51
 module SC = Spec.Curve25519
 
-#set-options "--z3rlimit 20 --max_fuel 0 --max_ifuel 0"
+#set-options "--z3rlimit 50 --fuel 0 --ifuel 0"
 
 inline_for_extraction noextract
-val point_add_step_1:
-    p:point
-  -> q:point
-  -> tmp:lbuffer uint64 30ul ->
-  Stack unit
-    (requires fun h ->
-      live h p /\ live h q /\ live h tmp /\
-      disjoint tmp p /\ disjoint tmp q /\
-      F51.point_inv_t h p /\
-      F51.point_inv_t h q
-      )
-    (ensures fun h0 _ h1 -> modifies (loc tmp) h0 h1 /\
-      (let x1 = F51.fevalh h0 (gsub p 0ul 5ul) in
-       let y1 = F51.fevalh h0 (gsub p 5ul 5ul) in
-       let x2 = F51.fevalh h0 (gsub q 0ul 5ul) in
-       let y2 = F51.fevalh h0 (gsub q 5ul 5ul) in
-       let a = (y1 `SC.fsub` x1) `SC.fmul` (y2 `SC.fsub` x2) in
-       let b = (y1 `SC.fadd` x1) `SC.fmul` (y2 `SC.fadd` x2) in
-       F51.mul_inv_t h1 (gsub tmp 10ul 5ul) /\
-       F51.mul_inv_t h1 (gsub tmp 15ul 5ul) /\
-       F51.fevalh h1 (gsub tmp 10ul 5ul) == a /\
-       F51.fevalh h1 (gsub tmp 15ul 5ul) == b)
-    )
+val point_add_step_1: p:point -> q:point -> tmp:lbuffer uint64 30ul -> Stack unit
+  (requires fun h ->
+    live h p /\ live h q /\ live h tmp /\
+    disjoint tmp p /\ disjoint tmp q /\
+    F51.point_inv_t h p /\ F51.point_inv_t h q)
+  (ensures fun h0 _ h1 -> modifies (loc tmp) h0 h1 /\
+   (let x1 = F51.fevalh h0 (gsub p 0ul 5ul) in
+    let y1 = F51.fevalh h0 (gsub p 5ul 5ul) in
+    let x2 = F51.fevalh h0 (gsub q 0ul 5ul) in
+    let y2 = F51.fevalh h0 (gsub q 5ul 5ul) in
+    let a = (y1 `SC.fsub` x1) `SC.fmul` (y2 `SC.fsub` x2) in
+    let b = (y1 `SC.fadd` x1) `SC.fmul` (y2 `SC.fadd` x2) in
+    F51.mul_inv_t h1 (gsub tmp 10ul 5ul) /\
+    F51.mul_inv_t h1 (gsub tmp 15ul 5ul) /\
+    F51.fevalh h1 (gsub tmp 10ul 5ul) == a /\
+    F51.fevalh h1 (gsub tmp 15ul 5ul) == b))
+
 let point_add_step_1 p q tmp =
   let tmp1 = sub tmp 0ul 5ul in
   let tmp2 = sub tmp 5ul 5ul in
   let tmp3 = sub tmp 10ul 5ul in
   let tmp4 = sub tmp 15ul 5ul in
-  //let tmp5 = sub tmp 20ul 5ul in
-  //let tmp6 = sub tmp 25ul 5ul in
   let x1 = getx p in
   let y1 = gety p in
   let x2 = getx q in
   let y2 = gety q in
-  copy tmp1 x1; // tmp1 = x1
-  copy tmp2 x2; // tmp2 = x2
-  fdifference tmp1 y1;    // tmp1 = y1 - x1
-  fdifference tmp2 y2;    // tmp2 = y2 - x2
-  fmul tmp3 tmp1 tmp2;    // tmp3 = a
-  copy tmp1 y1; // tmp1 = y1
-  copy tmp2 y2; // tmp2 = y2
-  fsum tmp1 x1;             // tmp1 = y1 + x1
-  fsum tmp2 x2;             // tmp2 = y2 + x2
-  fmul tmp4 tmp1 tmp2
+  fdifference tmp1 y1 x1;  // tmp1 = y1 - x1
+  fdifference tmp2 y2 x2;  // tmp2 = y2 - x2
+  fmul tmp3 tmp1 tmp2;     // tmp3 = a
+  fsum tmp1 y1 x1;         // tmp1 = y1 + x1
+  fsum tmp2 y2 x2;         // tmp2 = y2 + x2
+  fmul tmp4 tmp1 tmp2      // tmp4 = b
+
 
 inline_for_extraction noextract
-val point_add_step_2:
-    p:point
-  -> q:point
-  -> tmp:lbuffer uint64 30ul ->
-  Stack unit
-    (requires fun h ->
-      live h p /\ live h q /\ live h tmp /\
-      disjoint tmp p /\ disjoint tmp q /\
-      F51.point_inv_t h p /\
-      F51.point_inv_t h q /\
-      F51.mul_inv_t h (gsub tmp 10ul 5ul) /\
-      F51.mul_inv_t h (gsub tmp 15ul 5ul)
-    )
-    (ensures fun h0 _ h1 -> modifies (loc tmp) h0 h1 /\
-      (let z1 = F51.fevalh h0 (gsub p 10ul 5ul) in
-       let t1 = F51.fevalh h0 (gsub p 15ul 5ul) in
-       let z2 = F51.fevalh h0 (gsub q 10ul 5ul) in
-       let t2 = F51.fevalh h0 (gsub q 15ul 5ul) in
-       let a = F51.fevalh h0 (gsub tmp 10ul 5ul) in
-       let b = F51.fevalh h0 (gsub tmp 15ul 5ul) in
-       let c = (2 `SC.fmul` Spec.Ed25519.d `SC.fmul` t1) `SC.fmul` t2 in
-       let d = (2 `SC.fmul` z1) `SC.fmul` z2 in
-       let e = b `SC.fsub` a in
-       let f = d `SC.fsub` c in
-       let g = d `SC.fadd` c in
-       let h = b `SC.fadd` a in
-       F51.felem_fits h1 (gsub tmp 0ul 5ul) (9, 10, 9, 9, 9) /\
-       F51.felem_fits h1 (gsub tmp 25ul 5ul) (9, 10, 9, 9, 9) /\
-       F51.felem_fits h1 (gsub tmp 20ul 5ul) (9, 10, 9, 9, 9) /\
-       F51.felem_fits h1 (gsub tmp 15ul 5ul) (9, 10, 9, 9, 9) /\
-       F51.fevalh h1 (gsub tmp 0ul 5ul) == e /\
-       F51.fevalh h1 (gsub tmp 25ul 5ul) == f /\
-       F51.fevalh h1 (gsub tmp 20ul 5ul) == g /\
-       F51.fevalh h1 (gsub tmp 15ul 5ul) == h)
-    )
-
-#push-options "--z3rlimit 50"
+val point_add_step_2: p:point -> q:point -> tmp:lbuffer uint64 30ul -> Stack unit
+  (requires fun h ->
+    live h p /\ live h q /\ live h tmp /\
+    disjoint tmp p /\ disjoint tmp q /\
+    F51.point_inv_t h p /\ F51.point_inv_t h q /\
+    F51.mul_inv_t h (gsub tmp 10ul 5ul) /\
+    F51.mul_inv_t h (gsub tmp 15ul 5ul))
+  (ensures fun h0 _ h1 -> modifies (loc tmp) h0 h1 /\
+    (let z1 = F51.fevalh h0 (gsub p 10ul 5ul) in
+    let t1 = F51.fevalh h0 (gsub p 15ul 5ul) in
+    let z2 = F51.fevalh h0 (gsub q 10ul 5ul) in
+    let t2 = F51.fevalh h0 (gsub q 15ul 5ul) in
+    let a = F51.fevalh h0 (gsub tmp 10ul 5ul) in
+    let b = F51.fevalh h0 (gsub tmp 15ul 5ul) in
+    let c = (2 `SC.fmul` Spec.Ed25519.d `SC.fmul` t1) `SC.fmul` t2 in
+    let d = (2 `SC.fmul` z1) `SC.fmul` z2 in
+    let e = b `SC.fsub` a in
+    let f = d `SC.fsub` c in
+    let g = d `SC.fadd` c in
+    let h = b `SC.fadd` a in
+    F51.felem_fits h1 (gsub tmp 20ul 5ul) (9, 10, 9, 9, 9) /\
+    F51.felem_fits h1 (gsub tmp 25ul 5ul) (9, 10, 9, 9, 9) /\
+    F51.felem_fits h1 (gsub tmp 0ul 5ul) (9, 10, 9, 9, 9) /\
+    F51.felem_fits h1 (gsub tmp 5ul 5ul) (9, 10, 9, 9, 9) /\
+    F51.fevalh h1 (gsub tmp 20ul 5ul) == e /\
+    F51.fevalh h1 (gsub tmp 25ul 5ul) == f /\
+    F51.fevalh h1 (gsub tmp 0ul 5ul) == g /\
+    F51.fevalh h1 (gsub tmp 5ul 5ul) == h))
 
 let point_add_step_2 p q tmp =
-  let tmp1 = sub tmp 0ul 5ul in
-  let tmp2 = sub tmp 5ul 5ul in
-  let tmp3 = sub tmp 10ul 5ul in
-  let tmp4 = sub tmp 15ul 5ul in
-  let tmp5 = sub tmp 20ul 5ul in
-  let tmp6 = sub tmp 25ul 5ul in
+  let tmp1 = sub tmp 0ul 5ul in  // g
+  let tmp2 = sub tmp 5ul 5ul in  // h
+  let tmp3 = sub tmp 10ul 5ul in // a
+  let tmp4 = sub tmp 15ul 5ul in // b
+  let tmp5 = sub tmp 20ul 5ul in // e
+  let tmp6 = sub tmp 25ul 5ul in // f
   let z1 = getz p in
   let t1 = gett p in
   let z2 = getz q in
   let t2 = gett q in
-  times_2d tmp1 t1;
-  fmul tmp2 tmp1 t2;        // tmp2 = c
-  times_2 tmp1 z1;
-  fmul tmp5 tmp1 z2;        // tmp5 = d
-  copy tmp1 tmp3; // tmp1 = a
-  copy tmp6 tmp2; // tmp6 = c
-  fdifference tmp1 tmp4; // tmp1 = e
-  fdifference tmp6 tmp5; // tmp6 = f
-  fsum tmp5 tmp2;                // tmp5 = g
-  fsum tmp4 tmp3                // tmp4 = h
+  times_2d tmp1 t1;  // tmp1 = 2 * d * t1
+  fmul tmp1 tmp1 t2; // tmp1 = tmp1 * t2 = c
 
-#pop-options
+  times_2 tmp2 z1;    // tmp2 = 2 * z1
+  fmul tmp2 tmp2 z2;  // tmp2 = tmp2 * z2 = d
+
+  fdifference tmp5 tmp4 tmp3; // tmp5 = e = b - a = tmp4 - tmp3
+  fdifference tmp6 tmp2 tmp1; // tmp6 = f = d - c = tmp2 - tmp1
+  fsum tmp1 tmp2 tmp1;        // tmp1 = g = d + c = tmp2 + tmp1
+  fsum tmp2 tmp4 tmp3         // tmp2 = h = b + a = tmp4 - tmp3
+
 
 inline_for_extraction noextract
-val point_add_:
-    out:point
-  -> p:point
-  -> q:point
-  -> tmp:lbuffer uint64 30ul ->
-  Stack unit
-    (requires fun h ->
-      live h out /\ live h p /\ live h q /\ live h tmp /\
-      disjoint tmp p /\ disjoint tmp q /\ disjoint tmp out /\
-      eq_or_disjoint p out /\ eq_or_disjoint q out /\
-      F51.point_inv_t h p /\
-      F51.point_inv_t h q
-    )
-    (ensures fun h0 _ h1 -> modifies (loc out |+| loc tmp) h0 h1 /\
-      F51.point_inv_t h1 out /\
-      F51.point_eval h1 out == Spec.Ed25519.point_add (F51.point_eval h0 p) (F51.point_eval h0 q)
-    )
+val point_add_: out:point -> p:point -> q:point -> tmp:lbuffer uint64 30ul -> Stack unit
+  (requires fun h ->
+    live h out /\ live h p /\ live h q /\ live h tmp /\
+    disjoint tmp p /\ disjoint tmp q /\ disjoint tmp out /\
+    eq_or_disjoint p out /\ eq_or_disjoint q out /\
+    F51.point_inv_t h p /\ F51.point_inv_t h q)
+  (ensures fun h0 _ h1 -> modifies (loc out |+| loc tmp) h0 h1 /\
+    F51.point_inv_t h1 out /\
+    F51.point_eval h1 out == Spec.Ed25519.point_add (F51.point_eval h0 p) (F51.point_eval h0 q))
+
 let point_add_ out p q tmp =
   point_add_step_1 p q tmp;
   point_add_step_2 p q tmp;
-  let tmp1 = sub tmp 0ul 5ul in
-  //let tmp2 = sub tmp 5ul 5ul in
-  //let tmp3 = sub tmp 10ul 5ul in
-  let tmp4 = sub tmp 15ul 5ul in
-  let tmp5 = sub tmp 20ul 5ul in
-  let tmp6 = sub tmp 25ul 5ul in
+  let tmp_g = sub tmp 0ul 5ul in
+  let tmp_h = sub tmp 5ul 5ul in
+  let tmp_e = sub tmp 20ul 5ul in
+  let tmp_f = sub tmp 25ul 5ul in
   let x3 = getx out in
   let y3 = gety out in
   let z3 = getz out in
   let t3 = gett out in
-  fmul x3 tmp1 tmp6;
-  fmul y3 tmp5 tmp4;
-  fmul t3 tmp1 tmp4;
-  fmul z3 tmp6 tmp5
+  fmul x3 tmp_e tmp_f;
+  fmul y3 tmp_g tmp_h;
+  fmul t3 tmp_e tmp_h;
+  fmul z3 tmp_f tmp_g
 
-val point_add:
-    out:point
-  -> p:point
-  -> q:point ->
-  Stack unit
-    (requires fun h ->
-      live h out /\ live h p /\ live h q /\
-      eq_or_disjoint p out /\ eq_or_disjoint q out /\
-      F51.point_inv_t h p /\
-      F51.point_inv_t h q
-      )
-    (ensures fun h0 _ h1 -> modifies (loc out) h0 h1 /\
-      F51.point_inv_t h1 out /\
-      F51.point_eval h1 out == Spec.Ed25519.point_add (F51.point_eval h0 p) (F51.point_eval h0 q)
-    )
+
+val point_add: out:point -> p:point -> q:point -> Stack unit
+  (requires fun h ->
+    live h out /\ live h p /\ live h q /\
+    eq_or_disjoint p out /\ eq_or_disjoint q out /\
+    F51.point_inv_t h p /\ F51.point_inv_t h q)
+  (ensures fun h0 _ h1 -> modifies (loc out) h0 h1 /\
+    F51.point_inv_t h1 out /\
+    F51.point_eval h1 out == Spec.Ed25519.point_add (F51.point_eval h0 p) (F51.point_eval h0 q))
 
 let point_add out p q =
   push_frame();

--- a/code/ed25519/Hacl.Impl.Ed25519.PointDouble.fst
+++ b/code/ed25519/Hacl.Impl.Ed25519.PointDouble.fst
@@ -11,156 +11,124 @@ open Hacl.Bignum25519
 module F51 = Hacl.Impl.Ed25519.Field51
 module SC = Spec.Curve25519
 
-#set-options "--z3rlimit 20 --max_fuel 0 --max_ifuel 0"
+#set-options "--z3rlimit 50 --fuel 0 --ifuel 0"
 
 inline_for_extraction noextract
-val point_double_step_1:
-    p:point
-  -> tmp:lbuffer uint64 30ul ->
-  Stack unit
-    (requires fun h -> live h p /\ live h tmp /\ disjoint p tmp /\
-      F51.point_inv_t h p
-    )
-    (ensures  fun h0 _ h1 -> modifies (loc tmp) h0 h1 /\
-      (let x1, y1, z1, t1 = F51.point_eval h0 p in
-       let a = x1 `SC.fmul` x1 in
-       let b = y1 `SC.fmul` y1 in
-       let c = 2 `SC.fmul` (z1 `SC.fmul` z1) in
-       let h = a `SC.fadd` b in
-       F51.mul_inv_t h1 (gsub tmp 0ul 5ul) /\
-       F51.mul_inv_t h1 (gsub tmp 5ul 5ul) /\
-       F51.felem_fits h1 (gsub tmp 10ul 5ul) (2, 4, 2, 2, 2) /\
-       F51.felem_fits h1 (gsub tmp 15ul 5ul) (2, 4, 2, 2, 2) /\
-       F51.fevalh h1 (gsub tmp 0ul 5ul) == a /\
-       F51.fevalh h1 (gsub tmp 5ul 5ul) == b /\
-       F51.fevalh h1 (gsub tmp 10ul 5ul) == h /\
-       F51.fevalh h1 (gsub tmp 15ul 5ul) == c
-      )
-    )
+val point_double_step_1: p:point -> tmp:lbuffer uint64 20ul -> Stack unit
+  (requires fun h ->
+    live h p /\ live h tmp /\ disjoint p tmp /\
+    F51.point_inv_t h p)
+  (ensures  fun h0 _ h1 -> modifies (loc tmp) h0 h1 /\
+    (let x1, y1, z1, t1 = F51.point_eval h0 p in
+    let a = x1 `SC.fmul` x1 in
+    let b = y1 `SC.fmul` y1 in
+    let c = 2 `SC.fmul` (z1 `SC.fmul` z1) in
+    let h = a `SC.fadd` b in
+    let g = a `SC.fsub` b in
+    F51.felem_fits h1 (gsub tmp 0ul 5ul) (2, 4, 2, 2, 2) /\
+    F51.felem_fits h1 (gsub tmp 10ul 5ul) (2, 4, 2, 2, 2) /\
+    F51.felem_fits h1 (gsub tmp 15ul 5ul) (9, 10, 9, 9, 9) /\
+    F51.fevalh h1 (gsub tmp 15ul 5ul) == g /\
+    F51.fevalh h1 (gsub tmp 10ul 5ul) == h /\
+    F51.fevalh h1 (gsub tmp 0ul 5ul) == c))
+
 let point_double_step_1 p tmp =
-  let tmp1 = sub tmp 0ul 5ul in
+  let tmp1 = sub tmp 0ul 5ul in // c
   let tmp2 = sub tmp 5ul 5ul in
-  let tmp3 = sub tmp 10ul 5ul in
-  let tmp4 = sub tmp 15ul 5ul in
-  let tmp5 = sub tmp 20ul 5ul in
-  let tmp6 = sub tmp 25ul 5ul in
+  let tmp3 = sub tmp 10ul 5ul in // h
+  let tmp4 = sub tmp 15ul 5ul in // g
   let x1 = getx p in
   let y1 = gety p in
   let z1 = getz p in
 
-  fsquare tmp1 x1; // tmp1 = a
-  fsquare tmp2 y1; // tmp2 = b
-  fsquare tmp3 z1;
-  times_2 tmp4 tmp3; // tmp4 = c
-  copy tmp3 tmp1; // tmp3 = a
-  fsum tmp3 tmp2 // tmp3 = h
+  fsquare tmp1 x1;            // tmp1 = a
+  fsquare tmp2 y1;            // tmp2 = b
+  fsum tmp3 tmp1 tmp2;        // tmp3 = tmp1 + tmp2 = h
+  fdifference tmp4 tmp1 tmp2; // tmp4 = tmp1 - tmp2 = g
 
-#push-options "--z3rlimit 50"
+  fsquare tmp1 z1;            // tmp1 = z1 * z1
+  times_2 tmp1 tmp1           // tmp1 = 2 * tmp1 = c
+
 
 inline_for_extraction noextract
-val point_double_step_2:
-    p:point
-  -> tmp:lbuffer uint64 30ul ->
-  Stack unit
-    (requires fun h -> live h p /\ live h tmp /\ disjoint p tmp /\
-      F51.point_inv_t h p /\
-       F51.mul_inv_t h (gsub tmp 0ul 5ul) /\
-       F51.mul_inv_t h (gsub tmp 5ul 5ul) /\
-       F51.felem_fits h (gsub tmp 10ul 5ul) (2, 4, 2, 2, 2) /\
-       F51.felem_fits h (gsub tmp 15ul 5ul) (2, 4, 2, 2, 2)
-    )
-    (ensures  fun h0 _ h1 -> modifies (loc tmp) h0 h1 /\
-     ( let x1, y1, z1, t1 = F51.point_eval h0 p in
-       let a = F51.fevalh h0 (gsub tmp 0ul 5ul) in
-       let b = F51.fevalh h0 (gsub tmp 5ul 5ul) in
-       let c = F51.fevalh h0 (gsub tmp 15ul 5ul) in
-       let h = F51.fevalh h0 (gsub tmp 10ul 5ul) in
-       let e = h `SC.fsub` ((x1 `SC.fadd` y1) `SC.fmul` (x1 `SC.fadd` y1)) in
-       let g = a `SC.fsub` b in
-       let f = c `SC.fadd` g in
-       F51.felem_fits h1 (gsub tmp 5ul 5ul) (9, 10, 9, 9, 9) /\
-       F51.felem_fits h1 (gsub tmp 25ul 5ul) (9, 10, 9, 9, 9) /\
-       F51.felem_fits h1 (gsub tmp 10ul 5ul) (9, 10, 9, 9, 9) /\
-       F51.felem_fits h1 (gsub tmp 15ul 5ul) (9, 10, 9, 9, 9) /\
-       F51.fevalh h1 (gsub tmp 5ul 5ul) == g /\
-       F51.fevalh h1 (gsub tmp 10ul 5ul) == h /\
-       F51.fevalh h1 (gsub tmp 15ul 5ul) == f /\
-       F51.fevalh h1 (gsub tmp 25ul 5ul) == e
-     )
-    )
+val point_double_step_2: p:point -> tmp:lbuffer uint64 20ul -> Stack unit
+  (requires fun h ->
+    live h p /\ live h tmp /\ disjoint p tmp /\
+    F51.point_inv_t h p /\
+    F51.felem_fits h (gsub tmp 10ul 5ul) (9, 10, 9, 9, 9) /\
+    F51.felem_fits h (gsub tmp 15ul 5ul) (9, 10, 9, 9, 9) /\
+    F51.felem_fits h (gsub tmp 0ul 5ul) (2, 4, 2, 2, 2))
+  (ensures  fun h0 _ h1 -> modifies (loc tmp) h0 h1 /\
+    (let x1, y1, z1, t1 = F51.point_eval h0 p in
+    let c = F51.fevalh h0 (gsub tmp 0ul 5ul) in
+    let h = F51.fevalh h0 (gsub tmp 10ul 5ul) in
+    let g = F51.fevalh h0 (gsub tmp 15ul 5ul) in
+    let e = h `SC.fsub` ((x1 `SC.fadd` y1) `SC.fmul` (x1 `SC.fadd` y1)) in
+    let f = c `SC.fadd` g in
+    F51.felem_fits h1 (gsub tmp 0ul 5ul) (9, 10, 9, 9, 9) /\
+    F51.felem_fits h1 (gsub tmp 5ul 5ul) (9, 10, 9, 9, 9) /\
+    F51.felem_fits h1 (gsub tmp 10ul 5ul) (9, 10, 9, 9, 9) /\
+    F51.felem_fits h1 (gsub tmp 15ul 5ul) (9, 10, 9, 9, 9) /\
+    F51.fevalh h1 (gsub tmp 0ul 5ul) == f /\
+    F51.fevalh h1 (gsub tmp 5ul 5ul) == e /\
+    F51.fevalh h1 (gsub tmp 10ul 5ul) == h /\
+    F51.fevalh h1 (gsub tmp 15ul 5ul) == g))
 
 let point_double_step_2 p tmp =
-  let tmp1 = sub tmp 0ul 5ul in
-  let tmp2 = sub tmp 5ul 5ul in
-  let tmp3 = sub tmp 10ul 5ul in
-  let tmp4 = sub tmp 15ul 5ul in
-  let tmp5 = sub tmp 20ul 5ul in
-  let tmp6 = sub tmp 25ul 5ul in
+  let tmp1 = sub tmp 0ul 5ul in // c, f
+  let tmp2 = sub tmp 5ul 5ul in // e
+  let tmp3 = sub tmp 10ul 5ul in // h
+  let tmp4 = sub tmp 15ul 5ul in // g
   let x1 = getx p in
   let y1 = gety p in
-  copy tmp5 x1; // tmp5 = x1
-  fsum tmp5 y1;             // tmp5 = x1 + y1
-  fsquare tmp6 tmp5;        // tmp6 = (x1 + y1) ** 2
-  copy tmp5 tmp3; // tmp5 = h
-  reduce_513 tmp5;
-  fdifference tmp6 tmp5;      // tmp6 = e
-  fdifference tmp2 tmp1;      // tmp2 = g
-  reduce_513 tmp2;
-  reduce_513 tmp4;
-  fsum tmp4 tmp2             // tmp4 = f
 
-#pop-options
+  fsum tmp2 x1 y1;            // tmp2 = x1 + y1
+  fsquare tmp2 tmp2;          // tmp2 = (x1 + y1) ** 2
+  reduce_513 tmp3;
+  fdifference tmp2 tmp3 tmp2; // tmp2 = tmp3 - tmp2 = h - (x1 + y1) ** 2 = e
+
+  reduce_513 tmp1;
+  reduce_513 tmp4;
+  fsum tmp1 tmp1 tmp4        // tmp1 = c + g = tmp1 + tmp4 = f
 
 
 inline_for_extraction noextract
-val point_double_:
-    out:point
-  -> p:point
-  -> tmp:lbuffer uint64 30ul ->
-  Stack unit
-    (requires fun h ->
-      live h out /\ live h p /\ live h tmp /\
-      eq_or_disjoint out p /\ disjoint tmp p /\ disjoint tmp out /\
-      F51.point_inv_t h p
-    )
-    (ensures fun h0 _ h1 -> modifies (loc out |+| loc tmp) h0 h1 /\
-      F51.point_inv_t h1 out /\
-      F51.point_eval h1 out == Spec.Ed25519.point_double (F51.point_eval h0 p)
-    )
+val point_double_: out:point -> p:point -> tmp:lbuffer uint64 20ul -> Stack unit
+  (requires fun h ->
+    live h out /\ live h p /\ live h tmp /\
+    eq_or_disjoint out p /\ disjoint tmp p /\ disjoint tmp out /\
+    F51.point_inv_t h p)
+  (ensures fun h0 _ h1 -> modifies (loc out |+| loc tmp) h0 h1 /\
+    F51.point_inv_t h1 out /\
+    F51.point_eval h1 out == Spec.Ed25519.point_double (F51.point_eval h0 p))
+
 let point_double_ out p tmp =
-  let tmp1 = sub tmp 0ul 5ul in
-  let tmp2 = sub tmp 5ul 5ul in
-  let tmp3 = sub tmp 10ul 5ul in
-  let tmp4 = sub tmp 15ul 5ul in
-  let tmp5 = sub tmp 20ul 5ul in
-  let tmp6 = sub tmp 25ul 5ul in
+  point_double_step_1 p tmp;
+  point_double_step_2 p tmp;
+  let tmp_f = sub tmp 0ul 5ul in
+  let tmp_e = sub tmp 5ul 5ul in
+  let tmp_h = sub tmp 10ul 5ul in
+  let tmp_g = sub tmp 15ul 5ul in
   let x3 = getx out in
   let y3 = gety out in
   let z3 = getz out in
   let t3 = gett out in
-  let h0 = ST.get()in
-  point_double_step_1 p tmp;
-  point_double_step_2 p tmp;
-  fmul x3 tmp4 tmp6;
-  fmul y3 tmp2 tmp3;
-  fmul t3 tmp6 tmp3;
-  fmul z3 tmp4 tmp2
+  fmul x3 tmp_e tmp_f;
+  fmul y3 tmp_g tmp_h;
+  fmul t3 tmp_e tmp_h;
+  fmul z3 tmp_f tmp_g
 
 
-val point_double:
-    out:point
-  -> p:point ->
-  Stack unit
-    (requires fun h -> live h out /\ live h p /\ eq_or_disjoint out p /\
-      F51.point_inv_t h p
-    )
-    (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
-      F51.point_inv_t h1 out /\
-      F51.point_eval h1 out == Spec.Ed25519.point_double (F51.point_eval h0 p)
-    )
+val point_double: out:point -> p:point -> Stack unit
+  (requires fun h ->
+    live h out /\ live h p /\ eq_or_disjoint out p /\
+    F51.point_inv_t h p)
+  (ensures  fun h0 _ h1 -> modifies (loc out) h0 h1 /\
+    F51.point_inv_t h1 out /\
+    F51.point_eval h1 out == Spec.Ed25519.point_double (F51.point_eval h0 p))
 
 let point_double out p =
   push_frame();
-  let tmp = create 30ul (u64 0) in
+  let tmp = create 20ul (u64 0) in
   point_double_ out p tmp;
   pop_frame()

--- a/code/ed25519/Hacl.Impl.Ed25519.PointNegate.fst
+++ b/code/ed25519/Hacl.Impl.Ed25519.PointNegate.fst
@@ -27,22 +27,20 @@ let point_negate p out =
   push_frame ();
   let zero = create 5ul (u64 0) in
   make_zero zero;
-  let x = sub p 0ul 5ul in
-  let y = sub p 5ul 5ul in
-  let z = sub p 10ul 5ul in
-  let t = sub p 15ul 5ul in
+  let x = getx p in
+  let y = gety p in
+  let z = getz p in
+  let t = gett p in
 
-  let x1 = sub out 0ul 5ul in
-  let y1 = sub out 5ul 5ul in
-  let z1 = sub out 10ul 5ul in
-  let t1 = sub out 15ul 5ul in
+  let x1 = getx out in
+  let y1 = gety out in
+  let z1 = getz out in
+  let t1 = gett out in
 
-  copy x1 x;
-  fdifference x1 zero;
+  fdifference x1 zero x;
   reduce_513 x1;
   copy y1 y;
   copy z1 z;
-  copy t1 t;
-  fdifference t1 zero;
+  fdifference t1 zero t;
   reduce_513 t1;
   pop_frame ()

--- a/dist/gcc-compatible/Hacl_Ed25519.c
+++ b/dist/gcc-compatible/Hacl_Ed25519.c
@@ -28,14 +28,14 @@
 #include "internal/Hacl_Hash_SHA2.h"
 #include "internal/Hacl_Curve25519_51.h"
 
-static inline void fsum(uint64_t *a, uint64_t *b)
+static inline void fsum(uint64_t *out, uint64_t *a, uint64_t *b)
 {
-  Hacl_Impl_Curve25519_Field51_fadd(a, a, b);
+  Hacl_Impl_Curve25519_Field51_fadd(out, a, b);
 }
 
-static inline void fdifference(uint64_t *a, uint64_t *b)
+static inline void fdifference(uint64_t *out, uint64_t *a, uint64_t *b)
 {
-  Hacl_Impl_Curve25519_Field51_fsub(a, b, a);
+  Hacl_Impl_Curve25519_Field51_fsub(out, a, b);
 }
 
 void Hacl_Bignum25519_reduce_513(uint64_t *a)
@@ -239,50 +239,45 @@ void Hacl_Bignum25519_store_51(uint8_t *output, uint64_t *input)
 
 void Hacl_Impl_Ed25519_PointDouble_point_double(uint64_t *out, uint64_t *p)
 {
-  uint64_t tmp[30U] = { 0U };
+  uint64_t tmp[20U] = { 0U };
+  uint64_t *tmp1 = tmp;
+  uint64_t *tmp20 = tmp + (uint32_t)5U;
+  uint64_t *tmp30 = tmp + (uint32_t)10U;
+  uint64_t *tmp40 = tmp + (uint32_t)15U;
+  uint64_t *x10 = p;
+  uint64_t *y10 = p + (uint32_t)5U;
+  uint64_t *z1 = p + (uint32_t)10U;
+  fsquare(tmp1, x10);
+  fsquare(tmp20, y10);
+  fsum(tmp30, tmp1, tmp20);
+  fdifference(tmp40, tmp1, tmp20);
+  fsquare(tmp1, z1);
+  times_2(tmp1, tmp1);
+  uint64_t *tmp10 = tmp;
   uint64_t *tmp2 = tmp + (uint32_t)5U;
   uint64_t *tmp3 = tmp + (uint32_t)10U;
   uint64_t *tmp4 = tmp + (uint32_t)15U;
-  uint64_t *tmp6 = tmp + (uint32_t)25U;
+  uint64_t *x1 = p;
+  uint64_t *y1 = p + (uint32_t)5U;
+  fsum(tmp2, x1, y1);
+  fsquare(tmp2, tmp2);
+  Hacl_Bignum25519_reduce_513(tmp3);
+  fdifference(tmp2, tmp3, tmp2);
+  Hacl_Bignum25519_reduce_513(tmp10);
+  Hacl_Bignum25519_reduce_513(tmp4);
+  fsum(tmp10, tmp10, tmp4);
+  uint64_t *tmp_f = tmp;
+  uint64_t *tmp_e = tmp + (uint32_t)5U;
+  uint64_t *tmp_h = tmp + (uint32_t)10U;
+  uint64_t *tmp_g = tmp + (uint32_t)15U;
   uint64_t *x3 = out;
   uint64_t *y3 = out + (uint32_t)5U;
   uint64_t *z3 = out + (uint32_t)10U;
   uint64_t *t3 = out + (uint32_t)15U;
-  uint64_t *tmp11 = tmp;
-  uint64_t *tmp210 = tmp + (uint32_t)5U;
-  uint64_t *tmp310 = tmp + (uint32_t)10U;
-  uint64_t *tmp410 = tmp + (uint32_t)15U;
-  uint64_t *x10 = p;
-  uint64_t *y10 = p + (uint32_t)5U;
-  uint64_t *z1 = p + (uint32_t)10U;
-  fsquare(tmp11, x10);
-  fsquare(tmp210, y10);
-  fsquare(tmp310, z1);
-  times_2(tmp410, tmp310);
-  memcpy(tmp310, tmp11, (uint32_t)5U * sizeof (uint64_t));
-  fsum(tmp310, tmp210);
-  uint64_t *tmp110 = tmp;
-  uint64_t *tmp21 = tmp + (uint32_t)5U;
-  uint64_t *tmp31 = tmp + (uint32_t)10U;
-  uint64_t *tmp41 = tmp + (uint32_t)15U;
-  uint64_t *tmp51 = tmp + (uint32_t)20U;
-  uint64_t *tmp61 = tmp + (uint32_t)25U;
-  uint64_t *x1 = p;
-  uint64_t *y1 = p + (uint32_t)5U;
-  memcpy(tmp51, x1, (uint32_t)5U * sizeof (uint64_t));
-  fsum(tmp51, y1);
-  fsquare(tmp61, tmp51);
-  memcpy(tmp51, tmp31, (uint32_t)5U * sizeof (uint64_t));
-  Hacl_Bignum25519_reduce_513(tmp51);
-  fdifference(tmp61, tmp51);
-  fdifference(tmp21, tmp110);
-  Hacl_Bignum25519_reduce_513(tmp21);
-  Hacl_Bignum25519_reduce_513(tmp41);
-  fsum(tmp41, tmp21);
-  fmul0(x3, tmp4, tmp6);
-  fmul0(y3, tmp2, tmp3);
-  fmul0(t3, tmp6, tmp3);
-  fmul0(z3, tmp4, tmp2);
+  fmul0(x3, tmp_e, tmp_f);
+  fmul0(y3, tmp_g, tmp_h);
+  fmul0(t3, tmp_e, tmp_h);
+  fmul0(z3, tmp_f, tmp_g);
 }
 
 static inline void pow2_252m2(uint64_t *out, uint64_t *z)
@@ -350,7 +345,7 @@ static inline void mul_modp_sqrt_m1(uint64_t *x)
 
 static inline bool recover_x(uint64_t *x, uint64_t *y, uint64_t sign)
 {
-  uint64_t tmp[20U] = { 0U };
+  uint64_t tmp[15U] = { 0U };
   uint64_t *x2 = tmp;
   uint64_t x00 = y[0U];
   uint64_t x1 = y[1U];
@@ -372,7 +367,7 @@ static inline bool recover_x(uint64_t *x, uint64_t *y, uint64_t sign)
   }
   else
   {
-    uint64_t tmp1[25U] = { 0U };
+    uint64_t tmp1[20U] = { 0U };
     uint64_t *one = tmp1;
     uint64_t *y2 = tmp1 + (uint32_t)5U;
     uint64_t *dyyi = tmp1 + (uint32_t)10U;
@@ -384,11 +379,11 @@ static inline bool recover_x(uint64_t *x, uint64_t *y, uint64_t sign)
     one[4U] = (uint64_t)0U;
     fsquare(y2, y);
     times_d(dyy, y2);
-    fsum(dyy, one);
+    fsum(dyy, dyy, one);
     Hacl_Bignum25519_reduce_513(dyy);
     Hacl_Bignum25519_inverse(dyyi, dyy);
-    fdifference(one, y2);
-    fmul0(x2, one, dyyi);
+    fdifference(x2, y2, one);
+    fmul0(x2, x2, dyyi);
     reduce(x2);
     bool x2_is_0 = is_0(x2);
     uint8_t z;
@@ -425,28 +420,24 @@ static inline bool recover_x(uint64_t *x, uint64_t *y, uint64_t sign)
       uint64_t *x210 = tmp;
       uint64_t *x31 = tmp + (uint32_t)5U;
       uint64_t *t00 = tmp + (uint32_t)10U;
-      uint64_t *t10 = tmp + (uint32_t)15U;
       pow2_252m2(x31, x210);
       fsquare(t00, x31);
-      memcpy(t10, x210, (uint32_t)5U * sizeof (uint64_t));
-      fdifference(t10, t00);
-      Hacl_Bignum25519_reduce_513(t10);
-      reduce(t10);
-      bool t1_is_0 = is_0(t10);
-      if (!t1_is_0)
+      fdifference(t00, t00, x210);
+      Hacl_Bignum25519_reduce_513(t00);
+      reduce(t00);
+      bool t0_is_0 = is_0(t00);
+      if (!t0_is_0)
       {
         mul_modp_sqrt_m1(x31);
       }
       uint64_t *x211 = tmp;
       uint64_t *x3 = tmp + (uint32_t)5U;
       uint64_t *t01 = tmp + (uint32_t)10U;
-      uint64_t *t1 = tmp + (uint32_t)15U;
       fsquare(t01, x3);
-      memcpy(t1, x211, (uint32_t)5U * sizeof (uint64_t));
-      fdifference(t1, t01);
-      Hacl_Bignum25519_reduce_513(t1);
-      reduce(t1);
-      bool z1 = is_0(t1);
+      fdifference(t01, t01, x211);
+      Hacl_Bignum25519_reduce_513(t01);
+      reduce(t01);
+      bool z1 = is_0(t01);
       if (z1 == false)
       {
         res = false;
@@ -465,7 +456,7 @@ static inline bool recover_x(uint64_t *x, uint64_t *y, uint64_t sign)
           t0[2U] = (uint64_t)0U;
           t0[3U] = (uint64_t)0U;
           t0[4U] = (uint64_t)0U;
-          fdifference(x32, t0);
+          fdifference(x32, t0, x32);
           Hacl_Bignum25519_reduce_513(x32);
           reduce(x32);
         }
@@ -1218,48 +1209,42 @@ void Hacl_Impl_Ed25519_PointAdd_point_add(uint64_t *out, uint64_t *p, uint64_t *
   uint64_t *y1 = p + (uint32_t)5U;
   uint64_t *x2 = q;
   uint64_t *y2 = q + (uint32_t)5U;
-  memcpy(tmp1, x1, (uint32_t)5U * sizeof (uint64_t));
-  memcpy(tmp20, x2, (uint32_t)5U * sizeof (uint64_t));
-  fdifference(tmp1, y1);
-  fdifference(tmp20, y2);
+  fdifference(tmp1, y1, x1);
+  fdifference(tmp20, y2, x2);
   fmul0(tmp30, tmp1, tmp20);
-  memcpy(tmp1, y1, (uint32_t)5U * sizeof (uint64_t));
-  memcpy(tmp20, y2, (uint32_t)5U * sizeof (uint64_t));
-  fsum(tmp1, x1);
-  fsum(tmp20, x2);
+  fsum(tmp1, y1, x1);
+  fsum(tmp20, y2, x2);
   fmul0(tmp40, tmp1, tmp20);
   uint64_t *tmp10 = tmp;
   uint64_t *tmp2 = tmp + (uint32_t)5U;
   uint64_t *tmp3 = tmp + (uint32_t)10U;
-  uint64_t *tmp41 = tmp + (uint32_t)15U;
-  uint64_t *tmp50 = tmp + (uint32_t)20U;
-  uint64_t *tmp60 = tmp + (uint32_t)25U;
+  uint64_t *tmp4 = tmp + (uint32_t)15U;
+  uint64_t *tmp5 = tmp + (uint32_t)20U;
+  uint64_t *tmp6 = tmp + (uint32_t)25U;
   uint64_t *z1 = p + (uint32_t)10U;
   uint64_t *t1 = p + (uint32_t)15U;
   uint64_t *z2 = q + (uint32_t)10U;
   uint64_t *t2 = q + (uint32_t)15U;
   times_2d(tmp10, t1);
-  fmul0(tmp2, tmp10, t2);
-  times_2(tmp10, z1);
-  fmul0(tmp50, tmp10, z2);
-  memcpy(tmp10, tmp3, (uint32_t)5U * sizeof (uint64_t));
-  memcpy(tmp60, tmp2, (uint32_t)5U * sizeof (uint64_t));
-  fdifference(tmp10, tmp41);
-  fdifference(tmp60, tmp50);
-  fsum(tmp50, tmp2);
-  fsum(tmp41, tmp3);
-  uint64_t *tmp11 = tmp;
-  uint64_t *tmp4 = tmp + (uint32_t)15U;
-  uint64_t *tmp5 = tmp + (uint32_t)20U;
-  uint64_t *tmp6 = tmp + (uint32_t)25U;
+  fmul0(tmp10, tmp10, t2);
+  times_2(tmp2, z1);
+  fmul0(tmp2, tmp2, z2);
+  fdifference(tmp5, tmp4, tmp3);
+  fdifference(tmp6, tmp2, tmp10);
+  fsum(tmp10, tmp2, tmp10);
+  fsum(tmp2, tmp4, tmp3);
+  uint64_t *tmp_g = tmp;
+  uint64_t *tmp_h = tmp + (uint32_t)5U;
+  uint64_t *tmp_e = tmp + (uint32_t)20U;
+  uint64_t *tmp_f = tmp + (uint32_t)25U;
   uint64_t *x3 = out;
   uint64_t *y3 = out + (uint32_t)5U;
   uint64_t *z3 = out + (uint32_t)10U;
   uint64_t *t3 = out + (uint32_t)15U;
-  fmul0(x3, tmp11, tmp6);
-  fmul0(y3, tmp5, tmp4);
-  fmul0(t3, tmp11, tmp4);
-  fmul0(z3, tmp6, tmp5);
+  fmul0(x3, tmp_e, tmp_f);
+  fmul0(y3, tmp_g, tmp_h);
+  fmul0(t3, tmp_e, tmp_h);
+  fmul0(z3, tmp_f, tmp_g);
 }
 
 void Hacl_Impl_Ed25519_PointNegate_point_negate(uint64_t *p, uint64_t *out)
@@ -1278,13 +1263,11 @@ void Hacl_Impl_Ed25519_PointNegate_point_negate(uint64_t *p, uint64_t *out)
   uint64_t *y1 = out + (uint32_t)5U;
   uint64_t *z1 = out + (uint32_t)10U;
   uint64_t *t1 = out + (uint32_t)15U;
-  memcpy(x1, x, (uint32_t)5U * sizeof (uint64_t));
-  fdifference(x1, zero);
+  fdifference(x1, zero, x);
   Hacl_Bignum25519_reduce_513(x1);
   memcpy(y1, y, (uint32_t)5U * sizeof (uint64_t));
   memcpy(z1, z, (uint32_t)5U * sizeof (uint64_t));
-  memcpy(t1, t, (uint32_t)5U * sizeof (uint64_t));
-  fdifference(t1, zero);
+  fdifference(t1, zero, t);
   Hacl_Bignum25519_reduce_513(t1);
 }
 

--- a/tests/ed25519-test.c
+++ b/tests/ed25519-test.c
@@ -1,0 +1,127 @@
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <time.h>
+
+#include "Hacl_Ed25519.h"
+
+#include "test_helpers.h"
+
+#define ROUNDS 32768
+
+static uint8_t msg3[2U] = { (uint8_t)0xafU, (uint8_t)0x82U };
+
+static uint8_t sk3[32U] = {
+    (uint8_t)0xc5U, (uint8_t)0xaaU, (uint8_t)0x8dU, (uint8_t)0xf4U, (uint8_t)0x3fU, (uint8_t)0x9fU,
+    (uint8_t)0x83U, (uint8_t)0x7bU, (uint8_t)0xedU, (uint8_t)0xb7U, (uint8_t)0x44U, (uint8_t)0x2fU,
+    (uint8_t)0x31U, (uint8_t)0xdcU, (uint8_t)0xb7U, (uint8_t)0xb1U, (uint8_t)0x66U, (uint8_t)0xd3U,
+    (uint8_t)0x85U, (uint8_t)0x35U, (uint8_t)0x07U, (uint8_t)0x6fU, (uint8_t)0x09U, (uint8_t)0x4bU,
+    (uint8_t)0x85U, (uint8_t)0xceU, (uint8_t)0x3aU, (uint8_t)0x2eU, (uint8_t)0x0bU, (uint8_t)0x44U,
+    (uint8_t)0x58U, (uint8_t)0xf7U };
+
+static uint8_t pk3[32U] = {
+    (uint8_t)0xfcU, (uint8_t)0x51U, (uint8_t)0xcdU, (uint8_t)0x8eU, (uint8_t)0x62U, (uint8_t)0x18U,
+    (uint8_t)0xa1U, (uint8_t)0xa3U, (uint8_t)0x8dU, (uint8_t)0xa4U, (uint8_t)0x7eU, (uint8_t)0xd0U,
+    (uint8_t)0x02U, (uint8_t)0x30U, (uint8_t)0xf0U, (uint8_t)0x58U, (uint8_t)0x08U, (uint8_t)0x16U,
+    (uint8_t)0xedU, (uint8_t)0x13U, (uint8_t)0xbaU, (uint8_t)0x33U, (uint8_t)0x03U, (uint8_t)0xacU,
+    (uint8_t)0x5dU, (uint8_t)0xebU, (uint8_t)0x91U, (uint8_t)0x15U, (uint8_t)0x48U, (uint8_t)0x90U,
+    (uint8_t)0x80U, (uint8_t)0x25U };
+
+static uint8_t sig3[64U] = {
+    (uint8_t)0x62U, (uint8_t)0x91U, (uint8_t)0xd6U, (uint8_t)0x57U, (uint8_t)0xdeU, (uint8_t)0xecU,
+    (uint8_t)0x24U, (uint8_t)0x02U, (uint8_t)0x48U, (uint8_t)0x27U, (uint8_t)0xe6U, (uint8_t)0x9cU,
+    (uint8_t)0x3aU, (uint8_t)0xbeU, (uint8_t)0x01U, (uint8_t)0xa3U, (uint8_t)0x0cU, (uint8_t)0xe5U,
+    (uint8_t)0x48U, (uint8_t)0xa2U, (uint8_t)0x84U, (uint8_t)0x74U, (uint8_t)0x3aU, (uint8_t)0x44U,
+    (uint8_t)0x5eU, (uint8_t)0x36U, (uint8_t)0x80U, (uint8_t)0xd7U, (uint8_t)0xdbU, (uint8_t)0x5aU,
+    (uint8_t)0xc3U, (uint8_t)0xacU, (uint8_t)0x18U, (uint8_t)0xffU, (uint8_t)0x9bU, (uint8_t)0x53U,
+    (uint8_t)0x8dU, (uint8_t)0x16U, (uint8_t)0xf2U, (uint8_t)0x90U, (uint8_t)0xaeU, (uint8_t)0x67U,
+    (uint8_t)0xf7U, (uint8_t)0x60U, (uint8_t)0x98U, (uint8_t)0x4dU, (uint8_t)0xc6U, (uint8_t)0x59U,
+    (uint8_t)0x4aU, (uint8_t)0x7cU, (uint8_t)0x15U, (uint8_t)0xe9U, (uint8_t)0x71U, (uint8_t)0x6eU,
+    (uint8_t)0xd2U, (uint8_t)0x8dU, (uint8_t)0xc0U, (uint8_t)0x27U, (uint8_t)0xbeU, (uint8_t)0xceU,
+    (uint8_t)0xeaU, (uint8_t)0x1eU, (uint8_t)0xc4U, (uint8_t)0x0aU };
+
+
+int main() {
+  bool ok = true;
+  uint8_t signature[64U] = { 0U };
+  uint8_t signature1[64U] = { 0U };
+  uint8_t expanded_keys[96U] = { 0U };
+
+  Hacl_Ed25519_sign(signature, sk3, 2ul, msg3);
+  ok &= compare(64U, signature, sig3);
+  ok &= Hacl_Ed25519_verify(pk3, 2ul, msg3, sig3);
+
+  Hacl_Ed25519_expand_keys(expanded_keys, sk3);
+  Hacl_Ed25519_sign_expanded(signature1, expanded_keys, 2ul, msg3);
+  ok &= compare(64U, signature1, sig3);
+
+  if (ok)
+    printf ("\n Success :) \n");
+  else
+    printf ("\n Failed :( \n");
+
+  // Benchmarking for signing (HACL)
+  for (int j = 0; j < ROUNDS; j++) {
+    Hacl_Ed25519_sign(signature, sk3, 2ul, msg3);
+  }
+
+  cycles a,b;
+  clock_t t1,t2;
+  t1 = clock();
+  a = cpucycles_begin();
+  for (int j = 0; j < ROUNDS; j++) {
+    Hacl_Ed25519_sign(signature, sk3, 2ul, msg3);
+  }
+  b = cpucycles_end();
+  t2 = clock();
+  double diff1 = t2 - t1;
+  uint64_t cyc1 = b - a;
+
+  // Benchmarking for verifying (HACL)
+  bool b1 = true;
+  for (int j = 0; j < ROUNDS; j++) {
+    b1 &= Hacl_Ed25519_verify(pk3, 2ul, msg3, sig3);
+  }
+
+  t1 = clock();
+  a = cpucycles_begin();
+  for (int j = 0; j < ROUNDS; j++) {
+    b1 &= Hacl_Ed25519_verify(pk3, 2ul, msg3, sig3);
+  }
+  b = cpucycles_end();
+  t2 = clock();
+  double diff2 = t2 - t1;
+  uint64_t cyc2 = b - a;
+
+  // Benchmarking for signing with expanded keys (HACL)
+  for (int j = 0; j < ROUNDS; j++) {
+    Hacl_Ed25519_sign_expanded(signature1, expanded_keys, 2ul, msg3);
+  }
+
+  t1 = clock();
+  a = cpucycles_begin();
+  for (int j = 0; j < ROUNDS; j++) {
+    Hacl_Ed25519_sign_expanded(signature1, expanded_keys, 2ul, msg3);
+  }
+  b = cpucycles_end();
+  t2 = clock();
+  double diff3 = t2 - t1;
+  uint64_t cyc3 = b - a;
+
+  uint64_t count = ROUNDS;
+  printf("\n Ed25519 Signing:\n");
+  print_time(count,diff1,cyc1);
+  printf("\n Ed25519 Verifying:\n");
+  print_time(count,diff2,cyc2);
+  printf("\n Ed25519 Signing with expanded keys:\n");
+  print_time(count,diff3,cyc3);
+
+  if (ok) return EXIT_SUCCESS;
+  else return EXIT_FAILURE;
+}


### PR DESCRIPTION
This PR changes the signature of the local `fsum` and `fdifference` functions to avoid extra copies.

It also improves a bit the speed (~3%):
```
this PR:
 Ed25519 Signing: 398153 cycles
 Ed25519 Verifying: 229060 cycles
 Ed25519 Signing with expanded keys: 199360 cycles

main:
 Ed25519 Signing: 409960 cycles
 Ed25519 Verifying: 233563 cycles
 Ed25519 Signing with expanded keys: 206210 cycles

R_sign = 409960/398153 = 1.029
R_verify = 233563/229060 = 1.019
R_expand = 206210/199360 = 1.034
```