### PR TITLE
ci: update and fix `hintsanddist.yml`

### DIFF
--- a/.github/workflows/hintsanddist.yml
+++ b/.github/workflows/hintsanddist.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: regenerate hints and dist
         run: |
           # build the new artifacts (in ./result)
-          nix build .#hacl.passthru.build-products
+          nix build --no-write-lock-file .#hacl.passthru.build-products
           # delete the old ones
           git rm -r hints dist/*/*
           # copy the new artifacts
@@ -33,8 +33,13 @@ jobs:
         run: |
           [[ 1 -lt $(git diff --compact-summary HEAD~.. | grep -v INFO.txt | wc -l) ]]
 
+      - name: leave no uncommitted changes
+        run: |
+          git restore .
+          git clean -xfd
+
       - name: create pull request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.HACL_BOT }}
           branch: "hints-and-dist-main"

--- a/.nix/hacl.nix
+++ b/.nix/hacl.nix
@@ -1,6 +1,6 @@
-{ dotnet-runtime, fetchFromGitHub, fstar, fstar-scripts, git, karamel, lib
-, ocamlPackages, openssl, python3, stdenv, time, vale, which, writeTextFile, z3
-}:
+{ bash, dotnet-runtime, fetchFromGitHub, fstar, fstar-scripts, git, karamel, lib
+, ocamlPackages, openssl, python3, sd, stdenv, time, vale, which, writeTextFile
+, z3 }:
 
 let
 
@@ -151,13 +151,13 @@ let
       build-products = stdenv.mkDerivation {
         name = "hacl-build-products";
         src = hacl;
-        buildInputs = [ git ];
+        buildInputs = [ git sd ];
         buildPhase = ''
-          sed -i 's/\#\!.*/\#\!\/usr\/bin\/env bash/' dist/configure
-          sed -i 's/\#\!.*/\#\!\/usr\/bin\/env bash/' dist/package-mozilla.sh
-          for target in gcc-compatible msvc-compatible portable-gcc-compatible
+          sd '${bash}/bin/bash' '/usr/bin/env bash' dist/configure
+          sd '${bash}/bin/bash' '/usr/bin/env bash' dist/package-mozilla.sh
+          for target in gcc-compatible msvc-compatible portable-gcc-compatible mozilla
           do
-            sed -i 's/\#\!.*/\#\!\/usr\/bin\/env bash/' dist/$target/configure
+            sd '${bash}/bin/bash' '/usr/bin/env bash' dist/$target/configure
           done
 
           for target in gcc-compatible mozilla msvc-compatible portable-gcc-compatible wasm


### PR DESCRIPTION
The new regeneration workflow is broken: it commits the flake lock file and a link to the store.
I did not realize that https://github.com/peter-evans/create-pull-request is designed to commit any uncommitted changes before creating a PR.
The old regeneration workflow did not write anything on disk beside the intended changes, so I never noticed.
This should fix the issue by not writing the lock file and cleaning the repository before running `create-pull-request`.