### PR TITLE
Some changes for the core type checker branch in F*

### DIFF
--- a/code/meta/Meta.Interface.fst
+++ b/code/meta/Meta.Interface.fst
@@ -263,11 +263,7 @@ let rec visit_function (t_i: term) (st: state) (f_name: name): Tac (state & list
               fail (string_of_name f_name ^ "is expected to be a function!")
         in
 
-        let inv_bv: bv = pack_bv ({
-          bv_ppname = "p";
-          bv_index = 355;
-          bv_sort = `Type0;
-        }) in
+        let inv_bv: bv = fresh_bv_named "p" (`Type0) in
 
         let st, new_body, new_args, new_sigelts =
           match index_bv with
@@ -404,11 +400,7 @@ let rec visit_function (t_i: term) (st: state) (f_name: name): Tac (state & list
 
       | _ ->
           if has_attr f (`Meta.Attribute.specialize) then
-            let inv_bv: bv = pack_bv ({
-              bv_ppname = "p";
-              bv_index = 355;
-              bv_sort = `Type0;
-            }) in
+            let inv_bv: bv = fresh_bv_named "p" (`Type0) in
 
             // Assuming that this is a val, but we can't inspect it. Let's work around this.
             let t = pack (Tv_FVar (pack_fv f_name)) in
@@ -517,11 +509,7 @@ and visit_body (t_i: term)
                       if needs_index then pack (Tv_App typ (must index_arg, Q_Implicit)) else typ
                     in
                     let typ = pack (Tv_App typ (inv_bv, Q_Explicit)) in
-                    let bv: bv = pack_bv ({
-                      bv_ppname = "arg_" ^ string_of_name name;
-                      bv_index = 42;
-                      bv_sort = typ
-                    }) in
+                    let bv: bv = fresh_bv_named ("arg_" ^ string_of_name name) typ in
                     (pack (Tv_Var bv), Q_Explicit), (name, bv) :: bvs
               in
 

--- a/hints/Hacl.Bignum.fsti.hints
+++ b/hints/Hacl.Bignum.fsti.hints
@@ -19,7 +19,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "d0d07a93ee3f5e8cc42f56e72f528709"
+      "b5aa668c460c06e9e0a12cc7bc9dff26"
     ],
     [
       "Hacl.Bignum.bn_sub1",
@@ -39,7 +39,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "993aff2454eff85c7915b9863b7f30f9"
+      "c1e281855dabd57d3a7533fa016cd47b"
     ],
     [
       "Hacl.Bignum.bn_add_eq_len_st",
@@ -65,7 +65,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "f3223b496c3d375f6dee3f550c2415b8"
+      "dd14c4605dd4472dd3745e5ab613965b"
     ],
     [
       "Hacl.Bignum.bn_sub_eq_len_st",
@@ -91,7 +91,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0e13f233c9a7a96bdfbdacc9d372db33"
+      "1c5bed6ccc564177cce1db6a7d8457ae"
     ],
     [
       "Hacl.Bignum.bn_add_st",
@@ -119,7 +119,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "59bd38540ad43594522d00af73c11bf4"
+      "dc0c9a87e21ded5737295a1b9e131ea7"
     ],
     [
       "Hacl.Bignum.bn_sub_st",
@@ -147,7 +147,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "561b31ca01f0c4b845a46c536b1bfd74"
+      "f37c95776726f02bd0c1f490c9a8c3c1"
     ],
     [
       "Hacl.Bignum.bn_reduce_once",
@@ -167,7 +167,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "5f444f58b55fd2c6fdb1f33ff6d762c0"
+      "fb8b5b2000544fa119b103c20965d3b6"
     ],
     [
       "Hacl.Bignum.bn_add_mod_n_st",
@@ -187,7 +187,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "918eb69ceebe5ac3fc8110b8974a7e8e"
+      "837aebe86c28aa7008a0d8ac440d5028"
     ],
     [
       "Hacl.Bignum.bn_sub_mod_n_st",
@@ -207,7 +207,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "9b6f287a47e78dc5bd73bf0835ec1d33"
+      "41295f7830df65e19a4d0d1e1213f4ab"
     ],
     [
       "Hacl.Bignum.bn_mul1",
@@ -233,7 +233,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "3264c9e830d51ec218e3911e5f787025"
+      "a8c5b21ab98b6ba27eb93c0e78a5513a"
     ],
     [
       "Hacl.Bignum.bn_karatsuba_mul_st",
@@ -256,7 +256,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "79b74cc79d44d92164e6bac92aae3cd1"
+      "9574dbd814428c2bed4fcc034fd5c6d1"
     ],
     [
       "Hacl.Bignum.bn_mul_st",
@@ -297,7 +297,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "9d22a7bb0406c80b54a44c8b71e71521"
+      "4c793f81945235116e3193170fe65c82"
     ],
     [
       "Hacl.Bignum.bn_karatsuba_sqr_st",
@@ -320,7 +320,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "a4075a02e38e48a07f013a28b8eda061"
+      "e56788a2e28e7fe641b5df84e8e6e32b"
     ],
     [
       "Hacl.Bignum.bn_sqr_st",
@@ -342,7 +342,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "8f7643e724732ea5ca8e93de2eb4597f"
+      "758e25420ee6d3eb3f7048916a52f031"
     ],
     [
       "Hacl.Bignum.bn_mul1_lshift_add_in_place",
@@ -371,7 +371,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0dbce05bfba4b0f4f3d4c1c870682dd1"
+      "704ceba0cc370c3fa978a6eb4d387d34"
     ],
     [
       "Hacl.Bignum.bn_rshift",
@@ -411,7 +411,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "7e3f62207a4cf770a81ca6450a557575"
+      "d0374f14afa2c1778804c2f6b6758f7b"
     ],
     [
       "Hacl.Bignum.bn_sub_mask",
@@ -431,7 +431,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "c1a20a0dcc2b43182254f7cf20059163"
+      "60abd5b34536e196abbd4ded73aa24b2"
     ],
     [
       "Hacl.Bignum.bn_get_ith_bit",
@@ -472,7 +472,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "e0d2a4e3c2edc37fa7a081c0e2342b90"
+      "b6e832bafc15a78efa8920f7f2ef3f5b"
     ],
     [
       "Hacl.Bignum.bn_get_bits",
@@ -510,7 +510,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "4ae8036287206d75a20c92da3455a296"
+      "3d4292d397f500baa032d68187cc27d9"
     ],
     [
       "Hacl.Bignum.bn_set_ith_bit",
@@ -551,7 +551,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "df2e32ed32b1889b6b860d84da69900a"
+      "5913c68fc324ac3c3a5d0f91a287e931"
     ],
     [
       "Hacl.Bignum.cswap2",
@@ -577,7 +577,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "069443fd8e5e1390008a46fe9431f8b6"
+      "5dd2f51e32f939c98a586254319a99bb"
     ],
     [
       "Hacl.Bignum.bn",
@@ -612,7 +612,7 @@
         "typing_Lib.IntTypes.bits", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "07e53d6c37fe2eb46ffa13e281af607d"
+      "d94050612f499da0609cec4b625f9f76"
     ],
     [
       "Hacl.Bignum.__proj__Mkbn__item__add_mod_n",
@@ -621,7 +621,7 @@
       0,
       [ "@query" ],
       0,
-      "2105966e289acc716f67477862d2754e"
+      "8a64600b611ca50279611464ad3d620b"
     ],
     [
       "Hacl.Bignum.__proj__Mkbn__item__add_mod_n",
@@ -636,7 +636,7 @@
         "refinement_interpretation_Tm_refine_e0ab8a8974e5b3a9101c38b7001ed683"
       ],
       0,
-      "d53b93f1e285767f24700002baeffd9c"
+      "9e8bee79685808ead1355179eadd4793"
     ],
     [
       "Hacl.Bignum.__proj__Mkbn__item__sub_mod_n",
@@ -645,7 +645,7 @@
       0,
       [ "@query" ],
       0,
-      "a9f52c36696e2050c5ab6f27bd76f4e6"
+      "90e26eb8b69e2c0644c2bdb4c95dbc82"
     ],
     [
       "Hacl.Bignum.__proj__Mkbn__item__sub_mod_n",
@@ -660,7 +660,7 @@
         "refinement_interpretation_Tm_refine_e0ab8a8974e5b3a9101c38b7001ed683"
       ],
       0,
-      "84337efd0030b3a656c45b3a4314c047"
+      "5af3b9a164f35a41d18247790e04c9c3"
     ],
     [
       "Hacl.Bignum.__proj__Mkbn__item__mul",
@@ -691,7 +691,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "28d99ee5fbc7a539ba542bbcf4add900"
+      "493bc9e20ab57548ed4e037ec51999a6"
     ],
     [
       "Hacl.Bignum.__proj__Mkbn__item__mul",
@@ -728,7 +728,7 @@
         "typing_Lib.IntTypes.bits", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "27491155cd102884e248d7e376740d7b"
+      "6f6fa21b712e76ec91f32d2724989a9c"
     ],
     [
       "Hacl.Bignum.__proj__Mkbn__item__sqr",
@@ -759,7 +759,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "44d376e3287d5dde2c2391f6a465e77c"
+      "4f54581c4ec11d0fc8b7cfea810de2f0"
     ],
     [
       "Hacl.Bignum.__proj__Mkbn__item__sqr",
@@ -794,7 +794,7 @@
         "typing_Lib.IntTypes.bits", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "d0100ec44041cb9540e3211b7ff41e5d"
+      "b36f8ab803e42513e245532a01f2e2f4"
     ],
     [
       "Hacl.Bignum.bn_is_odd",
@@ -811,7 +811,7 @@
         "refinement_interpretation_Tm_refine_cfc41488cee641ca406ae764563b3947"
       ],
       0,
-      "f606f97af2481a81e14753c0448f87fa"
+      "7efbc6db0543ee3fb21e5749a7ff8a09"
     ],
     [
       "Hacl.Bignum.bn_eq_mask_st",
@@ -837,7 +837,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "4608b0119bf657e0ce6df87968ef62fe"
+      "dac8b384b49c04c313955592465c0437"
     ],
     [
       "Hacl.Bignum.bn_is_zero_mask",
@@ -854,7 +854,7 @@
         "refinement_interpretation_Tm_refine_cfc41488cee641ca406ae764563b3947"
       ],
       0,
-      "ee5ff5de4a8e60bf07a6588f790b5efd"
+      "28a9eb7107f801caecd158130e6dfef3"
     ],
     [
       "Hacl.Bignum.bn_lt_mask_st",
@@ -880,7 +880,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "db4ebb530c6cdf2be6175cbb7db4d780"
+      "28c09c4b14fae23b5e702c9f9ff7e73b"
     ],
     [
       "Hacl.Bignum.bn_lt_pow2_mask",
@@ -903,7 +903,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "555c71c0691b8dd985de327c6b29f838"
+      "797cb0eaa9394e4aa52a375a1d4ec2d5"
     ],
     [
       "Hacl.Bignum.bn_gt_pow2_mask",
@@ -926,7 +926,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0310eb7ecac42dbb27463a21c9ba3753"
+      "72cbba3c1f5b415b6de1199711cdb7b7"
     ],
     [
       "Hacl.Bignum.bn_from_uint",
@@ -946,7 +946,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "f74d9f98c4994f511c7d2e3b45425681"
+      "8e4bfd2b817df0a09b0bdacc61eff312"
     ],
     [
       "Hacl.Bignum.bn_from_bytes_be",
@@ -997,7 +997,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "99af1a4efe2f2026b8b74328d8efbc99"
+      "8f2ccb319c213951a29f620fd6e65dd9"
     ],
     [
       "Hacl.Bignum.bn_to_bytes_be",
@@ -1041,7 +1041,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "5d9d684e035e557d7d7363f4803f5330"
+      "17d1a07363d3e1221bc27f76da4343d7"
     ],
     [
       "Hacl.Bignum.bn_from_bytes_le",
@@ -1092,7 +1092,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "9aafee0a3cc8ff2bb4f8cbc76073c5c2"
+      "c2d2c93be329b59daf8c95bf9018351c"
     ],
     [
       "Hacl.Bignum.bn_to_bytes_le",
@@ -1136,7 +1136,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "b3190e15523c18793e992ad3a8a567b3"
+      "0010b145cf87ee6ce920f04ef5d54027"
     ]
   ]
 ]

--- a/hints/Hacl.Impl.Exponentiation.Definitions.fst.hints
+++ b/hints/Hacl.Impl.Exponentiation.Definitions.fst.hints
@@ -8,7 +8,7 @@
       0,
       [ "@query", "assumption_Lib.IntTypes.inttype__uu___haseq" ],
       0,
-      "e40304694af9828158adc0658eb72f24"
+      "5165469c52100e42955eca33073cd024"
     ],
     [
       "Hacl.Impl.Exponentiation.Definitions.to_comm_monoid",
@@ -41,7 +41,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "9474d4a4ac266582c93a1675a2e67a34"
+      "27e6730a6caed02c10391d1d1525ff5b"
     ],
     [
       "Hacl.Impl.Exponentiation.Definitions.__proj__Mkto_comm_monoid__item__linv_ctx",
@@ -74,7 +74,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "f234635adc0829eaaae3562822e6e608"
+      "c866748e14ad438f3977eb03b8f54d8e"
     ],
     [
       "Hacl.Impl.Exponentiation.Definitions.__proj__Mkto_comm_monoid__item__linv_ctx",
@@ -106,7 +106,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "6a798cafee32d2d878edb5edf68e2feb"
+      "b47edb16ae95d30027e497fdbf28e4b8"
     ],
     [
       "Hacl.Impl.Exponentiation.Definitions.__proj__Mkto_comm_monoid__item__linv",
@@ -139,7 +139,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "8b172555ec9d4527669ef1ccb3e4810d"
+      "05777b580b63a8a1e546e7f616ac281d"
     ],
     [
       "Hacl.Impl.Exponentiation.Definitions.__proj__Mkto_comm_monoid__item__linv",
@@ -169,7 +169,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "857a1eb27ee23aad7b39a7b598d9892e"
+      "3daad940df2a8de6184f0a3018f07a93"
     ],
     [
       "Hacl.Impl.Exponentiation.Definitions.__proj__Mkto_comm_monoid__item__refl",
@@ -202,7 +202,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "1cf525a825e6758dc787e0a348005a31"
+      "09b83bdff5b3bc939310c3d6c7a83095"
     ],
     [
       "Hacl.Impl.Exponentiation.Definitions.__proj__Mkto_comm_monoid__item__refl",
@@ -232,7 +232,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "5a7a8fa57915235bbd91f3924f998b17"
+      "1b98d39fe4ea7c2ca6c7e4a3e3e45f61"
     ],
     [
       "Hacl.Impl.Exponentiation.Definitions.lone_st",
@@ -255,7 +255,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "8033bef096a6c05787c0d64692a87b81"
+      "f707adc753f9d2e0e977083251c826e1"
     ],
     [
       "Hacl.Impl.Exponentiation.Definitions.lmul_st",
@@ -279,7 +279,7 @@
         "refinement_interpretation_Tm_refine_f9c3fa0ddf8de7ae721787d684116564"
       ],
       0,
-      "90d5e5264d4df0e0ad5f08c4507cf1fe"
+      "0aa24d82c5618471db056d4ecc3d364c"
     ],
     [
       "Hacl.Impl.Exponentiation.Definitions.lsqr_st",
@@ -303,7 +303,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "947a26d1c863e43e84f67305fb6ef786"
+      "f4d4061ee8ba148a584011a83f659668"
     ]
   ]
 ]

--- a/hints/Hacl.Impl.Exponentiation.fst.hints
+++ b/hints/Hacl.Impl.Exponentiation.fst.hints
@@ -34,7 +34,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "6586cfc499dc6f773ffd517de52d35b0"
+      "9c8539d7964cc86155ed622f647ab512"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_rl_vartime",
@@ -71,7 +71,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "445fe3761207055bf65f21fd6b191bfa"
+      "be957b9578fcc58d36329680cbe945a1"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_rl_vartime",
@@ -214,7 +214,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "858dcd60de1ac948c3cc9f640b68cbe7"
+      "e97d80b5c0f5ea26f079b37081ea6904"
     ],
     [
       "Hacl.Impl.Exponentiation.cswap2",
@@ -244,7 +244,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok"
       ],
       0,
-      "9ada4218de8a0429a9f2497e1fd94fa2"
+      "40a28ce358de285b9ede8c7b7e63d22f"
     ],
     [
       "Hacl.Impl.Exponentiation.cswap2",
@@ -267,7 +267,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "fa07886dc221944e27980743f1a93599"
+      "ae5f6e856b40b2a6754b8e5149159be7"
     ],
     [
       "Hacl.Impl.Exponentiation.cswap2",
@@ -327,7 +327,7 @@
         "typing_tok_Lib.Buffer.MUT@tok", "typing_tok_Lib.IntTypes.SEC@tok"
       ],
       0,
-      "7c70b436b5fed9d84e7124491a3fbfd5"
+      "1754ceff4b9f2c8cfacb548a2d35ca31"
     ],
     [
       "Hacl.Impl.Exponentiation.lemma_bit_xor_is_sum_mod2",
@@ -349,7 +349,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "08008c64367b0f543577adb5a67853db"
+      "f5b3fdae81e88bb88dfa72d54ebe4929"
     ],
     [
       "Hacl.Impl.Exponentiation.lemma_bit_xor_is_sum_mod2",
@@ -371,7 +371,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "86141fd53c7836d443de749be6ae10fe"
+      "eb5cde5c5d9ce750b8d69d09bd0eae69"
     ],
     [
       "Hacl.Impl.Exponentiation.lemma_bit_xor_is_sum_mod2",
@@ -420,7 +420,7 @@
         "typing_tok_Lib.IntTypes.U32@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "c48bda25dcc12ac54893e976773ea156"
+      "d8973f5729a5249daac1b037b07d6398"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_mont_ladder_swap_consttime",
@@ -455,7 +455,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "062966590c9fa7d0c1a7ea610245b8d3"
+      "c160ed8ee6ab60b2354f86ca36e0c79d"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_mont_ladder_swap_consttime",
@@ -492,7 +492,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "4fd710b59553bacb6d3bb6954be2bd15"
+      "0579912c1fd6ccebf82653bda2de28e4"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_mont_ladder_swap_consttime",
@@ -704,7 +704,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "6d97b5b0d2fbfc0070083975a140ef70"
+      "b0a7291c3ad2dc4bc7e6bb49fbd00b10"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_pow2",
@@ -729,7 +729,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "4c99a5c54a04335b3127589b84302363"
+      "651dbd8e54202a5cd1f9494ca3b0f96d"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_pow2",
@@ -752,7 +752,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "7df19bc08a062ddf58a3c9fc3b45793b"
+      "3f45d3c123870e3faaee7ceb2665f579"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_pow2",
@@ -844,7 +844,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "f7880751f8bb0bae2b317b993a5ec565"
+      "b50ef6ba2b1718cc17fbaa7bfd478368"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_pow2_in_place",
@@ -869,7 +869,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "6f923aee0d048e4b82ed020647b21901"
+      "2666b8b412dbd12b0e4d37ee48a8606f"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_pow2_in_place",
@@ -892,7 +892,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "3837aad659a571c3a78d62e9e2fc4e7d"
+      "d7f05bd019b5582c63acad2fe1d413ad"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_pow2_in_place",
@@ -982,7 +982,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "913564312ec90eff5767d6082ca14da7"
+      "d53a37daff798596d73de3808da85641"
     ],
     [
       "Hacl.Impl.Exponentiation.size_window_t",
@@ -991,7 +991,7 @@
       0,
       [ "@query" ],
       0,
-      "99fa96ec3785aaa33cbed422faa02cc8"
+      "0b1a0f17dd49eb1fe18fd7bf9ccf3042"
     ],
     [
       "Hacl.Impl.Exponentiation.table_inv_t",
@@ -1032,7 +1032,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "23ac8f18fbda7935a2a00cb2265cb7b3"
+      "d9b32523a8f1dffc66787099b315a4ae"
     ],
     [
       "Hacl.Impl.Exponentiation.pow_a_to_small_b_st",
@@ -1079,7 +1079,7 @@
         "typing_FStar.UInt32.v", "typing_Lib.IntTypes.unsigned"
       ],
       0,
-      "d2ac6e98cb523959bc8b6b94b70a5e15"
+      "1258f2ae06fc552d635af68971eec4c3"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_table_st",
@@ -1128,7 +1128,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "07a732fbb15557b48358954796952208"
+      "78f9b16195d78daa5928d81230aca96f"
     ],
     [
       "Hacl.Impl.Exponentiation.bn_get_bits_l",
@@ -1163,7 +1163,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "af900ef551e6dc65ddede41a55832b2f"
+      "50430f6c8ffce40355b52de9604166b8"
     ],
     [
       "Hacl.Impl.Exponentiation.bn_get_bits_l",
@@ -1191,7 +1191,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "c8bf9625d1d35d40ef300c2a1473fa7b"
+      "c959188fdfa9034c737c2641f8c3d5fe"
     ],
     [
       "Hacl.Impl.Exponentiation.bn_get_bits_l",
@@ -1279,7 +1279,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "61a540be2dfdd23c4bdcbbec182f1455"
+      "eac12108649da06d03dd6467c2595986"
     ],
     [
       "Hacl.Impl.Exponentiation.bn_get_bits_c",
@@ -1315,7 +1315,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "8a6cac6e05c0fae756735b3a7f12c162"
+      "c20cfcaa7ad023fb4762c123fb5506ec"
     ],
     [
       "Hacl.Impl.Exponentiation.bn_get_bits_c",
@@ -1341,7 +1341,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "6f47611281b7c866bcd76c1e55e4eca0"
+      "56c81c4883080b41eaafa65aacbf21b7"
     ],
     [
       "Hacl.Impl.Exponentiation.bn_get_bits_c",
@@ -1426,7 +1426,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0f9e62b57bfbdd84544a7f6f0bdee2a1"
+      "d9fc606b6afc95f227a5c7c647dde37c"
     ],
     [
       "Hacl.Impl.Exponentiation.lmul_acc_pow_a_bits_l_st",
@@ -1476,7 +1476,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "630be86defef358104926f24e6b5ae30"
+      "9b02e8cacc744f70dc5f21bb33afbc4f"
     ],
     [
       "Hacl.Impl.Exponentiation.lmul_acc_pow_a_bits_l",
@@ -1513,7 +1513,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "6406ce50825fe07c2154b8160032732b"
+      "2cd846d65bb22180a5b4924eaeb442e0"
     ],
     [
       "Hacl.Impl.Exponentiation.lmul_acc_pow_a_bits_l",
@@ -1695,7 +1695,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "35b020df9f2c31982c843807e69edf62"
+      "979c14fab00d5e0f9adf3c54067007a1"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_f_st",
@@ -1740,7 +1740,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "41d18281abf29bb20c979a095e02dc19"
+      "7102ccb4939639567ec7001cc706604c"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_f",
@@ -1782,7 +1782,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "4238f9f7b73b3ca21ec99e587d3ac47d"
+      "129f892213d634cfb00b7252d598dc33"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_f",
@@ -1839,7 +1839,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok"
       ],
       0,
-      "23c435d8001d86b0951ade87e2ee6523"
+      "d78b0cd4e20f1ba16e7127419cd843ab"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_loop_st",
@@ -1879,7 +1879,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0f094fc0d3ea5d960d9150f2e8800953"
+      "8569f0781eaf449702cc3449caf3838e"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_loop",
@@ -1916,7 +1916,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "22cb219402f9812fab10862322133fbf"
+      "1ca03b3368cc345739b0c37cf41c8bab"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_loop",
@@ -2028,7 +2028,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "35d3f880ef2ba5a2ef2a890100cb6547"
+      "92e00372a5144b10be5287ca46eb7247"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_acc0_st",
@@ -2067,7 +2067,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "918f7dcaf30f7a9fab7ae2e3b58fb941"
+      "78fb26b4fabc5c09e6def90eea618431"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_acc0",
@@ -2111,7 +2111,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "6bd752c30df7e91f5f1147b5521c9652"
+      "e5ae7b9c576528880464bf39f3b259c3"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_acc0",
@@ -2210,7 +2210,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "82f171d57dd0b059547d2c93946ef251"
+      "c19d0ee256bb418f4a88409aad614c8a"
     ],
     [
       "Hacl.Impl.Exponentiation.mk_lexp_fw_table",
@@ -2260,7 +2260,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "9c01115bf97ff032b6116760891f57b5"
+      "d8ba67df920f19019252708f895dd908"
     ],
     [
       "Hacl.Impl.Exponentiation.mk_lexp_fw_table",
@@ -2381,7 +2381,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "05e57b468da8eacde83fb2eee8bf75d8"
+      "d9039a9472494f57d29eb330b1e89531"
     ],
     [
       "Hacl.Impl.Exponentiation.table_inv_precomp",
@@ -2430,7 +2430,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "e0f605a894e4c121de8a511b20d22d7f"
+      "2d332a1ece5e6fa0d8061ee7a84439f2"
     ],
     [
       "Hacl.Impl.Exponentiation.lprecomp_get_vartime",
@@ -2477,7 +2477,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "a124293b4e9d85e1f166c8961b382b72"
+      "5c3339e9656b871ba782c79300d148b1"
     ],
     [
       "Hacl.Impl.Exponentiation.lprecomp_get_vartime",
@@ -2503,7 +2503,7 @@
         "token_correspondence_Hacl.Impl.Exponentiation.table_inv_precomp"
       ],
       0,
-      "8fac5a4178cd621a99a37c5abbfd7fbe"
+      "b7e01e8101daccd42466bc4ac735b8b8"
     ],
     [
       "Hacl.Impl.Exponentiation.lprecomp_get_consttime",
@@ -2550,7 +2550,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "5ce9a8b501653960fad93771ffdac924"
+      "edb75b784e9102faca760749b4b4085d"
     ],
     [
       "Hacl.Impl.Exponentiation.lprecomp_get_consttime",
@@ -2576,7 +2576,7 @@
         "token_correspondence_Hacl.Impl.Exponentiation.table_inv_precomp"
       ],
       0,
-      "dbe98fc94eab0467a8a2735d1bf43e98"
+      "ad36a9bef2c8a188190e346a1473f590"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_st",
@@ -2608,7 +2608,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0c4dfbf73e16ed76e7359df4c5f60842"
+      "3c1e3d867d5e2514c4567d4f1dff126a"
     ],
     [
       "Hacl.Impl.Exponentiation.lemma_pow2_is_divisible_by_2",
@@ -2617,7 +2617,7 @@
       0,
       [ "@query" ],
       0,
-      "ef6583662b25cd3c163aef61d76e9975"
+      "6d750b2e8d9e191f52f559f288cc0940"
     ],
     [
       "Hacl.Impl.Exponentiation.lemma_pow2_is_divisible_by_2",
@@ -2632,7 +2632,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "5854cb44ee5de9b1810f353d064683c9"
+      "2de4be5491fe404be8ed58968253d2f8"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_gen",
@@ -2669,7 +2669,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "ede93cd2affe3ec953dd132486d3e7ce"
+      "96628307c2ce775a25c9814d9291bdfd"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_gen",
@@ -2857,7 +2857,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "bb5d2661afb9356d5748e43a3be7d932"
+      "ae19286c384a26c082ecc2d27dd3782f"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_gen",
@@ -3043,7 +3043,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "a21f934acf52fd683aa3a8318e4302a9"
+      "77964fcbd5683c147bff99b363ba6390"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_vartime",
@@ -3080,7 +3080,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "7e90fb2da17f9b3f634f494ebed638bf"
+      "a690b1976694aa4182489dd54a6329f6"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_vartime",
@@ -3155,7 +3155,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "90992c9a24a1a36a7b941c84bfa8ed8a"
+      "cf9426fd90ffc3d15d41a040181dba74"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_consttime",
@@ -3192,7 +3192,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "50c517c123686ecb7ba235ccc411abc0"
+      "7eaa396caa41f38414d497e798f392be"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_consttime",
@@ -3267,7 +3267,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "5e3ebf591a988f0914cc3ba6126eebc2"
+      "3aa033d7c3f8435ff2e4079e78b5c4f0"
     ]
   ]
 ]

--- a/hints/Hacl.Impl.Exponentiation.fsti.hints
+++ b/hints/Hacl.Impl.Exponentiation.fsti.hints
@@ -34,7 +34,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0e8a90105ba07cdf5133b7e9248a86ae"
+      "62a23c5dd581b16806a6de889e859f0f"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_mont_ladder_swap_consttime",
@@ -69,7 +69,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "6cbd4a077aa7830844233dcd2b8df922"
+      "ede7f7b7031a2b8d45e440910492df62"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_pow2",
@@ -94,7 +94,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "0878ae6b9eda381ca91672fa9cbabc8a"
+      "79d39638edeefbb3688cf6a9bbcb2a22"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_pow2_in_place",
@@ -119,7 +119,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "2f971b35d4460b706d2cdfda173a5697"
+      "1506dc4d05fa70b5100ab49643380b52"
     ],
     [
       "Hacl.Impl.Exponentiation.size_window_t",
@@ -128,7 +128,7 @@
       0,
       [ "@query" ],
       0,
-      "3100f5406f4ffda1917f7eb7f064a1ce"
+      "5b29c87657bcccb479fb604214706f8b"
     ],
     [
       "Hacl.Impl.Exponentiation.table_inv_t",
@@ -169,7 +169,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "f9bb0a9e223ae737a25bd0d64af4f753"
+      "92aff96546e3ec8151e0d498cadce177"
     ],
     [
       "Hacl.Impl.Exponentiation.pow_a_to_small_b_st",
@@ -219,7 +219,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "917c1353ae78331564821713ca9de9b8"
+      "7254cf3ebc19083bf82f09687c0a2b26"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_table_st",
@@ -258,7 +258,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "1aa09420265b53776ad6845ff308e083"
+      "1baf29c3ee585b2a0bc566009b4daa72"
     ],
     [
       "Hacl.Impl.Exponentiation.table_inv_precomp",
@@ -305,7 +305,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "45dfbbee8892e3cf86a4e2a27c0d05b9"
+      "6361b2560cf7a0c75114c4468f37d349"
     ],
     [
       "Hacl.Impl.Exponentiation.lexp_fw_st",
@@ -337,7 +337,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "56dfc0c5cec5a19e04339ac4d831c29c"
+      "6bc9d47789d3388ba767d60519135862"
     ]
   ]
 ]

--- a/hints/Hacl.Impl.MultiExponentiation.fst.hints
+++ b/hints/Hacl.Impl.MultiExponentiation.fst.hints
@@ -69,7 +69,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "6dee93efa9f51438369968855f27a902"
+      "930226285967e7385bf5b34244a1da97"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_f_st",
@@ -119,7 +119,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "d3d4ac02d69c6ce1fe7f612784c3e77b"
+      "c167f5193b296221efca6526fded4b8e"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_f",
@@ -156,7 +156,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "04b6065e1bb16d7abb2849e08dbe7ac3"
+      "2298db22ed6653980e8c7b9bb8f8ac58"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_f",
@@ -219,7 +219,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok"
       ],
       0,
-      "34916840608b02b0eae69764fc63fce4"
+      "d774c28a8305162ae657433903b8aff6"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_acc0_st",
@@ -268,7 +268,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "a6f8e2e73b5925785d710c90339b8e31"
+      "4111f56bc76c0f1926d43cfb19cc6ee1"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_acc0",
@@ -313,7 +313,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "4ac0b57a372a5e6d497b39b0f5d4a887"
+      "b248f8df26c0017a260a1761f2605e4e"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_acc0",
@@ -493,7 +493,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "acba4acaadb495da17e06445725a8387"
+      "e4fa2c84074fa01934ed0dae09242f1d"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_loop_st",
@@ -533,7 +533,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "527f6b8829c284906b5a472c6beaf810"
+      "bd7ba77aa628adec44077cddff034624"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_loop",
@@ -570,7 +570,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "84256c242fecd499f70d3baa99024aa9"
+      "43660e0d99f59b63b1da61a7a7c2b873"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_loop",
@@ -682,7 +682,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "e00fddda2c69a1a569ef29d950d06910"
+      "af4676e7fae02fc34022f737cc529ffb"
     ],
     [
       "Hacl.Impl.MultiExponentiation.mk_lexp_double_fw_tables",
@@ -726,7 +726,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "cdb8253f3367bb1246a196d1e3d10146"
+      "9f30ee27585fd5607662f0075c825d98"
     ],
     [
       "Hacl.Impl.MultiExponentiation.mk_lexp_double_fw_tables",
@@ -851,7 +851,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "139cba5fa862b06ead2aac92b4754fb2"
+      "967e87d1e019f9db9ec67807a2be956b"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_st",
@@ -883,7 +883,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "5058f9cab73e6c5064346055fd008a18"
+      "0a9b6580e5d4e0775fb353559f8c9ba5"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_gen",
@@ -920,7 +920,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "bfc6508d62850f061e27be9aa7bc363b"
+      "f54a465ea4627a7da35028a9d50001b4"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_gen",
@@ -1107,7 +1107,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "ebab31a32d1db0331de09836b30c1533"
+      "075c654c1c29ff0571dc10d1ac6f5fcf"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_gen",
@@ -1290,7 +1290,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "a9371a9856e14410158057179b669cc7"
+      "5ee2f2e27dd9d0b006e58208d7021410"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_vartime",
@@ -1327,7 +1327,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "e3ed9441b0ba1b3c9f808f6a10062751"
+      "f333237cbe60386b6dcc61509436db4e"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_vartime",
@@ -1402,7 +1402,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "a6651e3571b376e588d42f9c01a990dd"
+      "b8214975b4d70f52f49c0d4a3896a9f1"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_consttime",
@@ -1439,7 +1439,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "48aeae1a93cb3c7d0b16b7d498be176e"
+      "fe707127b7faa1faba578c276011f77c"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_consttime",
@@ -1514,7 +1514,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "f3195405a2f04b10fd4d3b64b6094fba"
+      "e7211251c3e2469997847ae50d55f800"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_four_fw_tables_st",
@@ -1553,7 +1553,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "8a5eef32f0556d8715eab638879809f7"
+      "c7f560920ad566e3ecf88f63af51b7c5"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_four_fw_f_st",
@@ -1593,7 +1593,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "15819e219426c9e1c5b86180db379b59"
+      "c2ac66a253d9050f67fec4187f128a89"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_four_fw_f",
@@ -1630,7 +1630,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "cbd5d972016c9874769c70325e6295ca"
+      "e8d0fda81d1fc0d2e4514938d8d08a93"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_four_fw_f",
@@ -1697,7 +1697,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok"
       ],
       0,
-      "e62deb97d131d3c2f5ca96fc9642c07b"
+      "b5d727a8822c2acd259c6fd247ab5367"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_four_fw_acc0_st",
@@ -1743,7 +1743,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "3a53219d2ec63cdf6ee90013679cdb31"
+      "d0cd25e607f70dda33eac944bd0838fd"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_four_fw_acc0",
@@ -1787,7 +1787,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "32bb55e11e7a0d20cf0b907a3830976a"
+      "08b6c46f767c1790a6e6a3f50e63f66c"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_four_fw_acc0",
@@ -1961,7 +1961,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "942ee4724db231c1fbac39dca4fca5cf"
+      "01bdc76ffb3b9c4586809bbce7f2c843"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_four_fw_loop_st",
@@ -2001,7 +2001,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "1a6405cde0c17555d52ee180e02db644"
+      "46501c14c2d3ad4dedaca7c8c4390ac6"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_four_fw_loop",
@@ -2051,7 +2051,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "6e22921d7778930273ab556c656cc9c4"
+      "0430a4f044a5fd179a113cff7a70b432"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_four_fw_loop",
@@ -2165,7 +2165,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "b0618646ed69e22326f52fe58570ac33"
+      "b249c624c6000adfa47d4e8892870415"
     ],
     [
       "Hacl.Impl.MultiExponentiation.mk_lexp_four_fw_tables",
@@ -2202,7 +2202,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "30bc3515532155e35290a2d088da5d43"
+      "eca600715917b8e944457bc461f5b386"
     ],
     [
       "Hacl.Impl.MultiExponentiation.mk_lexp_four_fw_tables",
@@ -2331,7 +2331,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0e5c1ea5e8022057d46d33d70031ba6b"
+      "47340ce03c61e6ec39771dad23a7e6e9"
     ]
   ]
 ]

--- a/hints/Hacl.Impl.MultiExponentiation.fsti.hints
+++ b/hints/Hacl.Impl.MultiExponentiation.fsti.hints
@@ -38,7 +38,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0d52a6f5bfed9f0cead7aa6e14edfb0b"
+      "c939b101d79cce2c6f3bbd6df28531f2"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_double_fw_st",
@@ -70,7 +70,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "1f518e28e902eb4536fa27cbb78cf148"
+      "c62920f16977a1e4ea4be4015dfaf326"
     ],
     [
       "Hacl.Impl.MultiExponentiation.lexp_four_fw_tables_st",
@@ -116,7 +116,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "e04bfd42032efe4f71289faad99539b4"
+      "32f8e5e6008dead6059692c1acd56622"
     ]
   ]
 ]

--- a/hints/Hacl.Impl.PrecompTable.fsti.hints
+++ b/hints/Hacl.Impl.PrecompTable.fsti.hints
@@ -27,7 +27,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "68eebbd6aaeee31a6a866447a2b410ed"
+      "9407243977b32b51e1482cffe6d94e3a"
     ],
     [
       "Hacl.Impl.PrecompTable.spec_table_sub_len",
@@ -65,7 +65,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok"
       ],
       0,
-      "697af45303e226b6c20bd8eaff2c01d7"
+      "8d364fd2633d538f5693564ce7e1e27e"
     ],
     [
       "Hacl.Impl.PrecompTable.table_select_consttime",
@@ -129,7 +129,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "bb5f5069a08682e28efa6a7a2cb7642e"
+      "f1056c687f44aecbdbd72052b070ca19"
     ],
     [
       "Hacl.Impl.PrecompTable.precomp_table_inv",
@@ -173,7 +173,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "435ee775765fc90340533bd05e2731dc"
+      "8679210c014724cd72597becc59de9c0"
     ],
     [
       "Hacl.Impl.PrecompTable.precomp_table_inv",
@@ -217,7 +217,7 @@
         "typing_Lib.IntTypes.int_t", "typing_tok_Lib.IntTypes.SEC@tok"
       ],
       0,
-      "3f7bffa2142df0aca3a24f9b1de7069b"
+      "8d2e68f333ddb74c977903d40a426958"
     ],
     [
       "Hacl.Impl.PrecompTable.lprecomp_table",
@@ -262,7 +262,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0b407c36c93e7228f595f04623834547"
+      "8eab0901f1f41bdf15aec303c8895a10"
     ],
     [
       "Hacl.Impl.PrecompTable.lprecomp_get_st",
@@ -313,7 +313,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "7c5a28e55d4be6ad11ed293f53384030"
+      "cc56d0fc2f849198f197d9ab5cf7d347"
     ]
   ]
 ]

--- a/hints/Hacl.Spec.Bignum.Base.fst.hints
+++ b/hints/Hacl.Spec.Bignum.Base.fst.hints
@@ -646,7 +646,7 @@
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "12cb6d7938596e97a9be13be679d3ae2"
+      "5e7e81d456ac72677f38f10639f27c74"
     ],
     [
       "Hacl.Spec.Bignum.Base.mask_select_lemma",
@@ -695,7 +695,7 @@
         "typing_tok_Lib.IntTypes.U32@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "89e5e82b81a595e9ca0268903fbfae3f"
+      "ac1ff7312416660108e37d36077f2594"
     ],
     [
       "Hacl.Spec.Bignum.Base.mask_select_lemma1",
@@ -721,7 +721,7 @@
         "typing_Lib.IntTypes.zeros", "typing_tok_Lib.IntTypes.SEC@tok"
       ],
       0,
-      "6e597b827e6a4555e860f8880b1add7b"
+      "d13f5a7f23e146a26b6133ca74f6c055"
     ],
     [
       "Hacl.Spec.Bignum.Base.lseq_mask_select_lemma",
@@ -749,7 +749,7 @@
         "typing_Lib.Sequence.index", "typing_tok_Lib.IntTypes.SEC@tok"
       ],
       0,
-      "0db1e904272846f9d8c6d0390fab4c36"
+      "dee2e25c875de067ba1c471839f0571c"
     ]
   ]
 ]

--- a/hints/Hacl.Spec.Bignum.Definitions.fst.hints
+++ b/hints/Hacl.Spec.Bignum.Definitions.fst.hints
@@ -114,7 +114,7 @@
         "typing_Lib.IntTypes.bits", "well-founded-ordering-on-nat"
       ],
       0,
-      "d78be08ad68342756ff02f468d313c0a"
+      "86240c2c49f88eb75948f40cee2870da"
     ],
     [
       "Hacl.Spec.Bignum.Definitions.bn_v",
@@ -409,7 +409,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "9c28e7826f79c1b069fe241a90454a84"
+      "9ee566fe19a703e7e3c3a4499fe90bc0"
     ],
     [
       "Hacl.Spec.Bignum.Definitions.bn_eval_zeroes",
@@ -456,7 +456,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "d5e8606aac54a625d1c705f1a8a55e04"
+      "a0e8f62f8f2babaf1eadeeea3c0dcc34"
     ],
     [
       "Hacl.Spec.Bignum.Definitions.bn_eval_create1",
@@ -548,13 +548,13 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
         "refinement_interpretation_Tm_refine_72fc08deb9830bf580be9916009cbade",
         "refinement_interpretation_Tm_refine_837bca83cb16efa663cc2f96712f7df8",
-        "refinement_interpretation_Tm_refine_ab9752d1c5791ef518cad5ae49d0f4f3",
+        "refinement_interpretation_Tm_refine_a9e7e7d921716ada1402a76ee23bb460",
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c",
         "refinement_interpretation_Tm_refine_c8dd98bb91cb1ba6963e5299b3babaa4",
         "refinement_interpretation_Tm_refine_d8d83307254a8900dd20598654272e42"
       ],
       0,
-      "1f667a5e86c06349c6097a220c8cbfa2"
+      "5372cf11d32d4d1d693af3fda36530f6"
     ],
     [
       "Hacl.Spec.Bignum.Definitions.bn_eval_extensionality_j",
@@ -606,7 +606,7 @@
         "typing_Lib.Sequence.to_seq", "well-founded-ordering-on-nat"
       ],
       0,
-      "1d160237a9ef29109917bf94c9b007d8"
+      "c1612bd667fa9f71829f7ffa3f0f705f"
     ],
     [
       "Hacl.Spec.Bignum.Definitions.bn_eval_snoc",
@@ -777,12 +777,12 @@
         "primitive_Prims.op_Multiply", "primitive_Prims.op_Subtraction",
         "projection_inverse_BoxInt_proj_0",
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
-        "refinement_interpretation_Tm_refine_b97ef148e418bf97fe6de26e9c44d578",
+        "refinement_interpretation_Tm_refine_8a0e61d65f93c9a0763dd751ed6d2dd1",
         "refinement_interpretation_Tm_refine_c8dd98bb91cb1ba6963e5299b3babaa4",
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "b414cc97202e6afd1414d1f9c9fc2a21"
+      "3f204e71464851d2110727a033472e9d"
     ],
     [
       "Hacl.Spec.Bignum.Definitions.bn_eval_split_i",
@@ -869,7 +869,7 @@
         "unit_inversion", "unit_typing", "well-founded-ordering-on-nat"
       ],
       0,
-      "6281c989cc1c09f6e709d7739f59c209"
+      "8252ecb8df0586a386921e71c78e781a"
     ],
     [
       "Hacl.Spec.Bignum.Definitions.bn_eval_inj",
@@ -944,7 +944,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "64fe7535a1bb3a87f0fdd108f64a2604"
+      "59bb096dfa1bc066dc6af8957f550059"
     ],
     [
       "Hacl.Spec.Bignum.Definitions.bn_eval_bound",
@@ -994,11 +994,11 @@
         "equation_Lib.IntTypes.bits", "equation_Prims.nat",
         "primitive_Prims.op_Multiply", "projection_inverse_BoxInt_proj_0",
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
-        "refinement_interpretation_Tm_refine_7ca8f45aa340d2cd33ec833548466554",
+        "refinement_interpretation_Tm_refine_90486de220a83de45dfa9fb987f69721",
         "refinement_interpretation_Tm_refine_cfc744b198940c21e3f980c86ac17a92"
       ],
       0,
-      "d8242038126e63bd13237d065e2da2ff"
+      "ac751ad91c4f21b779a13363d47800b0"
     ],
     [
       "Hacl.Spec.Bignum.Definitions.bn_eval_bound",
@@ -1052,7 +1052,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "well-founded-ordering-on-nat"
       ],
       0,
-      "92a3b489fe3f53f139bca6288668a501"
+      "e3705e676f88500655588254fdefd392"
     ],
     [
       "Hacl.Spec.Bignum.Definitions.bn_eval_index",

--- a/hints/Lib.Exponentiation.Definition.fsti.hints
+++ b/hints/Lib.Exponentiation.Definition.fsti.hints
@@ -18,7 +18,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "6c248a0acd2711690bff1738393f2cdc"
+      "95b0638e4678cd406e33ef4aee46b393"
     ],
     [
       "Lib.Exponentiation.Definition.pow_neg",
@@ -32,7 +32,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "733c11c1ac0e342d5508b29e40b55e82"
+      "6e9d4ae977c1dee6efb359bb5b70c40a"
     ],
     [
       "Lib.Exponentiation.Definition.lemma_pow_unfold",
@@ -45,7 +45,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "880afd9612f1dbd68a5522d60924adc8"
+      "50fdb34d015945d3db830efc7a7f86d0"
     ],
     [
       "Lib.Exponentiation.Definition.lemma_pow_add",
@@ -58,7 +58,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "435821f27fcda3c826e19495602e3871"
+      "78f84c7f35eedd61725ac123594e5235"
     ],
     [
       "Lib.Exponentiation.Definition.lemma_pow_mul",
@@ -71,7 +71,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "bfd468314a63a92ef0fee41e0dad5eda"
+      "cca1220cbaa4eee38dc72ac8d928e44e"
     ],
     [
       "Lib.Exponentiation.Definition.lemma_pow_double",
@@ -84,7 +84,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "660f2689b98b8a4fd42137f9f95de5a9"
+      "d17cbe5181e049b7dd31a0799bbf46b6"
     ]
   ]
 ]

--- a/hints/Lib.Exponentiation.fsti.hints
+++ b/hints/Lib.Exponentiation.fsti.hints
@@ -8,7 +8,7 @@
       0,
       [ "@query" ],
       0,
-      "6e86a461e8fe391897111ed8d3148ec8"
+      "c0ac36d3c070d2dac8018382b820af22"
     ],
     [
       "Lib.Exponentiation.exp_lr_f",
@@ -23,7 +23,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "deb1e2f2be10d05d176e0a2514c04500"
+      "2b3390bdb95097eafc7c1e21558128c4"
     ],
     [
       "Lib.Exponentiation.exp_mont_ladder_f",
@@ -38,7 +38,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "b5f58721cd284d101f46ca8ba32acead"
+      "3803121d4645ecbe708a863d0099d20a"
     ],
     [
       "Lib.Exponentiation.exp_mont_ladder_swap2_f",
@@ -55,7 +55,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "944a8feaef2df7e9076bc0ea73683c79"
+      "3f34198497e4b001de33bf6046bdad1a"
     ],
     [
       "Lib.Exponentiation.exp_mont_ladder_swap_f",
@@ -72,7 +72,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "dc058bc42542431c16475626b14a4696"
+      "5252ad0f05b1f14014bf52954f8c2453"
     ],
     [
       "Lib.Exponentiation.exp_pow2_lemma",
@@ -81,7 +81,7 @@
       0,
       [ "@query" ],
       0,
-      "5b9687e6134dac07f34320d454ce62f3"
+      "381b670fd86a053b802ac7bd3bc53806"
     ],
     [
       "Lib.Exponentiation.get_ith_lbits",
@@ -93,7 +93,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "b45cbce01132495022a4e8d8091f8726"
+      "fd290b859fb67636e6f2961a85456981"
     ],
     [
       "Lib.Exponentiation.get_bits_l",
@@ -102,7 +102,7 @@
       0,
       [ "@query" ],
       0,
-      "f3b5fae73b478572f05dba6b07989083"
+      "5eaa6390c57559466b015caf66eda211"
     ],
     [
       "Lib.Exponentiation.get_bits_l",
@@ -123,7 +123,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "1c22e4f8ee727b01f5478eac5fa6cf78"
+      "43a6821c9e9aebef419a6221b9f3e3bd"
     ],
     [
       "Lib.Exponentiation.mul_acc_pow_a_bits_l",
@@ -132,7 +132,7 @@
       0,
       [ "@query" ],
       0,
-      "7aa850db725b3e07b00f10dbdd64f7a9"
+      "d6057207fdd8e267616717fbd51de726"
     ],
     [
       "Lib.Exponentiation.mul_acc_pow_a_bits_l",
@@ -141,7 +141,7 @@
       0,
       [ "@query" ],
       0,
-      "40467edf53fe87677aaf0e3650dc279d"
+      "8967c72f903bb3d72cef46570747ae8b"
     ],
     [
       "Lib.Exponentiation.exp_fw_f",
@@ -153,7 +153,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "901cb7a0502d2d5402635d123a969545"
+      "02bebe3dcca661db938ab02e896290eb"
     ],
     [
       "Lib.Exponentiation.exp_fw_f",
@@ -166,7 +166,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "a9fc656ed1cf9d83c4cc03b2d7c572e7"
+      "af92a78b3eddc533999acf2daadb0014"
     ],
     [
       "Lib.Exponentiation.exp_fw_acc0",
@@ -175,7 +175,7 @@
       0,
       [ "@query" ],
       0,
-      "074606e6dd9a09a8b63e26cb565b0740"
+      "ca2a9834f2ffa99d097d7ac95922fd73"
     ],
     [
       "Lib.Exponentiation.exp_fw_acc0",
@@ -196,7 +196,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "082cdb6083915d2b75bd8e6d3391d900"
+      "c09d59210b4158aee941f70636036c33"
     ],
     [
       "Lib.Exponentiation.exp_fw",
@@ -216,7 +216,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "14cc207a6aaac2a5fa0574b73beb4165"
+      "21e487b663c0d9fca059f1f4fed96bf3"
     ],
     [
       "Lib.Exponentiation.exp_double_fw_f",
@@ -225,7 +225,7 @@
       0,
       [ "@query" ],
       0,
-      "dba1ddec6327c7aaa039832dd4d62fae"
+      "7295b5a7fb058d1b54386998c6c156ae"
     ],
     [
       "Lib.Exponentiation.exp_double_fw_acc0",
@@ -234,7 +234,7 @@
       0,
       [ "@query" ],
       0,
-      "f9ae16dac15c17c236a86361ca6d44f2"
+      "2d7a05da98fae4853ca281b81a720d85"
     ],
     [
       "Lib.Exponentiation.exp_double_fw",
@@ -254,7 +254,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "d82d1a82c14bfb1f7fd8e006a68ecdcd"
+      "80bb798c6798e7a9056ddf99a73d6b3f"
     ],
     [
       "Lib.Exponentiation.exp_four_fw_f",
@@ -263,7 +263,7 @@
       0,
       [ "@query" ],
       0,
-      "9ec20520b9787ea7b827c51fcc73ac68"
+      "a19337b558cc4e9def37a4e752990bb6"
     ],
     [
       "Lib.Exponentiation.exp_four_fw_acc0",
@@ -272,7 +272,7 @@
       0,
       [ "@query" ],
       0,
-      "949688f49394356e1fe2cc790a78ae5b"
+      "d0b3f5230457493b700d1e9b6def0ea9"
     ],
     [
       "Lib.Exponentiation.exp_four_fw",
@@ -292,7 +292,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "9c1266263eba79e25bffa37bdd5217ce"
+      "461658d32182d193138a921ec8c10262"
     ]
   ]
 ]


### PR DESCRIPTION
Noticeably, using `fresh_bv` to generate a new name.

Related to F* changes in https://github.com/FStarLang/FStar/pull/2747.