### PR TITLE
Extend the max input length bound for SHA3

### DIFF
--- a/code/streaming/Hacl.Streaming.Keccak.fst
+++ b/code/streaming/Hacl.Streaming.Keccak.fst
@@ -124,7 +124,7 @@ let hacl_keccak (a: G.erased alg): block alg =
     (stateful_unused alg) (* key *)
     Lib.IntTypes.(x:size_t { v x > 0 }) (* output_length_t *)
 
-    (fun _ -> 0xffffffffUL) (* max_input_len *)
+    (fun _ -> 0xffffffffffffffffUL) (* max_input_len *)
     (fun a l -> if is_shake_ a then Lib.IntTypes.v l else Spec.Hash.Definitions.hash_length a) (* output_length *)
     Hacl.Hash.SHA3.block_len (* block_len *)
     Hacl.Hash.SHA3.block_len (* blocks_state_len *)

--- a/dist/gcc-compatible/Hacl_Hash_SHA3.c
+++ b/dist/gcc-compatible/Hacl_Hash_SHA3.c
@@ -244,7 +244,7 @@ Hacl_Streaming_Keccak_update(Hacl_Streaming_Keccak_state *p, uint8_t *data, uint
   Hacl_Streaming_Keccak_hash_buf block_state = s.block_state;
   uint64_t total_len = s.total_len;
   Spec_Hash_Definitions_hash_alg i = block_state.fst;
-  if ((uint64_t)len > (uint64_t)0xffffffffU - total_len)
+  if ((uint64_t)len > (uint64_t)0xffffffffffffffffU - total_len)
   {
     return (uint32_t)1U;
   }


### PR DESCRIPTION
Owing to a typo, the length of data that could be hashed by the SHA3 streaming API was artificially low. This did not affect soundness, but just meant that the `update` function would return a non-zero return value to indicate that the maximum input length was exceeded.

The new max input length is 2^64-1, which no client can exceed in reasonable time.