### PR TITLE
Update usage of --split_queries

### DIFF
--- a/code/meta/example/Device.fst
+++ b/code/meta/example/Device.fst
@@ -9,7 +9,7 @@ module ST = FStar.HyperStack.ST
 open FStar.HyperStack.ST
 open LowStar.BufferOps
 
-#set-options "--z3rlimit 100 --fuel 1 --ifuel 1 --__no_positivity --record_options --split_queries"
+#set-options "--z3rlimit 100 --fuel 1 --ifuel 1 --__no_positivity --record_options --split_queries always"
 
 (*** Linked lists *)
 noeq


### PR DESCRIPTION
This is a fix needed to merge https://github.com/FStarLang/FStar/pull/2776. I will update this later with an everest green including both changes.

## Proposed changes

An upcoming PR in F* will require an argument for `--split_queries`, either `no`, `on_failure` or `always`. The default is `on_failure` (same as not passing the flag before). The old behavior is obtained with `--split_queries always`. So, this just replaces uses of the option to the `always.`

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [x] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [x] I have added necessary documentation (if appropriate)
- [x] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
