### PR TITLE
add workflow to update hacl-packages

### DIFF
--- a/.github/workflows/hacl-packages-create-branch.yml
+++ b/.github/workflows/hacl-packages-create-branch.yml
@@ -1,11 +1,11 @@
-name: Update hacl-packages
+name: Create branch on hacl-packages
 
 on:
   pull_request:
     branches: [ main ]
 
 jobs:
-  update-hacl-packages:
+  hacl-packages-create-branch:
     runs-on: ubuntu-latest
     steps:
       - name: checkout hacl-star

--- a/.github/workflows/hacl-packages-delete-branch.yml
+++ b/.github/workflows/hacl-packages-delete-branch.yml
@@ -1,0 +1,18 @@
+name: Delete branch on hacl-packages
+
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  hacl-packages-delete-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout hacl-packages
+        uses: actions/checkout@v3
+        with:
+          repository: cryspen/hacl-packages
+          token: ${{ secrets.HACL_BOT }}
+      - name: delete remote branch
+        run: |
+          git push -d origin hacl-star-${{ github.head_ref }}

--- a/.github/workflows/update-hacl-packages.yml
+++ b/.github/workflows/update-hacl-packages.yml
@@ -1,0 +1,43 @@
+name: Update hacl-packages
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  update-hacl-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout hacl-star
+        uses: actions/checkout@v3
+        with:
+          path: hacl-star
+      - name: checkout hacl-packages
+        uses: actions/checkout@v3
+        with:
+          repository: cryspen/hacl-packages
+          path: hacl-packages
+          token: ${{ secrets.HACL_BOT }}
+      - name: update hacl-packages
+        working-directory: hacl-packages
+        run: |
+          rm -r src/* include/*
+          cp ../hacl-star/dist/gcc-compatible/*.c src/
+          cp ../hacl-star/dist/gcc-compatible/*.h include/
+          cp -r ../hacl-star/dist/gcc-compatible/internal include/
+      - name: push to hacl-packages
+        working-directory: hacl-packages
+        run: |
+          branch=hacl-star-${{ github.head_ref }}
+          token=${{ secrets.HACL_BOT }}
+          git config --local user.name "Hacl Bot"
+          git config --local user.email "hacl-star@mailo.com"
+          git checkout -b $branch
+          git add src include
+          git commit -m "[CI] update code"
+          git push --force --set-upstream  origin $branch
+      - name: comment pr
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: "[CI] corresponding branch on hacl-packages: https://github.com/cryspen/hacl-packages/tree/hacl-star-${{ github.head_ref }}"
+          comment_includes: "[CI]"

--- a/.github/workflows/update-hacl-packages.yml
+++ b/.github/workflows/update-hacl-packages.yml
@@ -36,8 +36,3 @@ jobs:
           git add src include
           git commit -m "[CI] update code"
           git push --force --set-upstream  origin $branch
-      - name: comment pr
-        uses: thollander/actions-comment-pull-request@v1
-        with:
-          message: "[CI] corresponding branch on hacl-packages: https://github.com/cryspen/hacl-packages/tree/hacl-star-${{ github.head_ref }}"
-          comment_includes: "[CI]"


### PR DESCRIPTION
When a PR is opened (or updated), this workflow will create (or update) a branch on cryspen/hacl-packages with the corresponding code update.
~~The workflow will then post a link to the branch on the hacl-star PR.~~
If the PR is from branch `[ref]`, then the branch on hacl-packages will be called `hacl-star-[ref]`.
A second workflow deletes the branch when the PR is closed.