### PR TITLE
More hash specs cleanup

### DIFF
--- a/code/hash/Hacl.Hash.Definitions.fst
+++ b/code/hash/Hacl.Hash.Definitions.fst
@@ -205,7 +205,7 @@ let update_multi_st (i:impl) =
   n:size_t { B.length blocks = block_length (get_alg i) * v n } ->
   ST.Stack unit
     (requires (fun h ->
-      Spec.Agile.Hash.update_multi_pre (get_alg i) (as_seq h s) (ev_v ev) (B.as_seq h blocks) /\
+      Spec.Agile.Hash.update_multi_pre (get_alg i) (ev_v ev) (B.as_seq h blocks) /\
       B.live h s /\ B.live h blocks /\ B.disjoint s blocks))
     (ensures (fun h0 _ h1 ->
       B.(modifies (loc_buffer s) h0 h1) /\
@@ -246,7 +246,7 @@ let update_last_st (i:impl) =
   ST.Stack unit
     (requires (fun h ->
       B.live h s /\ B.live h input /\ B.disjoint s input /\
-      Spec.Agile.Hash.update_multi_pre a (as_seq h s) (extra_state_of_prev_length (prev_len_v prev_len)) (B.as_seq h input)))
+      Spec.Agile.Hash.update_multi_pre a (extra_state_of_prev_length (prev_len_v prev_len)) (B.as_seq h input)))
     (ensures (fun h0 _ h1 ->
       B.(modifies (loc_buffer s) h0 h1) /\
       as_seq h1 s ==

--- a/providers/evercrypt/EverCrypt.Hash.fsti
+++ b/providers/evercrypt/EverCrypt.Hash.fsti
@@ -251,7 +251,7 @@ val update_multi:
   (requires fun h0 ->
     invariant s h0 /\
     B.live h0 blocks /\
-    Spec.Agile.Hash.update_multi_pre a (repr s h0) (ev_of_uint64 a prevlen) (B.as_seq h0 blocks) /\
+    Spec.Agile.Hash.update_multi_pre a (ev_of_uint64 a prevlen) (B.as_seq h0 blocks) /\
     M.(loc_disjoint (footprint s h0) (loc_buffer blocks)))
   (ensures fun h0 _ h1 ->
     M.(modifies (footprint s h0) h0 h1) /\
@@ -295,7 +295,7 @@ val update_last:
   (requires fun h0 ->
     invariant s h0 /\
     B.live h0 last /\
-    Spec.Agile.Hash.update_multi_pre a (repr s h0) (ev_of_uint64 a prev_len) (B.as_seq h0 last) /\
+    Spec.Agile.Hash.update_multi_pre a (ev_of_uint64 a prev_len) (B.as_seq h0 last) /\
     M.(loc_disjoint (footprint s h0) (loc_buffer last)))
   (ensures fun h0 _ h1 ->
     invariant s h1 /\

--- a/specs/Spec.Agile.Hash.fsti
+++ b/specs/Spec.Agile.Hash.fsti
@@ -65,7 +65,6 @@ val update (a:md_alg): update_t a
 (* Because of blake2, we unfortunately have this precondition creeping up. *)
 let update_multi_pre
   (a:hash_alg)
-  (hash:words_state a)
   (prev:extra_state a)
   (blocks:bytes)
 =
@@ -81,7 +80,7 @@ val update_multi
   (prev:extra_state a)
   (blocks:bytes_blocks a):
   Pure (words_state a)
-    (requires update_multi_pre a hash prev blocks)
+    (requires update_multi_pre a prev blocks)
     (ensures fun _ -> True)
 
 val finish (a:hash_alg) (hashw:words_state a): Tot (bytes_hash a)

--- a/specs/lemmas/Spec.Hash.Lemmas.fst
+++ b/specs/lemmas/Spec.Hash.Lemmas.fst
@@ -163,12 +163,12 @@ let update_multi_associative_blake (a: blake_alg)
     S.length input1 % block_length a == 0 /\
     S.length input2 % block_length a == 0 /\
     prevlen2 = prevlen1 + S.length input1 /\
-    update_multi_pre a h prevlen1 (S.append input1 input2)))
+    update_multi_pre a prevlen1 (S.append input1 input2)))
   (ensures (
     let input = S.append input1 input2 in
     S.length input % block_length a == 0 /\
-    update_multi_pre a h prevlen1 input1 /\
-    update_multi_pre a (update_multi a h prevlen1 input1) prevlen2 input2 /\
+    update_multi_pre a prevlen1 input1 /\
+    update_multi_pre a prevlen2 input2 /\
     update_multi a (update_multi a h prevlen1 input1) prevlen2 input2 == update_multi a h prevlen1 input))
   = let input = S.append input1 input2 in
     let nb1 = S.length input1 / block_length a in

--- a/specs/lemmas/Spec.Hash.Lemmas.fsti
+++ b/specs/lemmas/Spec.Hash.Lemmas.fsti
@@ -17,7 +17,7 @@ val update_multi_zero (a: hash_alg { not (is_blake a)} ) (h: words_state a): Lem
   (ensures (update_multi a h () S.empty == h))
 
 val update_multi_zero_blake (a: hash_alg { is_blake a } ) (prevlen: extra_state a) (h: words_state a): Lemma
-  (requires (update_multi_pre a h prevlen S.empty))
+  (requires (update_multi_pre a prevlen S.empty))
   (ensures (update_multi a h prevlen S.empty == h))
 #pop-options
 
@@ -51,12 +51,12 @@ val update_multi_associative_blake (a: blake_alg)
     S.length input1 % block_length a == 0 /\
     S.length input2 % block_length a == 0 /\
     prevlen2 = prevlen1 + S.length input1 /\
-    update_multi_pre a h prevlen1 (S.append input1 input2)))
+    update_multi_pre a prevlen1 (S.append input1 input2)))
   (ensures (
     let input = S.append input1 input2 in
     S.length input % block_length a == 0 /\
-    update_multi_pre a h prevlen1 input1 /\
-    update_multi_pre a (update_multi a h prevlen1 input1) prevlen2 input2 /\
+    update_multi_pre a prevlen1 input1 /\
+    update_multi_pre a prevlen2 input2 /\
     update_multi a (update_multi a h prevlen1 input1) prevlen2 input2 == update_multi a h prevlen1 input))
 
 val block_length_smaller_than_max_input (a:hash_alg) :


### PR DESCRIPTION
## Proposed changes

This PR does a minor cleanup of the hash specs, by removing an unneeded argument in the `update_multi_pre` predicate, and propagating this change to the rest of the codebase.

## Types of changes

- [x] Proof maintenance (non-breaking change which fixes a proof regression)