### PR TITLE
Unify hash state types between different specs

### DIFF
--- a/specs/Spec.Hash.Definitions.fst
+++ b/specs/Spec.Hash.Definitions.fst
@@ -196,7 +196,7 @@ let block_length a =
 let size_block = block_length
 
 (* Number of words for intermediate hash, i.e. the working state. *)
-inline_for_extraction 
+inline_for_extraction
 let state_word_length a =
   match a with
   | MD5 -> 4
@@ -205,7 +205,7 @@ let state_word_length a =
   | SHA3_256 -> 25
   | _ -> 8
 
-inline_for_extraction 
+inline_for_extraction
 let extra_state a = match a with
   | MD5 | SHA1 | SHA2_224 | SHA2_256 | SHA2_384 | SHA2_512 | SHA3_256 -> unit
   // Directly storing the length instead of the number of blocks to avoid
@@ -215,19 +215,19 @@ let extra_state a = match a with
   | Blake2S -> uint_t U64 SEC
   | Blake2B -> uint_t U128 SEC
 
-inline_for_extraction 
+inline_for_extraction
 let extra_state_v (#a:hash_alg) (s:extra_state a) : nat =
   match a with
   | MD5 | SHA1 | SHA2_224 | SHA2_256 | SHA2_384 | SHA2_512 | SHA3_256 -> 0
   | Blake2S -> v #U64 #SEC s
   | Blake2B -> v #U128 #SEC s
 
-inline_for_extraction 
+inline_for_extraction
 let extra_state_int_type : a:hash_alg{is_blake a} -> inttype = function
   | Blake2S -> U64
   | Blake2B -> U128
 
-inline_for_extraction 
+inline_for_extraction
 let extra_state_int_t (a:hash_alg{is_blake a}) : Type0 =
   int_t (extra_state_int_type a) SEC
 
@@ -244,20 +244,20 @@ let nat_to_extra_state (a:hash_alg{is_blake a}) (n:nat{n <= max_extra_state a}) 
   | Blake2S -> mk_int #U64 #SEC n
   | Blake2B -> mk_int #U128 #SEC n
 
-inline_for_extraction 
+inline_for_extraction
 let extra_state_add_nat (#a:hash_alg{is_blake a}) (s : extra_state a)
                         (n:nat{n <= maxint (extra_state_int_type a)}) :
   extra_state a =
   (s <: extra_state_int_t a) +. nat_to_extra_state a n
 
-inline_for_extraction 
+inline_for_extraction
 let extra_state_add_size_t (#a:hash_alg{is_blake a}) (s : extra_state a) (n : size_t) :
   s':extra_state a{s' == extra_state_add_nat s (size_v n)} =
   (s <: extra_state_int_t a) +. (cast (extra_state_int_type a) SEC n)
 
 (* The working state *)
-inline_for_extraction 
-let words_state' a = m:Seq.seq (word a) {Seq.length m = state_word_length a}
+inline_for_extraction
+let words_state' a = lseq (word a) (state_word_length a)
 
 let words_state a = words_state' a & extra_state a
 

--- a/specs/lemmas/Spec.Blake2.Incremental.fst
+++ b/specs/lemmas/Spec.Blake2.Incremental.fst
@@ -313,13 +313,6 @@ let rec repeati_blake2_update1_is_update_multi_aux a nb prev d hash =
 let repeati_blake2_update1_is_update_multi a nb prev d hash =
   repeati_blake2_update1_is_update_multi_aux a nb prev d hash
 
-/// TODO: duplicate with Hacl.Streaming.Blake2.fst - MOVE
-/// Equality between the state types defined by blake2s and the generic hash.
-/// The below equality is not trivial because of the way types are encoded for Z3.
-val blake2_state_types_equalities (a : hash_alg{is_blake a}) :
-  Lemma(Blake2.state (to_blake_alg a) == words_state' a)
-
-let blake2_state_types_equalities a = ()
 let extra_state_v_nat_to_extra_state_is_id (a : hash_alg{is_blake a})
                                            (n : nat{n <= max_extra_state a}) :
   Lemma(extra_state_v (nat_to_extra_state a n) = n) = ()
@@ -425,8 +418,6 @@ let blake2_is_hash_incremental_aux2 a input s1 =
     (Loops.repeati #(words_state' a) nb (Blake2.blake2_update1 (to_blake_alg a) prev0 input) s1,
      nat_to_extra_state a (prev0 + nb * block_length a)) ==
        update_multi a (s1, nat_to_extra_state a prev0) bs);
-  blake2_state_types_equalities a;
-  assert(words_state' a == Blake2.state (to_blake_alg a));
   assert(is2 == ((s2 <: words_state' a), nat_to_extra_state a (prev0 + nb * block_length a)))
 #pop-options
 

--- a/specs/lemmas/Spec.Blake2.Incremental.fst
+++ b/specs/lemmas/Spec.Blake2.Incremental.fst
@@ -45,7 +45,7 @@ let split_blocks_props (a:hash_alg{is_blake a}) (input:bytes) :
     Seq.length l = rem /\
     rem <= block_length a /\
     Seq.length input = Seq.length bs + rem /\
-    rem = Seq.length input - Seq.length bs /\ 
+    rem = Seq.length input - Seq.length bs /\
     l `S.equal` S.slice input (S.length input - rem) (S.length input) /\
     (Seq.length input <= block_length a ==>
      (nb = 0 /\ rem = Seq.length input))))
@@ -89,7 +89,7 @@ let last_split_blake_get_last_padded_block_eq (a:hash_alg{is_blake a}) (input : 
 let blake2_update_multi_one_block_eq
   (a:hash_alg{is_blake a})
   (block : bytes_block a)
-  (hash : words_state' a) 
+  (hash : words_state' a)
   (totlen : nat{(totlen + block_length a) <= max_extra_state a}) :
   Lemma
   (ensures (
@@ -319,27 +319,7 @@ let repeati_blake2_update1_is_update_multi a nb prev d hash =
 val blake2_state_types_equalities (a : hash_alg{is_blake a}) :
   Lemma(Blake2.state (to_blake_alg a) == words_state' a)
 
-let blake2_state_types_equalities a =
-  let open Lib.Sequence in
-  let open Lib.IntTypes in
-  (* Because of the necessity to be able to normalize, we basically do
-   * the same proof twice. TODO: find a better way *)
-  match a with
-  | Blake2S ->
-    let a = Blake2S in (* small trick to get a proper normalization *)
-    let row = Blake2.row (to_blake_alg a) in
-    assert(Blake2.state (to_blake_alg a) == lseq row 4);
-    assert_norm(words_state' a == m:Seq.seq row {Seq.length m = 4});
-    assert_norm(lseq row 4 == m:Seq.seq row {Seq.length m == 4});
-    assert(lseq row 4 == m:Seq.seq row {Seq.length m = 4})
-  | Blake2B ->
-    let a = Blake2B in
-    let row = Blake2.row (to_blake_alg a) in
-    assert(Blake2.state (to_blake_alg a) == lseq row 4);
-    assert_norm(words_state' a == m:Seq.seq row {Seq.length m = 4});
-    assert_norm(lseq row 4 == m:Seq.seq row {Seq.length m == 4});
-    assert(lseq row 4 == m:Seq.seq row {Seq.length m = 4})
-
+let blake2_state_types_equalities a = ()
 let extra_state_v_nat_to_extra_state_is_id (a : hash_alg{is_blake a})
                                            (n : nat{n <= max_extra_state a}) :
   Lemma(extra_state_v (nat_to_extra_state a n) = n) = ()
@@ -535,7 +515,7 @@ let blake2_is_hash_incremental_aux3 a input s2 =
                                      last_block (fst h'),
      nat_to_extra_state a 0));
   (* Prove the final equality *)
-  assert(s3 == fst is3)  
+  assert(s3 == fst is3)
 #pop-options
 
 val blake2_is_hash_incremental_aux4

--- a/specs/lemmas/Spec.SHA3.Incremental.fst
+++ b/specs/lemmas/Spec.SHA3.Incremental.fst
@@ -141,19 +141,7 @@ let rec sha3_ignores_extra_state (a: sha3_alg) (acc: words_state' a) (bs: bytes)
 #pop-options
 
 #push-options "--print_implicits"
-let sha3_state_is_hash_state: squash (words_state' SHA3_256 == Spec.SHA3.state) =
-  let open Lib.Sequence in
-  calc (==) {
-    words_state' SHA3_256;
-  (==) { _ by (FStar.Tactics.trefl ()) }
-    m:Seq.seq (word SHA3_256) {Seq.length m = state_word_length SHA3_256};
-  (==) { }
-    m:Seq.seq (word SHA3_256) {(Seq.length m <: nat) == (state_word_length SHA3_256 <: nat)};
-  (==) { _ by (FStar.Tactics.norm [ delta_only [ `%lseq; `%seq ] ]; FStar.Tactics.trefl ())  }
-    lseq (word SHA3_256) (state_word_length SHA3_256);
-  (==) { }
-    Spec.SHA3.state;
-  }
+let sha3_state_is_hash_state: squash (words_state' SHA3_256 == Spec.SHA3.state) = ()
 #pop-options
 
 let sha3_is_incremental2


### PR DESCRIPTION
There currently is a mismatch between the state type of Spec.Hash.Definitions, which uses Seq.seq with a refinement for the length, and the Blake2 and SHA3 specs, which directly use Lib's lseq.
While the two are conceptually equivalent, this leads to many issues with Z3, and the need to call lemmas stating the type equality.

This PR unifies both types, by using `lseq` in Spec.Hash.Definitions, and removing the now unneeded type_equalities lemmas.