### PR TITLE
fix hacl-packages CI for PRs from forks

### DIFF
--- a/.github/workflows/hacl-packages-create-branch.yml
+++ b/.github/workflows/hacl-packages-create-branch.yml
@@ -11,7 +11,7 @@ jobs:
       - name: checkout hacl-star
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           path: hacl-star
       - name: checkout hacl-packages
         uses: actions/checkout@v3


### PR DESCRIPTION
At the moment, PRs from forks fail to create a branch on the hacl-packages repository.
The checkout action fails because it is executed in the context of the hacl-star repository, which does not know the head ref of the PR.
Using the hash of the head commit instead seems to solve the problem.
