### PR TITLE
Fix size of key in handwritten C chacha test

### DIFF
--- a/tests/chacha20-test.c
+++ b/tests/chacha20-test.c
@@ -49,10 +49,10 @@ main()
 
   uint64_t len = SIZE;
   uint8_t plain[SIZE];
-  uint8_t key[16];
+  uint8_t key[32];
   uint8_t nonce[12];
   memset(plain, 'P', SIZE);
-  memset(key, 'K', 16);
+  memset(key, 'K', 32);
   memset(nonce, 'N', 12);
 
   for (int j = 0; j < ROUNDS; j++) {


### PR DESCRIPTION
## Proposed changes

Keys for chacha20 should be 32 bytes long (see e.g. https://github.com/hacl-star/hacl-star/blob/main/code/chacha20/Hacl.Chacha20.fst#L13). This PR fixes a handwritten C test for Chacha to satisfy this requirement.
Reported offline by @rmonat 