### PR TITLE
CI: use a self-hosted github runner

### DIFF
--- a/.github/workflows/hintsanddist.yml
+++ b/.github/workflows/hintsanddist.yml
@@ -7,43 +7,17 @@ on:
 
 jobs:
   regenerate-hints-and-dist:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: checkout
         uses: actions/checkout@v3
 
-      - name: delete old files
-        run: git rm -r hints dist/*/*
-
-      - name: download new files
+      - name: regenerate hints and dist
         run: |
-          STATUS_SUCCEEDED=0 # from https://github.com/NixOS/hydra/blob/cf9f38e43fd81f9298e3f2ff50c8a6ee0acc3af0/hydra-api.yaml#L927-L941
-          baseUrl="https://everest-ci.paris.inria.fr"
-          latestFinishedEval=$(curl -sLH 'Content-Type: application/json' "$baseUrl/jobset/hacl-star/branch-main/latest-eval")
-
-          rev=$(echo "$latestFinishedEval" | jq -r '.flake | split("/") | last')
-          id=$(echo "$latestFinishedEval" | jq -r '.id')
-
-          [[ "$rev" == "$(git rev-parse HEAD)" ]] || {
-              echo "The latest evaluation on the CI doesn't correspond to the latest commit."
-              exit 1
-          }
-
-          buildUrl="$baseUrl/eval/$id/job/hacl-build-products.x86_64-linux"
-          buildInfo=$(curl -sLH 'Content-Type: application/json' "$buildUrl")
-
-          # Check wether the build was successful
-          [[ "$(echo "$buildInfo" | jq -r '.buildstatus')" == "$STATUS_SUCCEEDED" ]] || {
-              echo "The latest evaluation wasn't successful. Aborting."
-              exit 2
-          }
-
-          installTar () {
-              curl -sL "$buildUrl/download-by-type/file/$1" | tar -xv
-          }
-
-          installTar "hints"
-          installTar "dist"
+          git rm -r hints dist/*/*
+          nix build .#hacl.passthru.build-products
+          tar -xvf result/hints.tar
+          tar -xvf result/dist.tar
 
       - name: commit changes
         run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,22 @@
+name: Nix
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  nix:
+    runs-on: self-hosted
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: build hacl
+        run: |
+          nix build .#hacl
+      - name: resource monitor
+        run: |
+          nix build .#hacl.passthru.resource-monitor
+          cat result/resources.txt

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,6 +16,9 @@ jobs:
       - name: build hacl
         run: |
           nix build -L .#hacl
+      - name: build logs
+        run: |
+          nix log .#hacl
       - name: resource monitor
         run: |
           nix build .#hacl.passthru.resource-monitor

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
       - name: build hacl
         run: |
-          nix build .#hacl
+          nix build -L .#hacl
       - name: resource monitor
         run: |
           nix build .#hacl.passthru.resource-monitor

--- a/.nix/hacl.nix
+++ b/.nix/hacl.nix
@@ -175,18 +175,15 @@ let
           git archive HEAD dist/* > dist.tar
         '';
         installPhase = ''
-          mkdir -p $out/nix-support
+          mkdir -p $out
           cp hints.tar dist.tar $out
-          echo "file hints $out/hints.tar" >> $out/nix-support/hydra-build-products
-          echo "file dist $out/dist.tar" >> $out/nix-support/hydra-build-products
         '';
       };
       stats = stdenv.mkDerivation {
         name = "hacl-stats";
         phases = [ "installPhase" ];
         installPhase = ''
-          mkdir -p $out/nix-support
-          echo "file stats $out/stats.txt" >> $out/nix-support/hydra-build-products
+          mkdir -p $out
           cat ${hacl}/log.txt \
               | grep "^\[VERIFY\]" \
               | sed 's/\[VERIFY\] \(.*\), \(.*\)/\2 \1/' \
@@ -198,9 +195,8 @@ let
         src = hacl;
         dontBuild = true;
         installPhase = ''
-          mkdir -p $out/nix-support
+          mkdir -p $out
           bash ${fstar-scripts}/res_summary.sh > $out/resources.txt
-          echo "file resources $out/resources.txt" >> $out/nix-support/hydra-build-products
         '';
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -31,13 +31,5 @@
           inherit hacl;
           default = hacl;
         };
-        hydraJobs = {
-          inherit hacl;
-          hacl-build-products = hacl.passthru.build-products;
-          hacl-stats = hacl.passthru.stats;
-          hacl-dist-compare = hacl.passthru.dist-compare;
-          hacl-dist-list = hacl.passthru.dist-list;
-          hacl-resource-monitor = hacl.passthru.resource-monitor;
-        };
       });
 }


### PR DESCRIPTION
Because of the upsurge of problems with Hydra, I propose to switch to a self-hosted github runner.
The new workflow will directly call nix from the same server that hosted the Hydra instance.
Using self-hosted runners on public repositories is usually discouraged because of adversarial pull requests.
Here, I argue that the risk is strongly mitigated thanks to the nix sandbox, as long as we only self-host simple nix commands.
(in fact, the risk stays essentially the same as with the Hydra instance, since an adversarial PR could already build arbitrary nix derivations)