### PR TITLE
Fix endianness issue in AIX

### DIFF
--- a/dist/karamel/include/krml/lowstar_endianness.h
+++ b/dist/karamel/include/krml/lowstar_endianness.h
@@ -96,7 +96,8 @@
 #  define le64toh(x) (x)
 
 /* ... generic big-endian fallback code */
-#elif defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+/* ... AIX doesn't have __BYTE_ORDER__ (with XLC compiler) & is always big-endian */
+#elif (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) || defined(_AIX)
 
 /* byte swapping code inspired by:
  * https://github.com/rweather/arduinolibs/blob/master/libraries/Crypto/utility/EndianUtil.h


### PR DESCRIPTION
AIX (always a big-endian) doesn't have `__BYTE_ORDER__` defined in any of its header files. GCC for this reason defines `__BYTE_ORDER__` in its own header files for AIX. But with XLC compiler, it's not the case. 
The issue is exposed while compiling the latest python --> https://github.com/python/cpython/pull/102206/
