### PR TITLE
Bump version of xcode used in github actions

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -31,17 +31,17 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
-          sudo xcode-select -s /Applications/Xcode_12.4.app
+          sudo xcode-select -s /Applications/Xcode_13.4.app
           CROSS_CI="aarch64-apple-darwin" .ci/script.sh
       - name: iOS aarch64
         if: matrix.os == 'macos-latest'
         run: |
           sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
-          sudo xcode-select -s /Applications/Xcode_12.4.app
+          sudo xcode-select -s /Applications/Xcode_13.4.app
           CROSS_CI="aarch64-apple-ios" .ci/script.sh
       - name: iOS x64 simulator
         if: matrix.os == 'macos-latest'
         run: |
           sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
-          sudo xcode-select -s /Applications/Xcode_12.4.app
+          sudo xcode-select -s /Applications/Xcode_13.4.app
           CROSS_CI="x86_64-apple-ios-simulator" .ci/script.sh


### PR DESCRIPTION
Following the recent upgrade from github actions to use macos-12, the version of Xcode used by CI is now unavailable.
This PR bumps the version to one of the newly supported ones.