### PR TITLE
EverCrypt.Hash: use @@strict_on_arguments for efficiency

### DIFF
--- a/providers/evercrypt/fst/EverCrypt.Hash.fst
+++ b/providers/evercrypt/fst/EverCrypt.Hash.fst
@@ -131,6 +131,7 @@ let invert_state_s (a: alg): Lemma
 =
   allow_inversion (state_s a)
 
+[@@strict_on_arguments [1]]
 inline_for_extraction
 let impl_of_state #a (s: state_s a): i:impl { alg_of_impl i == a } =
   match s with
@@ -155,6 +156,7 @@ let impl_of_state #a (s: state_s a): i:impl { alg_of_impl i == a } =
 //   ...) so as not to repeat redundant information at run-time
 // - hope that we can get away with returning dependent pairs only when needed.
 // We're going for a third one in this module, which is more lightweight.
+[@@strict_on_arguments [1]]
 inline_for_extraction
 let p #a (s: state_s a): Hacl.Hash.Definitions.state (impl_of_state s) =
   match s with
@@ -215,6 +217,7 @@ let frame_invariant #a l s h0 h1 =
   assert (repr_eq (repr s h0) (repr s h1))
 
 inline_for_extraction noextract
+[@@strict_on_arguments [0]]
 let alloca a =
   let s: state_s a =
     match a with
@@ -253,6 +256,7 @@ let alloca a =
   in
   B.alloca s 1ul
 
+[@@strict_on_arguments [0]]
 let create_in a r =
   let h0 = ST.get () in
   let s: state_s a =


### PR DESCRIPTION
The extraction of EverCrypt.Hash.Incremental has a peak memory usage of around 11GB, and takes around 10 minutes (on my setup). Some cursory inspection of F* debug output showed many normalization calls involving matches to destroy the hash state type, as is done in these functions.

Unfolding these functions into the match is (very) useful if the matched-on argument is a literal constructor, so the match can reduce, but a waste that can lead to an exponential explosion otherwise.

Hence, use the strict_on_arguments attribute to make F* 1) eagerly reduce the arguments to these functions before unfolding, and 2) only unfold if the specified arguments are concrete (i.e. the head is
   a constructor).

Re measuring showed that memory usage falls from 11084 MB to 3596 MB when extracting EverCrypt_Hash_Incremental.krml. Runtime decreases from 691s to 112s (again on my setup, measured in isolation).

A full build passed with this patch, and the `dist` directory ended up exactly the same on both runs. Also the extracted `krml` file is equal byte-for-byte.

There likely are more functions that can be benefit from this attribute.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [x] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)

## Further comments

Hi, we first noticed this file was taking tons of memory here https://github.com/FStarLang/FStar/pull/2734. I finally looked into it.

Here are some comparisons of a full build running before and after this patch, see how the memory usage peaks are lower (especially the second one). You can also see how `obj/EverCrypt_Hash_Incremental.krml.end` appears earlier.

![hacl_nf1 ramon](https://github.com/hacl-star/hacl-star/assets/4195583/862a4408-ad17-4610-aa5a-4a4dc0eb1dbb)
![hacl_nf2 ramon](https://github.com/hacl-star/hacl-star/assets/4195583/b508cd35-081d-4268-bf54-cca21ed39887)

Also the bottom line of extracting this file for both before and after:
```
group.total          692.154s
group.utime          686.489s
group.stime          5.665s
group.mempeak        11084MB
group.pidpeak        5
status               exited
exitcode             0
walltime             691.669s
loadavg              1.00
```
```
group.total          114.156s
group.utime          112.439s
group.stime          1.716s
group.mempeak        3596MB
group.pidpeak        5
status               exited
exitcode             0
walltime             114.140s
loadavg              1.00
```

(These results are from a tool that I am writing on and off, I hope to get it good enough to replace runlim and use it everywhere in our builds.)

Please run your tests though! I only did `make`.