### PR TITLE
JS: published hacl-wasm 1.2.0

### DIFF
--- a/bindings/js/.npmignore
+++ b/bindings/js/.npmignore
@@ -1,1 +1,3 @@
 doc/
+Makefile*
+test.html

--- a/bindings/js/Makefile
+++ b/bindings/js/Makefile
@@ -14,5 +14,7 @@ endif
 all:
 	cp $(KRML_HOME)/krmllib/js/loader.js .
 	cp ../../dist/wasm/*.{wasm,js,html} .
+	cp ../../dist/wasm/layouts.json .
+
 	node api_test.js
 	node test2.js

--- a/bindings/js/package-lock.json
+++ b/bindings/js/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "hacl-wasm",
-  "version": "1.1.0",
-  "lockfileVersion": 1
+  "version": "1.2.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hacl-wasm",
+      "version": "1.2.0",
+      "license": "Apache-2.0"
+    }
+  }
 }

--- a/bindings/js/package.json
+++ b/bindings/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacl-wasm",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Javascript bindings for the KaRaMeL-extracted WebAssembly version of the HACL* cryptographic library",
   "main": "api.js",
   "directories": {


### PR DESCRIPTION
Small changes made to publish the [hacl-wasm npm package](https://www.npmjs.com/package/hacl-wasm)