### PR TITLE
Nix update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,4 @@ dist/wasm/*.wast
 doc/_build
 config.h
 *.smt2
-flake.lock
 *.runlim

--- a/.nix/karamel.nix
+++ b/.nix/karamel.nix
@@ -1,0 +1,52 @@
+{ ocamlPackages, stdenv, symlinks, which, z3, fstar, src }:
+
+stdenv.mkDerivation {
+  pname = "karamel";
+  version = src.rev;
+
+  inherit src;
+
+  buildInputs = [ z3 which symlinks ] ++ (with ocamlPackages; [
+    ocaml
+    ocamlbuild
+    findlib
+    batteries
+    stdint
+    ppx_deriving_yojson
+    zarith
+    pprint
+    menhir
+    menhirLib
+    sedlex
+    process
+    fix
+    wasm
+    visitors
+    ctypes
+  ]);
+
+  FSTAR_HOME = fstar;
+
+  configurePhase = ''
+    export KRML_HOME=$(pwd)
+  '';
+
+  enableParallelBuilding = true;
+  preBuild = ''
+    mkdir -p krmllib/hints
+  '';
+  postBuild = ''
+    symlinks -c $KRML_HOME
+  '';
+
+  doCheck = false;
+  checkPhase = ''
+    make test -j$NIX_BUILD_CORES
+  '';
+
+  installPhase = ''
+    cp -r ./. $out
+  '';
+
+  dontFixup = true;
+}

--- a/.nix/vale.nix
+++ b/.nix/vale.nix
@@ -1,0 +1,66 @@
+{ dotnetPackages, fetchFromGitHub, fetchNuGet, fsharp, mono, scons, stdenv }:
+
+let
+  FsLexYacc = fetchNuGet {
+    pname = "FsLexYacc";
+    version = "6.1.0";
+    sha256 = "1v5myn62zqs431i046gscqw2v0c969fc7pdplx7z9cnpy0p2s4rv";
+    outputFiles = [ "build/*" ];
+  };
+
+  FsLexYaccRuntime = fetchNuGet {
+    pname = "FsLexYacc.Runtime";
+    version = "6.1.0";
+    sha256 = "18vrx4lxsn4hkfishg4abv0d4q21dsph0bm4mdq5z8afaypp5cr7";
+    outputFiles = [ "lib/net40/*" ];
+  };
+
+  vale = stdenv.mkDerivation rec {
+    pname = "vale";
+    version = "0.3.19";
+
+    src = fetchFromGitHub {
+      owner = "project-everest";
+      repo = "vale";
+      rev = "v${version}";
+      sha256 = "sha256-Y6BlLtX8o9gfJgk8FXymwsQ423+vt5QhHIfvGBiLGWE=";
+    };
+
+    postPatch = ''
+      substituteInPlace SConstruct --replace "common_env = Environment()" "common_env = Environment(ENV=os.environ)"
+    '';
+
+    preBuild = ''
+      mkdir -p tools/FsLexYacc/{FsLexYacc.6.1.0/build,FsLexYacc.Runtime.6.1.0/lib/net40}
+      cp -r ${FsLexYacc}/lib/dotnet/FsLexYacc/* tools/FsLexYacc/FsLexYacc.6.1.0/build/
+      cp -r ${FsLexYaccRuntime}/lib/dotnet/FsLexYacc.Runtime/* tools/FsLexYacc/FsLexYacc.Runtime.6.1.0/lib/net40/
+    '';
+
+    buildInputs = [ FsLexYacc fsharp mono scons ];
+
+    enableParallelBuilding = true;
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp bin/* $out/bin
+
+      cp -r . $out
+      for target in vale importFStarTypes; do
+        echo "$DOTNET_JSON_CONF" > $out/bin/$target.runtimeconfig.json
+      done
+    '';
+
+    dontFixup = true;
+
+    DOTNET_JSON_CONF = ''
+      {
+        "runtimeOptions": {
+          "framework": {
+            "name": "Microsoft.NETCore.App",
+            "version": "6.0.0"
+          }
+        }
+      }
+    '';
+  };
+in vale


### PR DESCRIPTION
This PR introduces some changes to the Nix code.

- It adds a dependency to the F* flake, which was merged upstream.
- It moves the expressions for Vale and Karamel to this repository.
- Thus it removes the dependency to hacl-star/hacl-nix and the ugly mutual reference between here and there.
- It filters the source before building, which should avoid some unnecessary rebuilds (for instance an update in `dist/` or in `.github/` will not trigger a full rebuild in Hydra).

Notably, this will help clarify the role of hacl-star/hacl-nix, which sole purpose will become to generate daily lockfiles for Hacl*.
As a future update, it could be nice to move the Nix code for Karamel in the Karamel repository.

