### PR TITLE
Add missing copy functions

### DIFF
--- a/code/streaming/Hacl.Streaming.MD5.fst
+++ b/code/streaming/Hacl.Streaming.MD5.fst
@@ -41,3 +41,5 @@ let legacy_init_md5 = F.init hacl_md5 (G.hide ()) (state_t_md5.s ()) (G.erased u
 let legacy_update_md5 = F.update hacl_md5 (G.hide ()) (state_t_md5.s ()) (G.erased unit)
 let legacy_finish_md5 = F.mk_finish hacl_md5 () (state_t_md5.s ()) (G.erased unit)
 let legacy_free_md5 = F.free hacl_md5 (G.hide ()) (state_t_md5.s ()) (G.erased unit)
+
+let legacy_copy_md5 = F.copy hacl_md5 () (state_t_md5.s ()) (G.erased unit)

--- a/code/streaming/Hacl.Streaming.SHA1.fst
+++ b/code/streaming/Hacl.Streaming.SHA1.fst
@@ -40,3 +40,5 @@ let legacy_init_sha1 = F.init hacl_sha1 (G.hide ()) (state_t_sha1.s ()) (G.erase
 let legacy_update_sha1 = F.update hacl_sha1 (G.hide ()) (state_t_sha1.s ()) (G.erased unit)
 let legacy_finish_sha1 = F.mk_finish hacl_sha1 () (state_t_sha1.s ()) (G.erased unit)
 let legacy_free_sha1 = F.free hacl_sha1 (G.hide ()) (state_t_sha1.s ()) (G.erased unit)
+
+let legacy_copy_sha1 = F.copy hacl_sha1 () (state_t_sha1.s ()) (G.erased unit)

--- a/code/streaming/Hacl.Streaming.SHA3.fst
+++ b/code/streaming/Hacl.Streaming.SHA3.fst
@@ -30,3 +30,4 @@ let init_256 = F.init hacl_sha3_256 (G.hide ()) (state_t_256.s ()) (G.erased uni
 let update_256 = F.update hacl_sha3_256 (G.hide ()) (state_t_256.s ()) (G.erased unit)
 let finish_256 = F.mk_finish hacl_sha3_256 () (state_t_256.s ()) (G.erased unit)
 let free_256 = F.free hacl_sha3_256 (G.hide ()) (state_t_256.s ()) (G.erased unit)
+let copy_256 = F.copy hacl_sha3_256 (G.hide ()) (state_t_256.s ()) (G.erased unit)

--- a/dist/gcc-compatible/Hacl_Streaming_MD5.c
+++ b/dist/gcc-compatible/Hacl_Streaming_MD5.c
@@ -282,3 +282,25 @@ void Hacl_Streaming_MD5_legacy_free_md5(Hacl_Streaming_SHA2_state_sha2_224 *s)
   KRML_HOST_FREE(s);
 }
 
+Hacl_Streaming_SHA2_state_sha2_224
+*Hacl_Streaming_MD5_legacy_copy_md5(Hacl_Streaming_SHA2_state_sha2_224 *s0)
+{
+  Hacl_Streaming_SHA2_state_sha2_224 scrut = *s0;
+  uint32_t *block_state0 = scrut.block_state;
+  uint8_t *buf0 = scrut.buf;
+  uint64_t total_len0 = scrut.total_len;
+  uint8_t *buf = (uint8_t *)KRML_HOST_CALLOC((uint32_t)64U, sizeof (uint8_t));
+  memcpy(buf, buf0, (uint32_t)64U * sizeof (uint8_t));
+  uint32_t *block_state = (uint32_t *)KRML_HOST_CALLOC((uint32_t)4U, sizeof (uint32_t));
+  memcpy(block_state, block_state0, (uint32_t)4U * sizeof (uint32_t));
+  Hacl_Streaming_SHA2_state_sha2_224
+  s = { .block_state = block_state, .buf = buf, .total_len = total_len0 };
+  Hacl_Streaming_SHA2_state_sha2_224
+  *p =
+    (Hacl_Streaming_SHA2_state_sha2_224 *)KRML_HOST_MALLOC(sizeof (
+        Hacl_Streaming_SHA2_state_sha2_224
+      ));
+  p[0U] = s;
+  return p;
+}
+

--- a/dist/gcc-compatible/Hacl_Streaming_MD5.h
+++ b/dist/gcc-compatible/Hacl_Streaming_MD5.h
@@ -58,6 +58,9 @@ void Hacl_Streaming_MD5_legacy_finish_md5(Hacl_Streaming_SHA2_state_sha2_224 *p,
 
 void Hacl_Streaming_MD5_legacy_free_md5(Hacl_Streaming_SHA2_state_sha2_224 *s);
 
+Hacl_Streaming_SHA2_state_sha2_224
+*Hacl_Streaming_MD5_legacy_copy_md5(Hacl_Streaming_SHA2_state_sha2_224 *s0);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/dist/gcc-compatible/Hacl_Streaming_SHA1.c
+++ b/dist/gcc-compatible/Hacl_Streaming_SHA1.c
@@ -283,3 +283,25 @@ void Hacl_Streaming_SHA1_legacy_free_sha1(Hacl_Streaming_SHA2_state_sha2_224 *s)
   KRML_HOST_FREE(s);
 }
 
+Hacl_Streaming_SHA2_state_sha2_224
+*Hacl_Streaming_SHA1_legacy_copy_sha1(Hacl_Streaming_SHA2_state_sha2_224 *s0)
+{
+  Hacl_Streaming_SHA2_state_sha2_224 scrut = *s0;
+  uint32_t *block_state0 = scrut.block_state;
+  uint8_t *buf0 = scrut.buf;
+  uint64_t total_len0 = scrut.total_len;
+  uint8_t *buf = (uint8_t *)KRML_HOST_CALLOC((uint32_t)64U, sizeof (uint8_t));
+  memcpy(buf, buf0, (uint32_t)64U * sizeof (uint8_t));
+  uint32_t *block_state = (uint32_t *)KRML_HOST_CALLOC((uint32_t)5U, sizeof (uint32_t));
+  memcpy(block_state, block_state0, (uint32_t)5U * sizeof (uint32_t));
+  Hacl_Streaming_SHA2_state_sha2_224
+  s = { .block_state = block_state, .buf = buf, .total_len = total_len0 };
+  Hacl_Streaming_SHA2_state_sha2_224
+  *p =
+    (Hacl_Streaming_SHA2_state_sha2_224 *)KRML_HOST_MALLOC(sizeof (
+        Hacl_Streaming_SHA2_state_sha2_224
+      ));
+  p[0U] = s;
+  return p;
+}
+

--- a/dist/gcc-compatible/Hacl_Streaming_SHA1.h
+++ b/dist/gcc-compatible/Hacl_Streaming_SHA1.h
@@ -59,6 +59,9 @@ Hacl_Streaming_SHA1_legacy_finish_sha1(Hacl_Streaming_SHA2_state_sha2_224 *p, ui
 
 void Hacl_Streaming_SHA1_legacy_free_sha1(Hacl_Streaming_SHA2_state_sha2_224 *s);
 
+Hacl_Streaming_SHA2_state_sha2_224
+*Hacl_Streaming_SHA1_legacy_copy_sha1(Hacl_Streaming_SHA2_state_sha2_224 *s0);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/dist/gcc-compatible/Hacl_Streaming_SHA3.c
+++ b/dist/gcc-compatible/Hacl_Streaming_SHA3.c
@@ -325,3 +325,25 @@ void Hacl_Streaming_SHA3_free_256(Hacl_Streaming_SHA2_state_sha2_384 *s)
   KRML_HOST_FREE(s);
 }
 
+Hacl_Streaming_SHA2_state_sha2_384
+*Hacl_Streaming_SHA3_copy_256(Hacl_Streaming_SHA2_state_sha2_384 *s0)
+{
+  Hacl_Streaming_SHA2_state_sha2_384 scrut = *s0;
+  uint64_t *block_state0 = scrut.block_state;
+  uint8_t *buf0 = scrut.buf;
+  uint64_t total_len0 = scrut.total_len;
+  uint8_t *buf = (uint8_t *)KRML_HOST_CALLOC((uint32_t)136U, sizeof (uint8_t));
+  memcpy(buf, buf0, (uint32_t)136U * sizeof (uint8_t));
+  uint64_t *block_state = (uint64_t *)KRML_HOST_CALLOC((uint32_t)25U, sizeof (uint64_t));
+  memcpy(block_state, block_state0, (uint32_t)25U * sizeof (uint64_t));
+  Hacl_Streaming_SHA2_state_sha2_384
+  s = { .block_state = block_state, .buf = buf, .total_len = total_len0 };
+  Hacl_Streaming_SHA2_state_sha2_384
+  *p =
+    (Hacl_Streaming_SHA2_state_sha2_384 *)KRML_HOST_MALLOC(sizeof (
+        Hacl_Streaming_SHA2_state_sha2_384
+      ));
+  p[0U] = s;
+  return p;
+}
+

--- a/dist/gcc-compatible/Hacl_Streaming_SHA3.h
+++ b/dist/gcc-compatible/Hacl_Streaming_SHA3.h
@@ -59,6 +59,9 @@ void Hacl_Streaming_SHA3_finish_256(Hacl_Streaming_SHA2_state_sha2_384 *p, uint8
 
 void Hacl_Streaming_SHA3_free_256(Hacl_Streaming_SHA2_state_sha2_384 *s);
 
+Hacl_Streaming_SHA2_state_sha2_384
+*Hacl_Streaming_SHA3_copy_256(Hacl_Streaming_SHA2_state_sha2_384 *s0);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/dist/gcc-compatible/lib/Hacl_Streaming_MD5_bindings.ml
+++ b/dist/gcc-compatible/lib/Hacl_Streaming_MD5_bindings.ml
@@ -26,4 +26,8 @@ module Bindings(F:Cstubs.FOREIGN) =
     let hacl_Streaming_MD5_legacy_free_md5 =
       foreign "Hacl_Streaming_MD5_legacy_free_md5"
         ((ptr hacl_Streaming_SHA2_state_sha2_224) @-> (returning void))
+    let hacl_Streaming_MD5_legacy_copy_md5 =
+      foreign "Hacl_Streaming_MD5_legacy_copy_md5"
+        ((ptr hacl_Streaming_SHA2_state_sha2_224) @->
+           (returning (ptr hacl_Streaming_SHA2_state_sha2_224)))
   end

--- a/dist/gcc-compatible/lib/Hacl_Streaming_SHA1_bindings.ml
+++ b/dist/gcc-compatible/lib/Hacl_Streaming_SHA1_bindings.ml
@@ -26,4 +26,8 @@ module Bindings(F:Cstubs.FOREIGN) =
     let hacl_Streaming_SHA1_legacy_free_sha1 =
       foreign "Hacl_Streaming_SHA1_legacy_free_sha1"
         ((ptr hacl_Streaming_SHA2_state_sha2_224) @-> (returning void))
+    let hacl_Streaming_SHA1_legacy_copy_sha1 =
+      foreign "Hacl_Streaming_SHA1_legacy_copy_sha1"
+        ((ptr hacl_Streaming_SHA2_state_sha2_224) @->
+           (returning (ptr hacl_Streaming_SHA2_state_sha2_224)))
   end

--- a/dist/gcc-compatible/lib/Hacl_Streaming_SHA3_bindings.ml
+++ b/dist/gcc-compatible/lib/Hacl_Streaming_SHA3_bindings.ml
@@ -27,4 +27,8 @@ module Bindings(F:Cstubs.FOREIGN) =
     let hacl_Streaming_SHA3_free_256 =
       foreign "Hacl_Streaming_SHA3_free_256"
         ((ptr hacl_Streaming_SHA2_state_sha2_384) @-> (returning void))
+    let hacl_Streaming_SHA3_copy_256 =
+      foreign "Hacl_Streaming_SHA3_copy_256"
+        ((ptr hacl_Streaming_SHA2_state_sha2_384) @->
+           (returning (ptr hacl_Streaming_SHA2_state_sha2_384)))
   end


### PR DESCRIPTION
This adds the missing copy functions for the streaming APIs for MD5, SHA1 and SHA3 respectively.