### PR TITLE
Fix the `hacl-packages-create-branch` workflow

### DIFF
--- a/.github/workflows/hacl-packages-create-branch.yml
+++ b/.github/workflows/hacl-packages-create-branch.yml
@@ -11,6 +11,7 @@ jobs:
       - name: checkout hacl-star
         uses: actions/checkout@v3
         with:
+          ref: ${{ github.head_ref }}
           path: hacl-star
       - name: checkout hacl-packages
         uses: actions/checkout@v3


### PR DESCRIPTION
The `hacl-packages-create-branch` workflow seems to checkout the `main` branch instead of the one that triggered the action.
To fix this, this PR explicitely sets the action's argument defining the reference to checkout (see https://github.com/actions/checkout#usage).