### PR TITLE
don't inline scalar32_sha512_init, it's used in ed25519

### DIFF
--- a/code/sha2-mb/Hacl.SHA2.Scalar32.fst
+++ b/code/sha2-mb/Hacl.SHA2.Scalar32.fst
@@ -36,7 +36,7 @@ open Hacl.Impl.SHA2.Generic
 [@CInline] let sha384_update_last = update_last #SHA2_384 #M32 sha384_update
 [@CInline] let sha384_finish = finish #SHA2_384 #M32
 
-[@CInline] let sha512_init = init #SHA2_512 #M32
+let sha512_init = init #SHA2_512 #M32
 [@CInline] let sha512_update = update #SHA2_512 #M32
 [@CInline] let sha512_update_nblocks = update_nblocks #SHA2_512 #M32 sha512_update
 [@CInline] let sha512_update_last = update_last #SHA2_512 #M32 sha512_update

--- a/dist/gcc-compatible/Hacl_Streaming_SHA2.c
+++ b/dist/gcc-compatible/Hacl_Streaming_SHA2.c
@@ -596,7 +596,7 @@ static inline void sha384_finish(uint64_t *st, uint8_t *h)
   memcpy(h, hbuf, (uint32_t)48U * sizeof (uint8_t));
 }
 
-inline void Hacl_SHA2_Scalar32_sha512_init(uint64_t *hash)
+void Hacl_SHA2_Scalar32_sha512_init(uint64_t *hash)
 {
   KRML_MAYBE_FOR8(i,
     (uint32_t)0U,

--- a/dist/gcc-compatible/INFO.txt
+++ b/dist/gcc-compatible/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: a70f1d81adee12db5de830c4138ab6b149b177a3
+F* version: 67eff4c771c19bfd3e8c46a2fc07bcf42af1bca2
 KaRaMeL version: 8c67f5b4a0ed245e108b2d69cbba8990aec7816a
 Vale version: 0.3.19


### PR DESCRIPTION
## Proposed changes

The `scalar32_sha512_init` function is inlined but used by ed25519. This breaks builds on Windows

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](LICENSE.md)
- [x] I have added necessary documentation (if appropriate)
- [X] I have edited [CHANGES.md](CHANGES.md) (if appropriate)

## Further comments

See the build issues for example here https://github.com/cryspen/hacl-packages/actions/runs/3631761531/jobs/6126803616
