### PR TITLE
vale: QuickCodes: open FStar.Range

### DIFF
--- a/vale/code/arch/ppc64le/Vale.PPC64LE.QuickCodes.fst
+++ b/vale/code/arch/ppc64le/Vale.PPC64LE.QuickCodes.fst
@@ -1,5 +1,6 @@
 module Vale.PPC64LE.QuickCodes
 open FStar.Mul
+open FStar.Range
 open Vale.Arch.HeapImpl
 module Map16 = Vale.Lib.Map16
 friend Vale.PPC64LE.Stack_Sems

--- a/vale/code/arch/ppc64le/Vale.PPC64LE.QuickCodes.fsti
+++ b/vale/code/arch/ppc64le/Vale.PPC64LE.QuickCodes.fsti
@@ -1,6 +1,7 @@
 module Vale.PPC64LE.QuickCodes
 // Optimized weakest precondition generation for 'quick' procedures
 open FStar.Mul
+open FStar.Range
 open Vale.Def.Prop_s
 open Vale.Arch.HeapImpl
 open Vale.PPC64LE.Machine_s

--- a/vale/code/arch/x64/Vale.X64.QuickCodes.fst
+++ b/vale/code/arch/x64/Vale.X64.QuickCodes.fst
@@ -1,6 +1,7 @@
 module Vale.X64.QuickCodes
 open FStar.Mul
 open Vale.Arch.HeapImpl
+open FStar.Range
 module Map16 = Vale.Lib.Map16
 
 #reset-options "--initial_ifuel 1 --z3rlimit 30"

--- a/vale/code/arch/x64/Vale.X64.QuickCodes.fsti
+++ b/vale/code/arch/x64/Vale.X64.QuickCodes.fsti
@@ -1,6 +1,7 @@
 module Vale.X64.QuickCodes
 // Optimized weakest precondition generation for 'quick' procedures
 open FStar.Mul
+open FStar.Range
 open Vale.Def.Prop_s
 open Vale.Arch.HeapImpl
 open Vale.X64.Machine_s


### PR DESCRIPTION
The `range` type and `labeled` function moved from Prims into this module.

This is going to be needed after merging PR FStarLang/FStar#2892. Will update with Everest green on CI machine here: ___.

Also, a question: should I take these files as authoritative? What's the relation between them and the ones in the Vale repo?

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [x] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)