### PR TITLE
Use shell pwd for HACL_HOME in Makefile.common

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -8,7 +8,7 @@ define newline
 
 endef
 
-HACL_HOME 	?= .
+HACL_HOME 	?= $(shell pwd)
 
 # Put your local configuration (e.g. HACL_HOME, KRML_HOME, etc.) in
 # Makefile.config


### PR DESCRIPTION
See the discussion in #682 for the rationale of this change.

Fixes #682 