### PR TITLE
Make code compile with all warnings enabled

### DIFF
--- a/dist/gcc-compatible/EverCrypt_AEAD.c
+++ b/dist/gcc-compatible/EverCrypt_AEAD.c
@@ -46,6 +46,8 @@ The state may be reused as many times as desired.
 */
 bool EverCrypt_AEAD_uu___is_Ek(Spec_Agile_AEAD_alg a, EverCrypt_AEAD_state_s projectee)
 {
+  KRML_HOST_IGNORE(a);
+  KRML_HOST_IGNORE(projectee);
   return true;
 }
 
@@ -108,8 +110,8 @@ create_in_aes128_gcm(EverCrypt_AEAD_state_s **dst, uint8_t *k)
     uint8_t *ek = (uint8_t *)KRML_HOST_CALLOC((uint32_t)480U, sizeof (uint8_t));
     uint8_t *keys_b = ek;
     uint8_t *hkeys_b = ek + (uint32_t)176U;
-    uint64_t scrut = aes128_key_expansion(k, keys_b);
-    uint64_t scrut0 = aes128_keyhash_init(keys_b, hkeys_b);
+    KRML_HOST_IGNORE(aes128_key_expansion(k, keys_b));
+    KRML_HOST_IGNORE(aes128_keyhash_init(keys_b, hkeys_b));
     EverCrypt_AEAD_state_s
     *p = (EverCrypt_AEAD_state_s *)KRML_HOST_MALLOC(sizeof (EverCrypt_AEAD_state_s));
     p[0U] = ((EverCrypt_AEAD_state_s){ .impl = Spec_Cipher_Expansion_Vale_AES128, .ek = ek });
@@ -136,8 +138,8 @@ create_in_aes256_gcm(EverCrypt_AEAD_state_s **dst, uint8_t *k)
     uint8_t *ek = (uint8_t *)KRML_HOST_CALLOC((uint32_t)544U, sizeof (uint8_t));
     uint8_t *keys_b = ek;
     uint8_t *hkeys_b = ek + (uint32_t)240U;
-    uint64_t scrut = aes256_key_expansion(k, keys_b);
-    uint64_t scrut0 = aes256_keyhash_init(keys_b, hkeys_b);
+    KRML_HOST_IGNORE(aes256_key_expansion(k, keys_b));
+    KRML_HOST_IGNORE(aes256_keyhash_init(keys_b, hkeys_b));
     EverCrypt_AEAD_state_s
     *p = (EverCrypt_AEAD_state_s *)KRML_HOST_MALLOC(sizeof (EverCrypt_AEAD_state_s));
     p[0U] = ((EverCrypt_AEAD_state_s){ .impl = Spec_Cipher_Expansion_Vale_AES256, .ek = ek });
@@ -223,8 +225,12 @@ encrypt_aes128_gcm(
   uint32_t bytes_len = len * (uint32_t)16U;
   uint8_t *iv_b = iv;
   memcpy(tmp_iv, iv + bytes_len, iv_len % (uint32_t)16U * sizeof (uint8_t));
-  uint64_t
-  uu____0 = compute_iv_stdcall(iv_b, (uint64_t)iv_len, (uint64_t)len, tmp_iv, tmp_iv, hkeys_b);
+  KRML_HOST_IGNORE(compute_iv_stdcall(iv_b,
+      (uint64_t)iv_len,
+      (uint64_t)len,
+      tmp_iv,
+      tmp_iv,
+      hkeys_b));
   uint8_t *inout_b = scratch_b;
   uint8_t *abytes_b = scratch_b + (uint32_t)16U;
   uint8_t *scratch_b1 = scratch_b + (uint32_t)32U;
@@ -250,9 +256,7 @@ encrypt_aes128_gcm(
     uint64_t auth_num = (uint64_t)ad_len / (uint64_t)16U;
     uint64_t len128x6_ = len128x6 / (uint64_t)16U;
     uint64_t len128_num_ = len128_num / (uint64_t)16U;
-    uint64_t
-    scrut0 =
-      gcm128_encrypt_opt(auth_b_,
+    KRML_HOST_IGNORE(gcm128_encrypt_opt(auth_b_,
         (uint64_t)ad_len,
         auth_num,
         keys_b,
@@ -268,7 +272,7 @@ encrypt_aes128_gcm(
         inout_b,
         (uint64_t)plain_len,
         scratch_b1,
-        tag);
+        tag));
   }
   else
   {
@@ -281,9 +285,7 @@ encrypt_aes128_gcm(
     uint64_t auth_num = (uint64_t)ad_len / (uint64_t)16U;
     uint64_t len128_num_ = len128_num / (uint64_t)16U;
     uint64_t len128x6_ = (uint64_t)0U;
-    uint64_t
-    scrut0 =
-      gcm128_encrypt_opt(auth_b_,
+    KRML_HOST_IGNORE(gcm128_encrypt_opt(auth_b_,
         (uint64_t)ad_len,
         auth_num,
         keys_b,
@@ -299,7 +301,7 @@ encrypt_aes128_gcm(
         inout_b,
         (uint64_t)plain_len,
         scratch_b1,
-        tag);
+        tag));
   }
   memcpy(cipher + (uint32_t)(uint64_t)plain_len / (uint32_t)16U * (uint32_t)16U,
     inout_b,
@@ -347,8 +349,12 @@ encrypt_aes256_gcm(
   uint32_t bytes_len = len * (uint32_t)16U;
   uint8_t *iv_b = iv;
   memcpy(tmp_iv, iv + bytes_len, iv_len % (uint32_t)16U * sizeof (uint8_t));
-  uint64_t
-  uu____0 = compute_iv_stdcall(iv_b, (uint64_t)iv_len, (uint64_t)len, tmp_iv, tmp_iv, hkeys_b);
+  KRML_HOST_IGNORE(compute_iv_stdcall(iv_b,
+      (uint64_t)iv_len,
+      (uint64_t)len,
+      tmp_iv,
+      tmp_iv,
+      hkeys_b));
   uint8_t *inout_b = scratch_b;
   uint8_t *abytes_b = scratch_b + (uint32_t)16U;
   uint8_t *scratch_b1 = scratch_b + (uint32_t)32U;
@@ -374,9 +380,7 @@ encrypt_aes256_gcm(
     uint64_t auth_num = (uint64_t)ad_len / (uint64_t)16U;
     uint64_t len128x6_ = len128x6 / (uint64_t)16U;
     uint64_t len128_num_ = len128_num / (uint64_t)16U;
-    uint64_t
-    scrut0 =
-      gcm256_encrypt_opt(auth_b_,
+    KRML_HOST_IGNORE(gcm256_encrypt_opt(auth_b_,
         (uint64_t)ad_len,
         auth_num,
         keys_b,
@@ -392,7 +396,7 @@ encrypt_aes256_gcm(
         inout_b,
         (uint64_t)plain_len,
         scratch_b1,
-        tag);
+        tag));
   }
   else
   {
@@ -405,9 +409,7 @@ encrypt_aes256_gcm(
     uint64_t auth_num = (uint64_t)ad_len / (uint64_t)16U;
     uint64_t len128_num_ = len128_num / (uint64_t)16U;
     uint64_t len128x6_ = (uint64_t)0U;
-    uint64_t
-    scrut0 =
-      gcm256_encrypt_opt(auth_b_,
+    KRML_HOST_IGNORE(gcm256_encrypt_opt(auth_b_,
         (uint64_t)ad_len,
         auth_num,
         keys_b,
@@ -423,7 +425,7 @@ encrypt_aes256_gcm(
         inout_b,
         (uint64_t)plain_len,
         scratch_b1,
-        tag);
+        tag));
   }
   memcpy(cipher + (uint32_t)(uint64_t)plain_len / (uint32_t)16U * (uint32_t)16U,
     inout_b,
@@ -529,18 +531,17 @@ EverCrypt_AEAD_encrypt_expand_aes128_gcm_no_check(
   uint8_t ek[480U] = { 0U };
   uint8_t *keys_b0 = ek;
   uint8_t *hkeys_b0 = ek + (uint32_t)176U;
-  uint64_t scrut0 = aes128_key_expansion(k, keys_b0);
-  uint64_t scrut1 = aes128_keyhash_init(keys_b0, hkeys_b0);
+  KRML_HOST_IGNORE(aes128_key_expansion(k, keys_b0));
+  KRML_HOST_IGNORE(aes128_keyhash_init(keys_b0, hkeys_b0));
   EverCrypt_AEAD_state_s p = { .impl = Spec_Cipher_Expansion_Vale_AES128, .ek = ek };
   EverCrypt_AEAD_state_s *s = &p;
-  EverCrypt_Error_error_code r;
   if (s == NULL)
   {
-    r = EverCrypt_Error_InvalidKey;
+    KRML_HOST_IGNORE(EverCrypt_Error_InvalidKey);
   }
   else if (iv_len == (uint32_t)0U)
   {
-    r = EverCrypt_Error_InvalidIVLength;
+    KRML_HOST_IGNORE(EverCrypt_Error_InvalidIVLength);
   }
   else
   {
@@ -555,8 +556,12 @@ EverCrypt_AEAD_encrypt_expand_aes128_gcm_no_check(
     uint32_t bytes_len = len * (uint32_t)16U;
     uint8_t *iv_b = iv;
     memcpy(tmp_iv, iv + bytes_len, iv_len % (uint32_t)16U * sizeof (uint8_t));
-    uint64_t
-    uu____0 = compute_iv_stdcall(iv_b, (uint64_t)iv_len, (uint64_t)len, tmp_iv, tmp_iv, hkeys_b);
+    KRML_HOST_IGNORE(compute_iv_stdcall(iv_b,
+        (uint64_t)iv_len,
+        (uint64_t)len,
+        tmp_iv,
+        tmp_iv,
+        hkeys_b));
     uint8_t *inout_b = scratch_b;
     uint8_t *abytes_b = scratch_b + (uint32_t)16U;
     uint8_t *scratch_b1 = scratch_b + (uint32_t)32U;
@@ -582,9 +587,7 @@ EverCrypt_AEAD_encrypt_expand_aes128_gcm_no_check(
       uint64_t auth_num = (uint64_t)ad_len / (uint64_t)16U;
       uint64_t len128x6_ = len128x6 / (uint64_t)16U;
       uint64_t len128_num_ = len128_num / (uint64_t)16U;
-      uint64_t
-      scrut2 =
-        gcm128_encrypt_opt(auth_b_,
+      KRML_HOST_IGNORE(gcm128_encrypt_opt(auth_b_,
           (uint64_t)ad_len,
           auth_num,
           keys_b,
@@ -600,7 +603,7 @@ EverCrypt_AEAD_encrypt_expand_aes128_gcm_no_check(
           inout_b,
           (uint64_t)plain_len,
           scratch_b1,
-          tag);
+          tag));
     }
     else
     {
@@ -613,9 +616,7 @@ EverCrypt_AEAD_encrypt_expand_aes128_gcm_no_check(
       uint64_t auth_num = (uint64_t)ad_len / (uint64_t)16U;
       uint64_t len128_num_ = len128_num / (uint64_t)16U;
       uint64_t len128x6_ = (uint64_t)0U;
-      uint64_t
-      scrut2 =
-        gcm128_encrypt_opt(auth_b_,
+      KRML_HOST_IGNORE(gcm128_encrypt_opt(auth_b_,
           (uint64_t)ad_len,
           auth_num,
           keys_b,
@@ -631,12 +632,12 @@ EverCrypt_AEAD_encrypt_expand_aes128_gcm_no_check(
           inout_b,
           (uint64_t)plain_len,
           scratch_b1,
-          tag);
+          tag));
     }
     memcpy(cipher + (uint32_t)(uint64_t)plain_len / (uint32_t)16U * (uint32_t)16U,
       inout_b,
       (uint32_t)(uint64_t)plain_len % (uint32_t)16U * sizeof (uint8_t));
-    r = EverCrypt_Error_Success;
+    KRML_HOST_IGNORE(EverCrypt_Error_Success);
   }
   return EverCrypt_Error_Success;
   #else
@@ -673,18 +674,17 @@ EverCrypt_AEAD_encrypt_expand_aes256_gcm_no_check(
   uint8_t ek[544U] = { 0U };
   uint8_t *keys_b0 = ek;
   uint8_t *hkeys_b0 = ek + (uint32_t)240U;
-  uint64_t scrut0 = aes256_key_expansion(k, keys_b0);
-  uint64_t scrut1 = aes256_keyhash_init(keys_b0, hkeys_b0);
+  KRML_HOST_IGNORE(aes256_key_expansion(k, keys_b0));
+  KRML_HOST_IGNORE(aes256_keyhash_init(keys_b0, hkeys_b0));
   EverCrypt_AEAD_state_s p = { .impl = Spec_Cipher_Expansion_Vale_AES256, .ek = ek };
   EverCrypt_AEAD_state_s *s = &p;
-  EverCrypt_Error_error_code r;
   if (s == NULL)
   {
-    r = EverCrypt_Error_InvalidKey;
+    KRML_HOST_IGNORE(EverCrypt_Error_InvalidKey);
   }
   else if (iv_len == (uint32_t)0U)
   {
-    r = EverCrypt_Error_InvalidIVLength;
+    KRML_HOST_IGNORE(EverCrypt_Error_InvalidIVLength);
   }
   else
   {
@@ -699,8 +699,12 @@ EverCrypt_AEAD_encrypt_expand_aes256_gcm_no_check(
     uint32_t bytes_len = len * (uint32_t)16U;
     uint8_t *iv_b = iv;
     memcpy(tmp_iv, iv + bytes_len, iv_len % (uint32_t)16U * sizeof (uint8_t));
-    uint64_t
-    uu____0 = compute_iv_stdcall(iv_b, (uint64_t)iv_len, (uint64_t)len, tmp_iv, tmp_iv, hkeys_b);
+    KRML_HOST_IGNORE(compute_iv_stdcall(iv_b,
+        (uint64_t)iv_len,
+        (uint64_t)len,
+        tmp_iv,
+        tmp_iv,
+        hkeys_b));
     uint8_t *inout_b = scratch_b;
     uint8_t *abytes_b = scratch_b + (uint32_t)16U;
     uint8_t *scratch_b1 = scratch_b + (uint32_t)32U;
@@ -726,9 +730,7 @@ EverCrypt_AEAD_encrypt_expand_aes256_gcm_no_check(
       uint64_t auth_num = (uint64_t)ad_len / (uint64_t)16U;
       uint64_t len128x6_ = len128x6 / (uint64_t)16U;
       uint64_t len128_num_ = len128_num / (uint64_t)16U;
-      uint64_t
-      scrut2 =
-        gcm256_encrypt_opt(auth_b_,
+      KRML_HOST_IGNORE(gcm256_encrypt_opt(auth_b_,
           (uint64_t)ad_len,
           auth_num,
           keys_b,
@@ -744,7 +746,7 @@ EverCrypt_AEAD_encrypt_expand_aes256_gcm_no_check(
           inout_b,
           (uint64_t)plain_len,
           scratch_b1,
-          tag);
+          tag));
     }
     else
     {
@@ -757,9 +759,7 @@ EverCrypt_AEAD_encrypt_expand_aes256_gcm_no_check(
       uint64_t auth_num = (uint64_t)ad_len / (uint64_t)16U;
       uint64_t len128_num_ = len128_num / (uint64_t)16U;
       uint64_t len128x6_ = (uint64_t)0U;
-      uint64_t
-      scrut2 =
-        gcm256_encrypt_opt(auth_b_,
+      KRML_HOST_IGNORE(gcm256_encrypt_opt(auth_b_,
           (uint64_t)ad_len,
           auth_num,
           keys_b,
@@ -775,12 +775,12 @@ EverCrypt_AEAD_encrypt_expand_aes256_gcm_no_check(
           inout_b,
           (uint64_t)plain_len,
           scratch_b1,
-          tag);
+          tag));
     }
     memcpy(cipher + (uint32_t)(uint64_t)plain_len / (uint32_t)16U * (uint32_t)16U,
       inout_b,
       (uint32_t)(uint64_t)plain_len % (uint32_t)16U * sizeof (uint8_t));
-    r = EverCrypt_Error_Success;
+    KRML_HOST_IGNORE(EverCrypt_Error_Success);
   }
   return EverCrypt_Error_Success;
   #else
@@ -816,18 +816,17 @@ EverCrypt_AEAD_encrypt_expand_aes128_gcm(
     uint8_t ek[480U] = { 0U };
     uint8_t *keys_b0 = ek;
     uint8_t *hkeys_b0 = ek + (uint32_t)176U;
-    uint64_t scrut0 = aes128_key_expansion(k, keys_b0);
-    uint64_t scrut1 = aes128_keyhash_init(keys_b0, hkeys_b0);
+    KRML_HOST_IGNORE(aes128_key_expansion(k, keys_b0));
+    KRML_HOST_IGNORE(aes128_keyhash_init(keys_b0, hkeys_b0));
     EverCrypt_AEAD_state_s p = { .impl = Spec_Cipher_Expansion_Vale_AES128, .ek = ek };
     EverCrypt_AEAD_state_s *s = &p;
-    EverCrypt_Error_error_code r;
     if (s == NULL)
     {
-      r = EverCrypt_Error_InvalidKey;
+      KRML_HOST_IGNORE(EverCrypt_Error_InvalidKey);
     }
     else if (iv_len == (uint32_t)0U)
     {
-      r = EverCrypt_Error_InvalidIVLength;
+      KRML_HOST_IGNORE(EverCrypt_Error_InvalidIVLength);
     }
     else
     {
@@ -842,8 +841,12 @@ EverCrypt_AEAD_encrypt_expand_aes128_gcm(
       uint32_t bytes_len = len * (uint32_t)16U;
       uint8_t *iv_b = iv;
       memcpy(tmp_iv, iv + bytes_len, iv_len % (uint32_t)16U * sizeof (uint8_t));
-      uint64_t
-      uu____0 = compute_iv_stdcall(iv_b, (uint64_t)iv_len, (uint64_t)len, tmp_iv, tmp_iv, hkeys_b);
+      KRML_HOST_IGNORE(compute_iv_stdcall(iv_b,
+          (uint64_t)iv_len,
+          (uint64_t)len,
+          tmp_iv,
+          tmp_iv,
+          hkeys_b));
       uint8_t *inout_b = scratch_b;
       uint8_t *abytes_b = scratch_b + (uint32_t)16U;
       uint8_t *scratch_b1 = scratch_b + (uint32_t)32U;
@@ -869,9 +872,7 @@ EverCrypt_AEAD_encrypt_expand_aes128_gcm(
         uint64_t auth_num = (uint64_t)ad_len / (uint64_t)16U;
         uint64_t len128x6_ = len128x6 / (uint64_t)16U;
         uint64_t len128_num_ = len128_num / (uint64_t)16U;
-        uint64_t
-        scrut2 =
-          gcm128_encrypt_opt(auth_b_,
+        KRML_HOST_IGNORE(gcm128_encrypt_opt(auth_b_,
             (uint64_t)ad_len,
             auth_num,
             keys_b,
@@ -887,7 +888,7 @@ EverCrypt_AEAD_encrypt_expand_aes128_gcm(
             inout_b,
             (uint64_t)plain_len,
             scratch_b1,
-            tag);
+            tag));
       }
       else
       {
@@ -900,9 +901,7 @@ EverCrypt_AEAD_encrypt_expand_aes128_gcm(
         uint64_t auth_num = (uint64_t)ad_len / (uint64_t)16U;
         uint64_t len128_num_ = len128_num / (uint64_t)16U;
         uint64_t len128x6_ = (uint64_t)0U;
-        uint64_t
-        scrut2 =
-          gcm128_encrypt_opt(auth_b_,
+        KRML_HOST_IGNORE(gcm128_encrypt_opt(auth_b_,
             (uint64_t)ad_len,
             auth_num,
             keys_b,
@@ -918,12 +917,12 @@ EverCrypt_AEAD_encrypt_expand_aes128_gcm(
             inout_b,
             (uint64_t)plain_len,
             scratch_b1,
-            tag);
+            tag));
       }
       memcpy(cipher + (uint32_t)(uint64_t)plain_len / (uint32_t)16U * (uint32_t)16U,
         inout_b,
         (uint32_t)(uint64_t)plain_len % (uint32_t)16U * sizeof (uint8_t));
-      r = EverCrypt_Error_Success;
+      KRML_HOST_IGNORE(EverCrypt_Error_Success);
     }
     return EverCrypt_Error_Success;
   }
@@ -957,18 +956,17 @@ EverCrypt_AEAD_encrypt_expand_aes256_gcm(
     uint8_t ek[544U] = { 0U };
     uint8_t *keys_b0 = ek;
     uint8_t *hkeys_b0 = ek + (uint32_t)240U;
-    uint64_t scrut0 = aes256_key_expansion(k, keys_b0);
-    uint64_t scrut1 = aes256_keyhash_init(keys_b0, hkeys_b0);
+    KRML_HOST_IGNORE(aes256_key_expansion(k, keys_b0));
+    KRML_HOST_IGNORE(aes256_keyhash_init(keys_b0, hkeys_b0));
     EverCrypt_AEAD_state_s p = { .impl = Spec_Cipher_Expansion_Vale_AES256, .ek = ek };
     EverCrypt_AEAD_state_s *s = &p;
-    EverCrypt_Error_error_code r;
     if (s == NULL)
     {
-      r = EverCrypt_Error_InvalidKey;
+      KRML_HOST_IGNORE(EverCrypt_Error_InvalidKey);
     }
     else if (iv_len == (uint32_t)0U)
     {
-      r = EverCrypt_Error_InvalidIVLength;
+      KRML_HOST_IGNORE(EverCrypt_Error_InvalidIVLength);
     }
     else
     {
@@ -983,8 +981,12 @@ EverCrypt_AEAD_encrypt_expand_aes256_gcm(
       uint32_t bytes_len = len * (uint32_t)16U;
       uint8_t *iv_b = iv;
       memcpy(tmp_iv, iv + bytes_len, iv_len % (uint32_t)16U * sizeof (uint8_t));
-      uint64_t
-      uu____0 = compute_iv_stdcall(iv_b, (uint64_t)iv_len, (uint64_t)len, tmp_iv, tmp_iv, hkeys_b);
+      KRML_HOST_IGNORE(compute_iv_stdcall(iv_b,
+          (uint64_t)iv_len,
+          (uint64_t)len,
+          tmp_iv,
+          tmp_iv,
+          hkeys_b));
       uint8_t *inout_b = scratch_b;
       uint8_t *abytes_b = scratch_b + (uint32_t)16U;
       uint8_t *scratch_b1 = scratch_b + (uint32_t)32U;
@@ -1010,9 +1012,7 @@ EverCrypt_AEAD_encrypt_expand_aes256_gcm(
         uint64_t auth_num = (uint64_t)ad_len / (uint64_t)16U;
         uint64_t len128x6_ = len128x6 / (uint64_t)16U;
         uint64_t len128_num_ = len128_num / (uint64_t)16U;
-        uint64_t
-        scrut2 =
-          gcm256_encrypt_opt(auth_b_,
+        KRML_HOST_IGNORE(gcm256_encrypt_opt(auth_b_,
             (uint64_t)ad_len,
             auth_num,
             keys_b,
@@ -1028,7 +1028,7 @@ EverCrypt_AEAD_encrypt_expand_aes256_gcm(
             inout_b,
             (uint64_t)plain_len,
             scratch_b1,
-            tag);
+            tag));
       }
       else
       {
@@ -1041,9 +1041,7 @@ EverCrypt_AEAD_encrypt_expand_aes256_gcm(
         uint64_t auth_num = (uint64_t)ad_len / (uint64_t)16U;
         uint64_t len128_num_ = len128_num / (uint64_t)16U;
         uint64_t len128x6_ = (uint64_t)0U;
-        uint64_t
-        scrut2 =
-          gcm256_encrypt_opt(auth_b_,
+        KRML_HOST_IGNORE(gcm256_encrypt_opt(auth_b_,
             (uint64_t)ad_len,
             auth_num,
             keys_b,
@@ -1059,12 +1057,12 @@ EverCrypt_AEAD_encrypt_expand_aes256_gcm(
             inout_b,
             (uint64_t)plain_len,
             scratch_b1,
-            tag);
+            tag));
       }
       memcpy(cipher + (uint32_t)(uint64_t)plain_len / (uint32_t)16U * (uint32_t)16U,
         inout_b,
         (uint32_t)(uint64_t)plain_len % (uint32_t)16U * sizeof (uint8_t));
-      r = EverCrypt_Error_Success;
+      KRML_HOST_IGNORE(EverCrypt_Error_Success);
     }
     return EverCrypt_Error_Success;
   }
@@ -1087,6 +1085,7 @@ EverCrypt_AEAD_encrypt_expand_chacha20_poly1305(
   uint8_t *tag
 )
 {
+  KRML_HOST_IGNORE(iv_len);
   uint8_t ek[32U] = { 0U };
   EverCrypt_AEAD_state_s p = { .impl = Spec_Cipher_Expansion_Hacl_CHACHA20, .ek = ek };
   memcpy(ek, k, (uint32_t)32U * sizeof (uint8_t));
@@ -1193,8 +1192,12 @@ decrypt_aes128_gcm(
   uint32_t bytes_len = len * (uint32_t)16U;
   uint8_t *iv_b = iv;
   memcpy(tmp_iv, iv + bytes_len, iv_len % (uint32_t)16U * sizeof (uint8_t));
-  uint64_t
-  uu____0 = compute_iv_stdcall(iv_b, (uint64_t)iv_len, (uint64_t)len, tmp_iv, tmp_iv, hkeys_b);
+  KRML_HOST_IGNORE(compute_iv_stdcall(iv_b,
+      (uint64_t)iv_len,
+      (uint64_t)len,
+      tmp_iv,
+      tmp_iv,
+      hkeys_b));
   uint8_t *inout_b = scratch_b;
   uint8_t *abytes_b = scratch_b + (uint32_t)16U;
   uint8_t *scratch_b1 = scratch_b + (uint32_t)32U;
@@ -1327,8 +1330,12 @@ decrypt_aes256_gcm(
   uint32_t bytes_len = len * (uint32_t)16U;
   uint8_t *iv_b = iv;
   memcpy(tmp_iv, iv + bytes_len, iv_len % (uint32_t)16U * sizeof (uint8_t));
-  uint64_t
-  uu____0 = compute_iv_stdcall(iv_b, (uint64_t)iv_len, (uint64_t)len, tmp_iv, tmp_iv, hkeys_b);
+  KRML_HOST_IGNORE(compute_iv_stdcall(iv_b,
+      (uint64_t)iv_len,
+      (uint64_t)len,
+      tmp_iv,
+      tmp_iv,
+      hkeys_b));
   uint8_t *inout_b = scratch_b;
   uint8_t *abytes_b = scratch_b + (uint32_t)16U;
   uint8_t *scratch_b1 = scratch_b + (uint32_t)32U;
@@ -1557,8 +1564,8 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm_no_check(
   uint8_t ek[480U] = { 0U };
   uint8_t *keys_b0 = ek;
   uint8_t *hkeys_b0 = ek + (uint32_t)176U;
-  uint64_t scrut = aes128_key_expansion(k, keys_b0);
-  uint64_t scrut0 = aes128_keyhash_init(keys_b0, hkeys_b0);
+  KRML_HOST_IGNORE(aes128_key_expansion(k, keys_b0));
+  KRML_HOST_IGNORE(aes128_keyhash_init(keys_b0, hkeys_b0));
   EverCrypt_AEAD_state_s p = { .impl = Spec_Cipher_Expansion_Vale_AES128, .ek = ek };
   EverCrypt_AEAD_state_s *s = &p;
   if (s == NULL)
@@ -1569,8 +1576,8 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm_no_check(
   {
     return EverCrypt_Error_InvalidIVLength;
   }
-  EverCrypt_AEAD_state_s scrut1 = *s;
-  uint8_t *ek0 = scrut1.ek;
+  EverCrypt_AEAD_state_s scrut = *s;
+  uint8_t *ek0 = scrut.ek;
   uint8_t *scratch_b = ek0 + (uint32_t)304U;
   uint8_t *ek1 = ek0;
   uint8_t *keys_b = ek1;
@@ -1580,8 +1587,12 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm_no_check(
   uint32_t bytes_len = len * (uint32_t)16U;
   uint8_t *iv_b = iv;
   memcpy(tmp_iv, iv + bytes_len, iv_len % (uint32_t)16U * sizeof (uint8_t));
-  uint64_t
-  uu____0 = compute_iv_stdcall(iv_b, (uint64_t)iv_len, (uint64_t)len, tmp_iv, tmp_iv, hkeys_b);
+  KRML_HOST_IGNORE(compute_iv_stdcall(iv_b,
+      (uint64_t)iv_len,
+      (uint64_t)len,
+      tmp_iv,
+      tmp_iv,
+      hkeys_b));
   uint8_t *inout_b = scratch_b;
   uint8_t *abytes_b = scratch_b + (uint32_t)16U;
   uint8_t *scratch_b1 = scratch_b + (uint32_t)32U;
@@ -1609,7 +1620,7 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm_no_check(
     uint64_t len128x6_ = len128x6 / (uint64_t)16U;
     uint64_t len128_num_ = len128_num / (uint64_t)16U;
     uint64_t
-    scrut2 =
+    scrut0 =
       gcm128_decrypt_opt(auth_b_,
         (uint64_t)ad_len,
         auth_num,
@@ -1627,7 +1638,7 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm_no_check(
         (uint64_t)cipher_len,
         scratch_b1,
         tag);
-    uint64_t c0 = scrut2;
+    uint64_t c0 = scrut0;
     c = c0;
   }
   else
@@ -1642,7 +1653,7 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm_no_check(
     uint64_t len128_num_ = len128_num / (uint64_t)16U;
     uint64_t len128x6_ = (uint64_t)0U;
     uint64_t
-    scrut2 =
+    scrut0 =
       gcm128_decrypt_opt(auth_b_,
         (uint64_t)ad_len,
         auth_num,
@@ -1660,7 +1671,7 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm_no_check(
         (uint64_t)cipher_len,
         scratch_b1,
         tag);
-    uint64_t c0 = scrut2;
+    uint64_t c0 = scrut0;
     c = c0;
   }
   memcpy(dst + (uint32_t)(uint64_t)cipher_len / (uint32_t)16U * (uint32_t)16U,
@@ -1706,8 +1717,8 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm_no_check(
   uint8_t ek[544U] = { 0U };
   uint8_t *keys_b0 = ek;
   uint8_t *hkeys_b0 = ek + (uint32_t)240U;
-  uint64_t scrut = aes256_key_expansion(k, keys_b0);
-  uint64_t scrut0 = aes256_keyhash_init(keys_b0, hkeys_b0);
+  KRML_HOST_IGNORE(aes256_key_expansion(k, keys_b0));
+  KRML_HOST_IGNORE(aes256_keyhash_init(keys_b0, hkeys_b0));
   EverCrypt_AEAD_state_s p = { .impl = Spec_Cipher_Expansion_Vale_AES256, .ek = ek };
   EverCrypt_AEAD_state_s *s = &p;
   if (s == NULL)
@@ -1718,8 +1729,8 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm_no_check(
   {
     return EverCrypt_Error_InvalidIVLength;
   }
-  EverCrypt_AEAD_state_s scrut1 = *s;
-  uint8_t *ek0 = scrut1.ek;
+  EverCrypt_AEAD_state_s scrut = *s;
+  uint8_t *ek0 = scrut.ek;
   uint8_t *scratch_b = ek0 + (uint32_t)368U;
   uint8_t *ek1 = ek0;
   uint8_t *keys_b = ek1;
@@ -1729,8 +1740,12 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm_no_check(
   uint32_t bytes_len = len * (uint32_t)16U;
   uint8_t *iv_b = iv;
   memcpy(tmp_iv, iv + bytes_len, iv_len % (uint32_t)16U * sizeof (uint8_t));
-  uint64_t
-  uu____0 = compute_iv_stdcall(iv_b, (uint64_t)iv_len, (uint64_t)len, tmp_iv, tmp_iv, hkeys_b);
+  KRML_HOST_IGNORE(compute_iv_stdcall(iv_b,
+      (uint64_t)iv_len,
+      (uint64_t)len,
+      tmp_iv,
+      tmp_iv,
+      hkeys_b));
   uint8_t *inout_b = scratch_b;
   uint8_t *abytes_b = scratch_b + (uint32_t)16U;
   uint8_t *scratch_b1 = scratch_b + (uint32_t)32U;
@@ -1758,7 +1773,7 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm_no_check(
     uint64_t len128x6_ = len128x6 / (uint64_t)16U;
     uint64_t len128_num_ = len128_num / (uint64_t)16U;
     uint64_t
-    scrut2 =
+    scrut0 =
       gcm256_decrypt_opt(auth_b_,
         (uint64_t)ad_len,
         auth_num,
@@ -1776,7 +1791,7 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm_no_check(
         (uint64_t)cipher_len,
         scratch_b1,
         tag);
-    uint64_t c0 = scrut2;
+    uint64_t c0 = scrut0;
     c = c0;
   }
   else
@@ -1791,7 +1806,7 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm_no_check(
     uint64_t len128_num_ = len128_num / (uint64_t)16U;
     uint64_t len128x6_ = (uint64_t)0U;
     uint64_t
-    scrut2 =
+    scrut0 =
       gcm256_decrypt_opt(auth_b_,
         (uint64_t)ad_len,
         auth_num,
@@ -1809,7 +1824,7 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm_no_check(
         (uint64_t)cipher_len,
         scratch_b1,
         tag);
-    uint64_t c0 = scrut2;
+    uint64_t c0 = scrut0;
     c = c0;
   }
   memcpy(dst + (uint32_t)(uint64_t)cipher_len / (uint32_t)16U * (uint32_t)16U,
@@ -1854,8 +1869,8 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm(
     uint8_t ek[480U] = { 0U };
     uint8_t *keys_b0 = ek;
     uint8_t *hkeys_b0 = ek + (uint32_t)176U;
-    uint64_t scrut = aes128_key_expansion(k, keys_b0);
-    uint64_t scrut0 = aes128_keyhash_init(keys_b0, hkeys_b0);
+    KRML_HOST_IGNORE(aes128_key_expansion(k, keys_b0));
+    KRML_HOST_IGNORE(aes128_keyhash_init(keys_b0, hkeys_b0));
     EverCrypt_AEAD_state_s p = { .impl = Spec_Cipher_Expansion_Vale_AES128, .ek = ek };
     EverCrypt_AEAD_state_s *s = &p;
     if (s == NULL)
@@ -1866,8 +1881,8 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm(
     {
       return EverCrypt_Error_InvalidIVLength;
     }
-    EverCrypt_AEAD_state_s scrut1 = *s;
-    uint8_t *ek0 = scrut1.ek;
+    EverCrypt_AEAD_state_s scrut = *s;
+    uint8_t *ek0 = scrut.ek;
     uint8_t *scratch_b = ek0 + (uint32_t)304U;
     uint8_t *ek1 = ek0;
     uint8_t *keys_b = ek1;
@@ -1877,8 +1892,12 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm(
     uint32_t bytes_len = len * (uint32_t)16U;
     uint8_t *iv_b = iv;
     memcpy(tmp_iv, iv + bytes_len, iv_len % (uint32_t)16U * sizeof (uint8_t));
-    uint64_t
-    uu____0 = compute_iv_stdcall(iv_b, (uint64_t)iv_len, (uint64_t)len, tmp_iv, tmp_iv, hkeys_b);
+    KRML_HOST_IGNORE(compute_iv_stdcall(iv_b,
+        (uint64_t)iv_len,
+        (uint64_t)len,
+        tmp_iv,
+        tmp_iv,
+        hkeys_b));
     uint8_t *inout_b = scratch_b;
     uint8_t *abytes_b = scratch_b + (uint32_t)16U;
     uint8_t *scratch_b1 = scratch_b + (uint32_t)32U;
@@ -1906,7 +1925,7 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm(
       uint64_t len128x6_ = len128x6 / (uint64_t)16U;
       uint64_t len128_num_ = len128_num / (uint64_t)16U;
       uint64_t
-      scrut2 =
+      scrut0 =
         gcm128_decrypt_opt(auth_b_,
           (uint64_t)ad_len,
           auth_num,
@@ -1924,7 +1943,7 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm(
           (uint64_t)cipher_len,
           scratch_b1,
           tag);
-      uint64_t c0 = scrut2;
+      uint64_t c0 = scrut0;
       c = c0;
     }
     else
@@ -1939,7 +1958,7 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm(
       uint64_t len128_num_ = len128_num / (uint64_t)16U;
       uint64_t len128x6_ = (uint64_t)0U;
       uint64_t
-      scrut2 =
+      scrut0 =
         gcm128_decrypt_opt(auth_b_,
           (uint64_t)ad_len,
           auth_num,
@@ -1957,7 +1976,7 @@ EverCrypt_AEAD_decrypt_expand_aes128_gcm(
           (uint64_t)cipher_len,
           scratch_b1,
           tag);
-      uint64_t c0 = scrut2;
+      uint64_t c0 = scrut0;
       c = c0;
     }
     memcpy(dst + (uint32_t)(uint64_t)cipher_len / (uint32_t)16U * (uint32_t)16U,
@@ -2000,8 +2019,8 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm(
     uint8_t ek[544U] = { 0U };
     uint8_t *keys_b0 = ek;
     uint8_t *hkeys_b0 = ek + (uint32_t)240U;
-    uint64_t scrut = aes256_key_expansion(k, keys_b0);
-    uint64_t scrut0 = aes256_keyhash_init(keys_b0, hkeys_b0);
+    KRML_HOST_IGNORE(aes256_key_expansion(k, keys_b0));
+    KRML_HOST_IGNORE(aes256_keyhash_init(keys_b0, hkeys_b0));
     EverCrypt_AEAD_state_s p = { .impl = Spec_Cipher_Expansion_Vale_AES256, .ek = ek };
     EverCrypt_AEAD_state_s *s = &p;
     if (s == NULL)
@@ -2012,8 +2031,8 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm(
     {
       return EverCrypt_Error_InvalidIVLength;
     }
-    EverCrypt_AEAD_state_s scrut1 = *s;
-    uint8_t *ek0 = scrut1.ek;
+    EverCrypt_AEAD_state_s scrut = *s;
+    uint8_t *ek0 = scrut.ek;
     uint8_t *scratch_b = ek0 + (uint32_t)368U;
     uint8_t *ek1 = ek0;
     uint8_t *keys_b = ek1;
@@ -2023,8 +2042,12 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm(
     uint32_t bytes_len = len * (uint32_t)16U;
     uint8_t *iv_b = iv;
     memcpy(tmp_iv, iv + bytes_len, iv_len % (uint32_t)16U * sizeof (uint8_t));
-    uint64_t
-    uu____0 = compute_iv_stdcall(iv_b, (uint64_t)iv_len, (uint64_t)len, tmp_iv, tmp_iv, hkeys_b);
+    KRML_HOST_IGNORE(compute_iv_stdcall(iv_b,
+        (uint64_t)iv_len,
+        (uint64_t)len,
+        tmp_iv,
+        tmp_iv,
+        hkeys_b));
     uint8_t *inout_b = scratch_b;
     uint8_t *abytes_b = scratch_b + (uint32_t)16U;
     uint8_t *scratch_b1 = scratch_b + (uint32_t)32U;
@@ -2052,7 +2075,7 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm(
       uint64_t len128x6_ = len128x6 / (uint64_t)16U;
       uint64_t len128_num_ = len128_num / (uint64_t)16U;
       uint64_t
-      scrut2 =
+      scrut0 =
         gcm256_decrypt_opt(auth_b_,
           (uint64_t)ad_len,
           auth_num,
@@ -2070,7 +2093,7 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm(
           (uint64_t)cipher_len,
           scratch_b1,
           tag);
-      uint64_t c0 = scrut2;
+      uint64_t c0 = scrut0;
       c = c0;
     }
     else
@@ -2085,7 +2108,7 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm(
       uint64_t len128_num_ = len128_num / (uint64_t)16U;
       uint64_t len128x6_ = (uint64_t)0U;
       uint64_t
-      scrut2 =
+      scrut0 =
         gcm256_decrypt_opt(auth_b_,
           (uint64_t)ad_len,
           auth_num,
@@ -2103,7 +2126,7 @@ EverCrypt_AEAD_decrypt_expand_aes256_gcm(
           (uint64_t)cipher_len,
           scratch_b1,
           tag);
-      uint64_t c0 = scrut2;
+      uint64_t c0 = scrut0;
       c = c0;
     }
     memcpy(dst + (uint32_t)(uint64_t)cipher_len / (uint32_t)16U * (uint32_t)16U,

--- a/dist/gcc-compatible/EverCrypt_DRBG.c
+++ b/dist/gcc-compatible/EverCrypt_DRBG.c
@@ -92,6 +92,7 @@ EverCrypt_DRBG_uu___is_SHA1_s(
   EverCrypt_DRBG_state_s projectee
 )
 {
+  KRML_HOST_IGNORE(uu___);
   if (projectee.tag == SHA1_s)
   {
     return true;
@@ -105,6 +106,7 @@ EverCrypt_DRBG_uu___is_SHA2_256_s(
   EverCrypt_DRBG_state_s projectee
 )
 {
+  KRML_HOST_IGNORE(uu___);
   if (projectee.tag == SHA2_256_s)
   {
     return true;
@@ -118,6 +120,7 @@ EverCrypt_DRBG_uu___is_SHA2_384_s(
   EverCrypt_DRBG_state_s projectee
 )
 {
+  KRML_HOST_IGNORE(uu___);
   if (projectee.tag == SHA2_384_s)
   {
     return true;
@@ -131,6 +134,7 @@ EverCrypt_DRBG_uu___is_SHA2_512_s(
   EverCrypt_DRBG_state_s projectee
 )
 {
+  KRML_HOST_IGNORE(uu___);
   if (projectee.tag == SHA2_512_s)
   {
     return true;

--- a/dist/gcc-compatible/EverCrypt_Hash.c
+++ b/dist/gcc-compatible/EverCrypt_Hash.c
@@ -399,7 +399,7 @@ void EverCrypt_Hash_update_multi_256(uint32_t *s, uint8_t *blocks, uint32_t n)
   if (has_shaext && has_sse)
   {
     uint64_t n1 = (uint64_t)n;
-    uint64_t scrut = sha256_update(s, blocks, n1, k224_256);
+    KRML_HOST_IGNORE(sha256_update(s, blocks, n1, k224_256));
     return;
   }
   Hacl_SHA2_Scalar32_sha256_update_nblocks(n * (uint32_t)64U, blocks, s);

--- a/dist/gcc-compatible/EverCrypt_Poly1305.c
+++ b/dist/gcc-compatible/EverCrypt_Poly1305.c
@@ -38,19 +38,16 @@ static void poly1305_vale(uint8_t *dst, uint8_t *src, uint32_t len, uint8_t *key
   uint8_t tmp[16U] = { 0U };
   if (n_extra == (uint32_t)0U)
   {
-    uint64_t scrut = x64_poly1305(ctx, src, (uint64_t)len, (uint64_t)1U);
-    KRML_HOST_IGNORE((void *)(uint8_t)0U);
+    KRML_HOST_IGNORE(x64_poly1305(ctx, src, (uint64_t)len, (uint64_t)1U));
   }
   else
   {
     uint32_t len16 = n_blocks * (uint32_t)16U;
     uint8_t *src16 = src;
     memcpy(tmp, src + len16, n_extra * sizeof (uint8_t));
-    uint64_t scrut = x64_poly1305(ctx, src16, (uint64_t)len16, (uint64_t)0U);
-    KRML_HOST_IGNORE((void *)(uint8_t)0U);
+    KRML_HOST_IGNORE(x64_poly1305(ctx, src16, (uint64_t)len16, (uint64_t)0U));
     memcpy(ctx + (uint32_t)24U, key, (uint32_t)32U * sizeof (uint8_t));
-    uint64_t scrut0 = x64_poly1305(ctx, tmp, (uint64_t)n_extra, (uint64_t)1U);
-    KRML_HOST_IGNORE((void *)(uint8_t)0U);
+    KRML_HOST_IGNORE(x64_poly1305(ctx, tmp, (uint64_t)n_extra, (uint64_t)1U));
   }
   memcpy(dst, ctx, (uint32_t)16U * sizeof (uint8_t));
   #endif

--- a/dist/gcc-compatible/Hacl_Curve25519_64.c
+++ b/dist/gcc-compatible/Hacl_Curve25519_64.c
@@ -35,7 +35,7 @@ static inline void add_scalar0(uint64_t *out, uint64_t *f1, uint64_t f2)
   #if HACL_CAN_COMPILE_INLINE_ASM
   add_scalar(out, f1, f2);
   #else
-  uint64_t uu____0 = add_scalar_e(out, f1, f2);
+  KRML_HOST_IGNORE(add_scalar_e(out, f1, f2));
   #endif
 }
 
@@ -44,7 +44,7 @@ static inline void fadd0(uint64_t *out, uint64_t *f1, uint64_t *f2)
   #if HACL_CAN_COMPILE_INLINE_ASM
   fadd(out, f1, f2);
   #else
-  uint64_t uu____0 = fadd_e(out, f1, f2);
+  KRML_HOST_IGNORE(fadd_e(out, f1, f2));
   #endif
 }
 
@@ -53,7 +53,7 @@ static inline void fsub0(uint64_t *out, uint64_t *f1, uint64_t *f2)
   #if HACL_CAN_COMPILE_INLINE_ASM
   fsub(out, f1, f2);
   #else
-  uint64_t uu____0 = fsub_e(out, f1, f2);
+  KRML_HOST_IGNORE(fsub_e(out, f1, f2));
   #endif
 }
 
@@ -62,7 +62,7 @@ static inline void fmul0(uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
   #if HACL_CAN_COMPILE_INLINE_ASM
   fmul(out, f1, f2, tmp);
   #else
-  uint64_t uu____0 = fmul_e(tmp, f1, out, f2);
+  KRML_HOST_IGNORE(fmul_e(tmp, f1, out, f2));
   #endif
 }
 
@@ -71,7 +71,7 @@ static inline void fmul20(uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
   #if HACL_CAN_COMPILE_INLINE_ASM
   fmul2(out, f1, f2, tmp);
   #else
-  uint64_t uu____0 = fmul2_e(tmp, f1, out, f2);
+  KRML_HOST_IGNORE(fmul2_e(tmp, f1, out, f2));
   #endif
 }
 
@@ -80,7 +80,7 @@ static inline void fmul_scalar0(uint64_t *out, uint64_t *f1, uint64_t f2)
   #if HACL_CAN_COMPILE_INLINE_ASM
   fmul_scalar(out, f1, f2);
   #else
-  uint64_t uu____0 = fmul_scalar_e(out, f1, f2);
+  KRML_HOST_IGNORE(fmul_scalar_e(out, f1, f2));
   #endif
 }
 
@@ -89,7 +89,7 @@ static inline void fsqr0(uint64_t *out, uint64_t *f1, uint64_t *tmp)
   #if HACL_CAN_COMPILE_INLINE_ASM
   fsqr(out, f1, tmp);
   #else
-  uint64_t uu____0 = fsqr_e(tmp, f1, out);
+  KRML_HOST_IGNORE(fsqr_e(tmp, f1, out));
   #endif
 }
 
@@ -98,7 +98,7 @@ static inline void fsqr20(uint64_t *out, uint64_t *f, uint64_t *tmp)
   #if HACL_CAN_COMPILE_INLINE_ASM
   fsqr2(out, f, tmp);
   #else
-  uint64_t uu____0 = fsqr2_e(tmp, f, out);
+  KRML_HOST_IGNORE(fsqr2_e(tmp, f, out));
   #endif
 }
 
@@ -107,7 +107,7 @@ static inline void cswap20(uint64_t bit, uint64_t *p1, uint64_t *p2)
   #if HACL_CAN_COMPILE_INLINE_ASM
   cswap2(bit, p1, p2);
   #else
-  uint64_t uu____0 = cswap2_e(bit, p1, p2);
+  KRML_HOST_IGNORE(cswap2_e(bit, p1, p2));
   #endif
 }
 

--- a/dist/gcc-compatible/Hacl_Ed25519.c
+++ b/dist/gcc-compatible/Hacl_Ed25519.c
@@ -711,65 +711,59 @@ static inline void barrett_reduction(uint64_t *z, uint64_t *t)
   FStar_UInt128_uint128 c00 = carry0;
   FStar_UInt128_uint128
   carry1 = FStar_UInt128_shift_right(FStar_UInt128_add_mod(z11, c00), (uint32_t)56U);
-  uint64_t
-  t100 =
-    FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(z11, c00))
-    & (uint64_t)0xffffffffffffffU;
+  KRML_HOST_IGNORE(FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(z11, c00))
+    & (uint64_t)0xffffffffffffffU);
   FStar_UInt128_uint128 c10 = carry1;
   FStar_UInt128_uint128
   carry2 = FStar_UInt128_shift_right(FStar_UInt128_add_mod(z21, c10), (uint32_t)56U);
-  uint64_t
-  t101 =
-    FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(z21, c10))
-    & (uint64_t)0xffffffffffffffU;
+  KRML_HOST_IGNORE(FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(z21, c10))
+    & (uint64_t)0xffffffffffffffU);
   FStar_UInt128_uint128 c20 = carry2;
   FStar_UInt128_uint128
   carry3 = FStar_UInt128_shift_right(FStar_UInt128_add_mod(z31, c20), (uint32_t)56U);
-  uint64_t
-  t102 =
-    FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(z31, c20))
-    & (uint64_t)0xffffffffffffffU;
+  KRML_HOST_IGNORE(FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(z31, c20))
+    & (uint64_t)0xffffffffffffffU);
   FStar_UInt128_uint128 c30 = carry3;
   FStar_UInt128_uint128
   carry4 = FStar_UInt128_shift_right(FStar_UInt128_add_mod(z41, c30), (uint32_t)56U);
   uint64_t
-  t103 =
+  t100 =
     FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(z41, c30))
     & (uint64_t)0xffffffffffffffU;
   FStar_UInt128_uint128 c40 = carry4;
-  uint64_t t410 = t103;
+  uint64_t t410 = t100;
   FStar_UInt128_uint128
   carry5 = FStar_UInt128_shift_right(FStar_UInt128_add_mod(z5, c40), (uint32_t)56U);
   uint64_t
-  t104 =
+  t101 =
     FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(z5, c40))
     & (uint64_t)0xffffffffffffffU;
   FStar_UInt128_uint128 c5 = carry5;
-  uint64_t t51 = t104;
+  uint64_t t51 = t101;
   FStar_UInt128_uint128
   carry6 = FStar_UInt128_shift_right(FStar_UInt128_add_mod(z6, c5), (uint32_t)56U);
   uint64_t
-  t105 =
+  t102 =
     FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(z6, c5))
     & (uint64_t)0xffffffffffffffU;
   FStar_UInt128_uint128 c6 = carry6;
-  uint64_t t61 = t105;
+  uint64_t t61 = t102;
   FStar_UInt128_uint128
   carry7 = FStar_UInt128_shift_right(FStar_UInt128_add_mod(z7, c6), (uint32_t)56U);
   uint64_t
-  t106 =
+  t103 =
     FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(z7, c6))
     & (uint64_t)0xffffffffffffffU;
   FStar_UInt128_uint128 c7 = carry7;
-  uint64_t t71 = t106;
+  uint64_t t71 = t103;
   FStar_UInt128_uint128
   carry8 = FStar_UInt128_shift_right(FStar_UInt128_add_mod(z8, c7), (uint32_t)56U);
   uint64_t
-  t107 =
+  t104 =
     FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(z8, c7))
     & (uint64_t)0xffffffffffffffU;
   FStar_UInt128_uint128 c8 = carry8;
-  uint64_t t81 = t107;
+  uint64_t t81 = t104;
   uint64_t t91 = FStar_UInt128_uint128_to_uint64(c8);
   uint64_t qmu4_ = t410;
   uint64_t qmu5_ = t51;
@@ -818,19 +812,19 @@ static inline void barrett_reduction(uint64_t *z, uint64_t *t)
   FStar_UInt128_uint128 xy31 = FStar_UInt128_mul_wide(qdiv3, m1);
   FStar_UInt128_uint128 xy40 = FStar_UInt128_mul_wide(qdiv4, m0);
   FStar_UInt128_uint128 carry9 = FStar_UInt128_shift_right(xy00, (uint32_t)56U);
-  uint64_t t108 = FStar_UInt128_uint128_to_uint64(xy00) & (uint64_t)0xffffffffffffffU;
+  uint64_t t105 = FStar_UInt128_uint128_to_uint64(xy00) & (uint64_t)0xffffffffffffffU;
   FStar_UInt128_uint128 c0 = carry9;
-  uint64_t t010 = t108;
+  uint64_t t010 = t105;
   FStar_UInt128_uint128
   carry10 =
     FStar_UInt128_shift_right(FStar_UInt128_add_mod(FStar_UInt128_add_mod(xy01, xy10), c0),
       (uint32_t)56U);
   uint64_t
-  t109 =
+  t106 =
     FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(FStar_UInt128_add_mod(xy01, xy10), c0))
     & (uint64_t)0xffffffffffffffU;
   FStar_UInt128_uint128 c11 = carry10;
-  uint64_t t110 = t109;
+  uint64_t t110 = t106;
   FStar_UInt128_uint128
   carry11 =
     FStar_UInt128_shift_right(FStar_UInt128_add_mod(FStar_UInt128_add_mod(FStar_UInt128_add_mod(xy02,
@@ -839,14 +833,14 @@ static inline void barrett_reduction(uint64_t *z, uint64_t *t)
         c11),
       (uint32_t)56U);
   uint64_t
-  t1010 =
+  t107 =
     FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(FStar_UInt128_add_mod(FStar_UInt128_add_mod(xy02,
             xy11),
           xy20),
         c11))
     & (uint64_t)0xffffffffffffffU;
   FStar_UInt128_uint128 c21 = carry11;
-  uint64_t t210 = t1010;
+  uint64_t t210 = t107;
   FStar_UInt128_uint128
   carry =
     FStar_UInt128_shift_right(FStar_UInt128_add_mod(FStar_UInt128_add_mod(FStar_UInt128_add_mod(FStar_UInt128_add_mod(xy03,
@@ -856,7 +850,7 @@ static inline void barrett_reduction(uint64_t *z, uint64_t *t)
         c21),
       (uint32_t)56U);
   uint64_t
-  t1011 =
+  t108 =
     FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(FStar_UInt128_add_mod(FStar_UInt128_add_mod(FStar_UInt128_add_mod(xy03,
               xy12),
             xy21),
@@ -864,7 +858,7 @@ static inline void barrett_reduction(uint64_t *z, uint64_t *t)
         c21))
     & (uint64_t)0xffffffffffffffU;
   FStar_UInt128_uint128 c31 = carry;
-  uint64_t t310 = t1011;
+  uint64_t t310 = t108;
   uint64_t
   t411 =
     FStar_UInt128_uint128_to_uint64(FStar_UInt128_add_mod(FStar_UInt128_add_mod(FStar_UInt128_add_mod(FStar_UInt128_add_mod(FStar_UInt128_add_mod(xy04,
@@ -880,24 +874,24 @@ static inline void barrett_reduction(uint64_t *z, uint64_t *t)
   uint64_t qmul3 = t310;
   uint64_t qmul4 = t411;
   uint64_t b5 = (r0 - qmul0) >> (uint32_t)63U;
-  uint64_t t1012 = (b5 << (uint32_t)56U) + r0 - qmul0;
+  uint64_t t109 = (b5 << (uint32_t)56U) + r0 - qmul0;
   uint64_t c1 = b5;
-  uint64_t t011 = t1012;
+  uint64_t t011 = t109;
   uint64_t b6 = (r1 - (qmul1 + c1)) >> (uint32_t)63U;
-  uint64_t t1013 = (b6 << (uint32_t)56U) + r1 - (qmul1 + c1);
+  uint64_t t1010 = (b6 << (uint32_t)56U) + r1 - (qmul1 + c1);
   uint64_t c2 = b6;
-  uint64_t t111 = t1013;
+  uint64_t t111 = t1010;
   uint64_t b7 = (r2 - (qmul2 + c2)) >> (uint32_t)63U;
-  uint64_t t1014 = (b7 << (uint32_t)56U) + r2 - (qmul2 + c2);
+  uint64_t t1011 = (b7 << (uint32_t)56U) + r2 - (qmul2 + c2);
   uint64_t c3 = b7;
-  uint64_t t211 = t1014;
+  uint64_t t211 = t1011;
   uint64_t b8 = (r3 - (qmul3 + c3)) >> (uint32_t)63U;
-  uint64_t t1015 = (b8 << (uint32_t)56U) + r3 - (qmul3 + c3);
+  uint64_t t1012 = (b8 << (uint32_t)56U) + r3 - (qmul3 + c3);
   uint64_t c4 = b8;
-  uint64_t t311 = t1015;
+  uint64_t t311 = t1012;
   uint64_t b9 = (r4 - (qmul4 + c4)) >> (uint32_t)63U;
-  uint64_t t1016 = (b9 << (uint32_t)40U) + r4 - (qmul4 + c4);
-  uint64_t t412 = t1016;
+  uint64_t t1013 = (b9 << (uint32_t)40U) + r4 - (qmul4 + c4);
+  uint64_t t412 = t1013;
   uint64_t s0 = t011;
   uint64_t s1 = t111;
   uint64_t s2 = t211;
@@ -914,21 +908,21 @@ static inline void barrett_reduction(uint64_t *z, uint64_t *t)
   uint64_t y3 = m31;
   uint64_t y4 = m41;
   uint64_t b10 = (s0 - y0) >> (uint32_t)63U;
-  uint64_t t1017 = (b10 << (uint32_t)56U) + s0 - y0;
+  uint64_t t1014 = (b10 << (uint32_t)56U) + s0 - y0;
   uint64_t b0 = b10;
-  uint64_t t01 = t1017;
+  uint64_t t01 = t1014;
   uint64_t b11 = (s1 - (y1 + b0)) >> (uint32_t)63U;
-  uint64_t t1018 = (b11 << (uint32_t)56U) + s1 - (y1 + b0);
+  uint64_t t1015 = (b11 << (uint32_t)56U) + s1 - (y1 + b0);
   uint64_t b1 = b11;
-  uint64_t t11 = t1018;
+  uint64_t t11 = t1015;
   uint64_t b12 = (s2 - (y2 + b1)) >> (uint32_t)63U;
-  uint64_t t1019 = (b12 << (uint32_t)56U) + s2 - (y2 + b1);
+  uint64_t t1016 = (b12 << (uint32_t)56U) + s2 - (y2 + b1);
   uint64_t b2 = b12;
-  uint64_t t21 = t1019;
+  uint64_t t21 = t1016;
   uint64_t b13 = (s3 - (y3 + b2)) >> (uint32_t)63U;
-  uint64_t t1020 = (b13 << (uint32_t)56U) + s3 - (y3 + b2);
+  uint64_t t1017 = (b13 << (uint32_t)56U) + s3 - (y3 + b2);
   uint64_t b3 = b13;
-  uint64_t t31 = t1020;
+  uint64_t t31 = t1017;
   uint64_t b = (s4 - (y4 + b3)) >> (uint32_t)63U;
   uint64_t t10 = (b << (uint32_t)56U) + s4 - (y4 + b3);
   uint64_t b4 = b;

--- a/dist/gcc-compatible/Hacl_FFDHE.c
+++ b/dist/gcc-compatible/Hacl_FFDHE.c
@@ -127,7 +127,6 @@ static inline uint64_t ffdhe_check_pk(Spec_FFDHE_ffdhe_alg a, uint64_t *pk_n, ui
   memset(p_n1, 0U, nLen * sizeof (uint64_t));
   uint64_t
   c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64((uint64_t)0U, p_n[0U], (uint64_t)1U, p_n1);
-  uint64_t c1;
   if ((uint32_t)1U < nLen)
   {
     uint64_t *a1 = p_n + (uint32_t)1U;
@@ -159,12 +158,12 @@ static inline uint64_t ffdhe_check_pk(Spec_FFDHE_ffdhe_alg a, uint64_t *pk_n, ui
       uint64_t *res_i = res1 + i;
       c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, (uint64_t)0U, res_i);
     }
-    uint64_t c10 = c;
-    c1 = c10;
+    uint64_t c1 = c;
+    KRML_HOST_IGNORE(c1);
   }
   else
   {
-    c1 = c0;
+    KRML_HOST_IGNORE(c0);
   }
   KRML_CHECK_SIZE(sizeof (uint64_t), nLen);
   uint64_t b2[nLen];

--- a/dist/gcc-compatible/Hacl_Frodo_KEM.c
+++ b/dist/gcc-compatible/Hacl_Frodo_KEM.c
@@ -30,6 +30,6 @@
 
 void randombytes_(uint32_t len, uint8_t *res)
 {
-  bool b = Lib_RandomBuffer_System_randombytes(res, len);
+  KRML_HOST_IGNORE(Lib_RandomBuffer_System_randombytes(res, len));
 }
 

--- a/dist/gcc-compatible/Hacl_HMAC_DRBG.c
+++ b/dist/gcc-compatible/Hacl_HMAC_DRBG.c
@@ -71,6 +71,8 @@ uint32_t Hacl_HMAC_DRBG_min_length(Spec_Hash_Definitions_hash_alg a)
 bool
 Hacl_HMAC_DRBG_uu___is_State(Spec_Hash_Definitions_hash_alg a, Hacl_HMAC_DRBG_state projectee)
 {
+  KRML_HOST_IGNORE(a);
+  KRML_HOST_IGNORE(projectee);
   return true;
 }
 
@@ -1084,6 +1086,7 @@ Hacl_HMAC_DRBG_generate(
 
 void Hacl_HMAC_DRBG_free(Spec_Hash_Definitions_hash_alg uu___, Hacl_HMAC_DRBG_state s)
 {
+  KRML_HOST_IGNORE(uu___);
   uint8_t *k = s.k;
   uint8_t *v = s.v;
   uint32_t *ctr = s.reseed_counter;

--- a/dist/gcc-compatible/Hacl_Hash_Blake2.c
+++ b/dist/gcc-compatible/Hacl_Hash_Blake2.c
@@ -545,6 +545,7 @@ Hacl_Blake2b_32_blake2b_update_multi(
   uint32_t nb
 )
 {
+  KRML_HOST_IGNORE(len);
   for (uint32_t i = (uint32_t)0U; i < nb; i++)
   {
     FStar_UInt128_uint128
@@ -1192,6 +1193,7 @@ Hacl_Blake2s_32_blake2s_update_multi(
   uint32_t nb
 )
 {
+  KRML_HOST_IGNORE(len);
   for (uint32_t i = (uint32_t)0U; i < nb; i++)
   {
     uint64_t totlen = prev + (uint64_t)((i + (uint32_t)1U) * (uint32_t)64U);

--- a/dist/gcc-compatible/Hacl_Hash_Blake2b_256.c
+++ b/dist/gcc-compatible/Hacl_Hash_Blake2b_256.c
@@ -268,6 +268,7 @@ Hacl_Blake2b_256_blake2b_update_multi(
   uint32_t nb
 )
 {
+  KRML_HOST_IGNORE(len);
   for (uint32_t i = (uint32_t)0U; i < nb; i++)
   {
     FStar_UInt128_uint128

--- a/dist/gcc-compatible/Hacl_Hash_Blake2s_128.c
+++ b/dist/gcc-compatible/Hacl_Hash_Blake2s_128.c
@@ -268,6 +268,7 @@ Hacl_Blake2s_128_blake2s_update_multi(
   uint32_t nb
 )
 {
+  KRML_HOST_IGNORE(len);
   for (uint32_t i = (uint32_t)0U; i < nb; i++)
   {
     uint64_t totlen = prev + (uint64_t)((i + (uint32_t)1U) * (uint32_t)64U);

--- a/dist/gcc-compatible/Hacl_Hash_MD5.c
+++ b/dist/gcc-compatible/Hacl_Hash_MD5.c
@@ -1218,7 +1218,6 @@ void Hacl_Streaming_MD5_legacy_init(Hacl_Streaming_MD_state_32 *s)
   Hacl_Streaming_MD_state_32 scrut = *s;
   uint8_t *buf = scrut.buf;
   uint32_t *block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_Hash_Core_MD5_legacy_init(block_state);
   Hacl_Streaming_MD_state_32
   tmp = { .block_state = block_state, .buf = buf, .total_len = (uint64_t)(uint32_t)0U };

--- a/dist/gcc-compatible/Hacl_Hash_SHA1.c
+++ b/dist/gcc-compatible/Hacl_Hash_SHA1.c
@@ -254,7 +254,6 @@ void Hacl_Streaming_SHA1_legacy_init(Hacl_Streaming_MD_state_32 *s)
   Hacl_Streaming_MD_state_32 scrut = *s;
   uint8_t *buf = scrut.buf;
   uint32_t *block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_Hash_Core_SHA1_legacy_init(block_state);
   Hacl_Streaming_MD_state_32
   tmp = { .block_state = block_state, .buf = buf, .total_len = (uint64_t)(uint32_t)0U };

--- a/dist/gcc-compatible/Hacl_Hash_SHA2.c
+++ b/dist/gcc-compatible/Hacl_Hash_SHA2.c
@@ -537,7 +537,6 @@ void Hacl_Streaming_SHA2_init_256(Hacl_Streaming_MD_state_32 *s)
   Hacl_Streaming_MD_state_32 scrut = *s;
   uint8_t *buf = scrut.buf;
   uint32_t *block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_SHA2_Scalar32_sha256_init(block_state);
   Hacl_Streaming_MD_state_32
   tmp = { .block_state = block_state, .buf = buf, .total_len = (uint64_t)(uint32_t)0U };
@@ -836,7 +835,6 @@ void Hacl_Streaming_SHA2_init_224(Hacl_Streaming_MD_state_32 *s)
   Hacl_Streaming_MD_state_32 scrut = *s;
   uint8_t *buf = scrut.buf;
   uint32_t *block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_SHA2_Scalar32_sha224_init(block_state);
   Hacl_Streaming_MD_state_32
   tmp = { .block_state = block_state, .buf = buf, .total_len = (uint64_t)(uint32_t)0U };
@@ -962,7 +960,6 @@ void Hacl_Streaming_SHA2_init_512(Hacl_Streaming_MD_state_64 *s)
   Hacl_Streaming_MD_state_64 scrut = *s;
   uint8_t *buf = scrut.buf;
   uint64_t *block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_SHA2_Scalar32_sha512_init(block_state);
   Hacl_Streaming_MD_state_64
   tmp = { .block_state = block_state, .buf = buf, .total_len = (uint64_t)(uint32_t)0U };
@@ -1262,7 +1259,6 @@ void Hacl_Streaming_SHA2_init_384(Hacl_Streaming_MD_state_64 *s)
   Hacl_Streaming_MD_state_64 scrut = *s;
   uint8_t *buf = scrut.buf;
   uint64_t *block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_SHA2_Scalar32_sha384_init(block_state);
   Hacl_Streaming_MD_state_64
   tmp = { .block_state = block_state, .buf = buf, .total_len = (uint64_t)(uint32_t)0U };

--- a/dist/gcc-compatible/Hacl_Hash_SHA3.c
+++ b/dist/gcc-compatible/Hacl_Hash_SHA3.c
@@ -809,6 +809,7 @@ Hacl_Impl_SHA3_keccak(
   uint8_t *output
 )
 {
+  KRML_HOST_IGNORE(capacity);
   uint32_t rateInBytes = rate / (uint32_t)8U;
   uint64_t s[25U] = { 0U };
   absorb(s, rateInBytes, inputByteLen, input, delimitedSuffix);

--- a/dist/gcc-compatible/Hacl_K256_ECDSA.c
+++ b/dist/gcc-compatible/Hacl_K256_ECDSA.c
@@ -498,7 +498,7 @@ mul_pow2_256_minus_q_add(
     uint64_t r = c;
     tmp[len + i0] = r;);
   memcpy(res + (uint32_t)2U, a, len * sizeof (uint64_t));
-  uint64_t uu____0 = bn_add(resLen, res, len + (uint32_t)2U, tmp, res);
+  KRML_HOST_IGNORE(bn_add(resLen, res, len + (uint32_t)2U, tmp, res));
   uint64_t c = bn_add(resLen, res, (uint32_t)4U, e, res);
   return c;
 }
@@ -514,15 +514,23 @@ static inline void modq(uint64_t *out, uint64_t *a)
   uint64_t *t01 = tmp;
   uint64_t m[7U] = { 0U };
   uint64_t p[5U] = { 0U };
-  uint64_t
-  c0 = mul_pow2_256_minus_q_add((uint32_t)4U, (uint32_t)7U, t01, a + (uint32_t)4U, a, m);
-  uint64_t
-  c10 = mul_pow2_256_minus_q_add((uint32_t)3U, (uint32_t)5U, t01, m + (uint32_t)4U, m, p);
+  KRML_HOST_IGNORE(mul_pow2_256_minus_q_add((uint32_t)4U,
+      (uint32_t)7U,
+      t01,
+      a + (uint32_t)4U,
+      a,
+      m));
+  KRML_HOST_IGNORE(mul_pow2_256_minus_q_add((uint32_t)3U,
+      (uint32_t)5U,
+      t01,
+      m + (uint32_t)4U,
+      m,
+      p));
   uint64_t
   c2 = mul_pow2_256_minus_q_add((uint32_t)1U, (uint32_t)4U, t01, p + (uint32_t)4U, p, r);
-  uint64_t c00 = c2;
+  uint64_t c0 = c2;
   uint64_t c1 = add4(r, tmp, out);
-  uint64_t mask = (uint64_t)0U - (c00 + c1);
+  uint64_t mask = (uint64_t)0U - (c0 + c1);
   KRML_MAYBE_FOR4(i,
     (uint32_t)0U,
     (uint32_t)4U,
@@ -612,7 +620,7 @@ static inline void qmul_shift_384(uint64_t *res, uint64_t *a, uint64_t *b)
     uint64_t *res_i = res1 + i;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, (uint64_t)0U, res_i););
   uint64_t c1 = c;
-  uint64_t uu____0 = c1;
+  KRML_HOST_IGNORE(c1);
   uint64_t flag = l[5U] >> (uint32_t)63U;
   uint64_t mask = (uint64_t)0U - flag;
   KRML_MAYBE_FOR4(i,
@@ -1215,7 +1223,7 @@ static inline void point_mul_g(uint64_t *out, uint64_t *scalar)
   memset(gz, 0U, (uint32_t)5U * sizeof (uint64_t));
   gz[0U] = (uint64_t)1U;
   uint64_t
-  q2[15U] =
+  buf[15U] =
     {
       (uint64_t)4496295042185355U, (uint64_t)3125448202219451U, (uint64_t)1239608518490046U,
       (uint64_t)2687445637493112U, (uint64_t)77979604880139U, (uint64_t)3360310474215011U,
@@ -1223,8 +1231,9 @@ static inline void point_mul_g(uint64_t *out, uint64_t *scalar)
       (uint64_t)118285133003718U, (uint64_t)434519962075150U, (uint64_t)1114612377498854U,
       (uint64_t)3488596944003813U, (uint64_t)450716531072892U, (uint64_t)66044973203836U
     };
+  KRML_HOST_IGNORE(buf);
   uint64_t
-  q3[15U] =
+  buf0[15U] =
     {
       (uint64_t)1277614565900951U, (uint64_t)378671684419493U, (uint64_t)3176260448102880U,
       (uint64_t)1575691435565077U, (uint64_t)167304528382180U, (uint64_t)2600787765776588U,
@@ -1232,8 +1241,9 @@ static inline void point_mul_g(uint64_t *out, uint64_t *scalar)
       (uint64_t)265969268774814U, (uint64_t)1913228635640715U, (uint64_t)2831959046949342U,
       (uint64_t)888030405442963U, (uint64_t)1817092932985033U, (uint64_t)101515844997121U
     };
+  KRML_HOST_IGNORE(buf0);
   uint64_t
-  q4[15U] =
+  buf1[15U] =
     {
       (uint64_t)34056422761564U, (uint64_t)3315864838337811U, (uint64_t)3797032336888745U,
       (uint64_t)2580641850480806U, (uint64_t)208048944042500U, (uint64_t)1233795288689421U,
@@ -1241,6 +1251,7 @@ static inline void point_mul_g(uint64_t *out, uint64_t *scalar)
       (uint64_t)12245672982162U, (uint64_t)2119364213800870U, (uint64_t)2034960311715107U,
       (uint64_t)3172697815804487U, (uint64_t)4185144850224160U, (uint64_t)2792055915674U
     };
+  KRML_HOST_IGNORE(buf1);
   uint64_t *r1 = scalar;
   uint64_t *r2 = scalar + (uint32_t)1U;
   uint64_t *r3 = scalar + (uint32_t)2U;
@@ -1604,7 +1615,8 @@ Hacl_K256_ECDSA_ecdsa_sign_hashed_msg(
   uint8_t *nonce
 )
 {
-  uint64_t oneq[4U] = { (uint64_t)0x1U, (uint64_t)0x0U, (uint64_t)0x0U, (uint64_t)0x0U };
+  uint64_t buf[4U] = { (uint64_t)0x1U, (uint64_t)0x0U, (uint64_t)0x0U, (uint64_t)0x0U };
+  KRML_HOST_IGNORE(buf);
   uint64_t rsdk_q[16U] = { 0U };
   uint64_t *r_q = rsdk_q;
   uint64_t *s_q = rsdk_q + (uint32_t)4U;

--- a/dist/gcc-compatible/Hacl_RSAPSS.c
+++ b/dist/gcc-compatible/Hacl_RSAPSS.c
@@ -404,9 +404,9 @@ load_skey(
 Sign a message `msg` and write the signature to `sgnt`.
 
 @param a Hash algorithm to use. Allowed values for `a` are ...
-  * Spec_Hash_Definitions_SHA2_256,
-  * Spec_Hash_Definitions_SHA2_384, and
-  * Spec_Hash_Definitions_SHA2_512.
+  - Spec_Hash_Definitions_SHA2_256,
+  - Spec_Hash_Definitions_SHA2_384, and
+  - Spec_Hash_Definitions_SHA2_512.
 @param modBits Count of bits in the modulus (`n`).
 @param eBits Count of bits in `e` value.
 @param dBits Count of bits in `d` value.
@@ -518,7 +518,10 @@ Hacl_RSAPSS_rsapss_sign(
 /**
 Verify the signature `sgnt` of a message `msg`.
 
-@param a Hash algorithm to use.
+@param a Hash algorithm to use. Allowed values for `a` are ...
+  - Spec_Hash_Definitions_SHA2_256,
+  - Spec_Hash_Definitions_SHA2_384, and
+  - Spec_Hash_Definitions_SHA2_512.
 @param modBits Count of bits in the modulus (`n`).
 @param eBits Count of bits in `e` value.
 @param pkey Pointer to public key created by `Hacl_RSAPSS_new_rsapss_load_pkey`.
@@ -637,10 +640,10 @@ Load a public key from key parts.
 
 @param modBits Count of bits in modulus (`n`).
 @param eBits Count of bits in `e` value.
-@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`) is read from.
-@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value is read from.
+@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`), in big-endian byte order, is read from.
+@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value, in big-endian byte order, is read from.
 
-@return Returns an allocated public key. Note: caller must take care to `free()` the created key.
+@return Returns an allocated public key upon success, otherwise, `NULL` if key part arguments are invalid or memory allocation fails. Note: caller must take care to `free()` the created key.
 */
 uint64_t
 *Hacl_RSAPSS_new_rsapss_load_pkey(uint32_t modBits, uint32_t eBits, uint8_t *nb, uint8_t *eb)
@@ -707,11 +710,11 @@ Load a secret key from key parts.
 @param modBits Count of bits in modulus (`n`).
 @param eBits Count of bits in `e` value.
 @param dBits Count of bits in `d` value.
-@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`) is read from.
-@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value is read from.
-@param db Pointer to `ceil(modBits / 8)` bytes where the `d` value is read from.
+@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`), in big-endian byte order, is read from.
+@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value, in big-endian byte order, is read from.
+@param db Pointer to `ceil(modBits / 8)` bytes where the `d` value, in big-endian byte order, is read from.
 
-@return Returns an allocated secret key. Note: caller must take care to `free()` the created key.
+@return Returns an allocated secret key upon success, otherwise, `NULL` if key part arguments are invalid or memory allocation fails. Note: caller must take care to `free()` the created key.
 */
 uint64_t
 *Hacl_RSAPSS_new_rsapss_load_skey(
@@ -804,13 +807,16 @@ uint64_t
 /**
 Sign a message `msg` and write the signature to `sgnt`.
 
-@param a Hash algorithm to use.
+@param a Hash algorithm to use. Allowed values for `a` are ...
+  - Spec_Hash_Definitions_SHA2_256,
+  - Spec_Hash_Definitions_SHA2_384, and
+  - Spec_Hash_Definitions_SHA2_512.
 @param modBits Count of bits in the modulus (`n`).
 @param eBits Count of bits in `e` value.
 @param dBits Count of bits in `d` value.
-@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`) is read from.
-@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value is read from.
-@param db Pointer to `ceil(modBits / 8)` bytes where the `d` value is read from.
+@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`), in big-endian byte order, is read from.
+@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value, in big-endian byte order, is read from.
+@param db Pointer to `ceil(modBits / 8)` bytes where the `d` value, in big-endian byte order, is read from.
 @param saltLen Length of salt.
 @param salt Pointer to `saltLen` bytes where the salt is read from.
 @param msgLen Length of message.
@@ -873,11 +879,14 @@ Hacl_RSAPSS_rsapss_skey_sign(
 /**
 Verify the signature `sgnt` of a message `msg`.
 
-@param a Hash algorithm to use.
+@param a Hash algorithm to use. Allowed values for `a` are ...
+  - Spec_Hash_Definitions_SHA2_256,
+  - Spec_Hash_Definitions_SHA2_384, and
+  - Spec_Hash_Definitions_SHA2_512.
 @param modBits Count of bits in the modulus (`n`).
 @param eBits Count of bits in `e` value.
-@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`) is read from.
-@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value is read from.
+@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`), in big-endian byte order, is read from.
+@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value, in big-endian byte order, is read from.
 @param saltLen Length of salt.
 @param sgntLen Length of signature.
 @param sgnt Pointer to `sgntLen` bytes where the signature is read from.

--- a/dist/gcc-compatible/Hacl_RSAPSS.h
+++ b/dist/gcc-compatible/Hacl_RSAPSS.h
@@ -43,9 +43,9 @@ extern "C" {
 Sign a message `msg` and write the signature to `sgnt`.
 
 @param a Hash algorithm to use. Allowed values for `a` are ...
-  * Spec_Hash_Definitions_SHA2_256,
-  * Spec_Hash_Definitions_SHA2_384, and
-  * Spec_Hash_Definitions_SHA2_512.
+  - Spec_Hash_Definitions_SHA2_256,
+  - Spec_Hash_Definitions_SHA2_384, and
+  - Spec_Hash_Definitions_SHA2_512.
 @param modBits Count of bits in the modulus (`n`).
 @param eBits Count of bits in `e` value.
 @param dBits Count of bits in `d` value.
@@ -75,7 +75,10 @@ Hacl_RSAPSS_rsapss_sign(
 /**
 Verify the signature `sgnt` of a message `msg`.
 
-@param a Hash algorithm to use.
+@param a Hash algorithm to use. Allowed values for `a` are ...
+  - Spec_Hash_Definitions_SHA2_256,
+  - Spec_Hash_Definitions_SHA2_384, and
+  - Spec_Hash_Definitions_SHA2_512.
 @param modBits Count of bits in the modulus (`n`).
 @param eBits Count of bits in `e` value.
 @param pkey Pointer to public key created by `Hacl_RSAPSS_new_rsapss_load_pkey`.
@@ -105,10 +108,10 @@ Load a public key from key parts.
 
 @param modBits Count of bits in modulus (`n`).
 @param eBits Count of bits in `e` value.
-@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`) is read from.
-@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value is read from.
+@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`), in big-endian byte order, is read from.
+@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value, in big-endian byte order, is read from.
 
-@return Returns an allocated public key. Note: caller must take care to `free()` the created key.
+@return Returns an allocated public key upon success, otherwise, `NULL` if key part arguments are invalid or memory allocation fails. Note: caller must take care to `free()` the created key.
 */
 uint64_t
 *Hacl_RSAPSS_new_rsapss_load_pkey(uint32_t modBits, uint32_t eBits, uint8_t *nb, uint8_t *eb);
@@ -119,11 +122,11 @@ Load a secret key from key parts.
 @param modBits Count of bits in modulus (`n`).
 @param eBits Count of bits in `e` value.
 @param dBits Count of bits in `d` value.
-@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`) is read from.
-@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value is read from.
-@param db Pointer to `ceil(modBits / 8)` bytes where the `d` value is read from.
+@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`), in big-endian byte order, is read from.
+@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value, in big-endian byte order, is read from.
+@param db Pointer to `ceil(modBits / 8)` bytes where the `d` value, in big-endian byte order, is read from.
 
-@return Returns an allocated secret key. Note: caller must take care to `free()` the created key.
+@return Returns an allocated secret key upon success, otherwise, `NULL` if key part arguments are invalid or memory allocation fails. Note: caller must take care to `free()` the created key.
 */
 uint64_t
 *Hacl_RSAPSS_new_rsapss_load_skey(
@@ -138,13 +141,16 @@ uint64_t
 /**
 Sign a message `msg` and write the signature to `sgnt`.
 
-@param a Hash algorithm to use.
+@param a Hash algorithm to use. Allowed values for `a` are ...
+  - Spec_Hash_Definitions_SHA2_256,
+  - Spec_Hash_Definitions_SHA2_384, and
+  - Spec_Hash_Definitions_SHA2_512.
 @param modBits Count of bits in the modulus (`n`).
 @param eBits Count of bits in `e` value.
 @param dBits Count of bits in `d` value.
-@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`) is read from.
-@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value is read from.
-@param db Pointer to `ceil(modBits / 8)` bytes where the `d` value is read from.
+@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`), in big-endian byte order, is read from.
+@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value, in big-endian byte order, is read from.
+@param db Pointer to `ceil(modBits / 8)` bytes where the `d` value, in big-endian byte order, is read from.
 @param saltLen Length of salt.
 @param salt Pointer to `saltLen` bytes where the salt is read from.
 @param msgLen Length of message.
@@ -172,11 +178,14 @@ Hacl_RSAPSS_rsapss_skey_sign(
 /**
 Verify the signature `sgnt` of a message `msg`.
 
-@param a Hash algorithm to use.
+@param a Hash algorithm to use. Allowed values for `a` are ...
+  - Spec_Hash_Definitions_SHA2_256,
+  - Spec_Hash_Definitions_SHA2_384, and
+  - Spec_Hash_Definitions_SHA2_512.
 @param modBits Count of bits in the modulus (`n`).
 @param eBits Count of bits in `e` value.
-@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`) is read from.
-@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value is read from.
+@param nb Pointer to `ceil(modBits / 8)` bytes where the modulus (`n`), in big-endian byte order, is read from.
+@param eb Pointer to `ceil(modBits / 8)` bytes where the `e` value, in big-endian byte order, is read from.
 @param saltLen Length of salt.
 @param sgntLen Length of signature.
 @param sgnt Pointer to `sgntLen` bytes where the signature is read from.

--- a/dist/gcc-compatible/Hacl_Salsa20.c
+++ b/dist/gcc-compatible/Hacl_Salsa20.c
@@ -180,7 +180,8 @@ salsa20_encrypt(
   ctx[10U] = (uint32_t)0x79622d32U;
   memcpy(ctx + (uint32_t)11U, k10, (uint32_t)4U * sizeof (uint32_t));
   ctx[15U] = (uint32_t)0x6b206574U;
-  uint32_t k[16U] = { 0U };
+  uint32_t buf[16U] = { 0U };
+  KRML_HOST_IGNORE(buf);
   uint32_t rem = len % (uint32_t)64U;
   uint32_t nb = len / (uint32_t)64U;
   uint32_t rem1 = len % (uint32_t)64U;
@@ -293,7 +294,8 @@ salsa20_decrypt(
   ctx[10U] = (uint32_t)0x79622d32U;
   memcpy(ctx + (uint32_t)11U, k10, (uint32_t)4U * sizeof (uint32_t));
   ctx[15U] = (uint32_t)0x6b206574U;
-  uint32_t k[16U] = { 0U };
+  uint32_t buf[16U] = { 0U };
+  KRML_HOST_IGNORE(buf);
   uint32_t rem = len % (uint32_t)64U;
   uint32_t nb = len / (uint32_t)64U;
   uint32_t rem1 = len % (uint32_t)64U;

--- a/dist/gcc-compatible/Hacl_Streaming_Blake2.c
+++ b/dist/gcc-compatible/Hacl_Streaming_Blake2.c
@@ -54,7 +54,6 @@ void Hacl_Streaming_Blake2_blake2s_32_no_key_init(Hacl_Streaming_Blake2_blake2s_
   Hacl_Streaming_Blake2_blake2s_32_state scrut = *s1;
   uint8_t *buf = scrut.buf;
   Hacl_Streaming_Blake2_blake2s_32_block_state block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_Blake2s_32_blake2s_init(block_state.snd, (uint32_t)0U, (uint32_t)32U);
   Hacl_Streaming_Blake2_blake2s_32_state
   tmp = { .block_state = block_state, .buf = buf, .total_len = (uint64_t)(uint32_t)0U };
@@ -354,7 +353,6 @@ void Hacl_Streaming_Blake2_blake2b_32_no_key_init(Hacl_Streaming_Blake2_blake2b_
   Hacl_Streaming_Blake2_blake2b_32_state scrut = *s1;
   uint8_t *buf = scrut.buf;
   Hacl_Streaming_Blake2_blake2b_32_block_state block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_Blake2b_32_blake2b_init(block_state.snd, (uint32_t)0U, (uint32_t)64U);
   Hacl_Streaming_Blake2_blake2b_32_state
   tmp = { .block_state = block_state, .buf = buf, .total_len = (uint64_t)(uint32_t)0U };

--- a/dist/gcc-compatible/Hacl_Streaming_Blake2b_256.c
+++ b/dist/gcc-compatible/Hacl_Streaming_Blake2b_256.c
@@ -66,7 +66,6 @@ Hacl_Streaming_Blake2b_256_blake2b_256_no_key_init(
   Hacl_Streaming_Blake2b_256_blake2b_256_state scrut = *s;
   uint8_t *buf = scrut.buf;
   Hacl_Streaming_Blake2b_256_blake2b_256_block_state block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_Blake2b_256_blake2b_init(block_state.snd, (uint32_t)0U, (uint32_t)64U);
   Hacl_Streaming_Blake2b_256_blake2b_256_state
   tmp = { .block_state = block_state, .buf = buf, .total_len = (uint64_t)(uint32_t)0U };

--- a/dist/gcc-compatible/Hacl_Streaming_Blake2s_128.c
+++ b/dist/gcc-compatible/Hacl_Streaming_Blake2s_128.c
@@ -66,7 +66,6 @@ Hacl_Streaming_Blake2s_128_blake2s_128_no_key_init(
   Hacl_Streaming_Blake2s_128_blake2s_128_state scrut = *s;
   uint8_t *buf = scrut.buf;
   Hacl_Streaming_Blake2s_128_blake2s_128_block_state block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_Blake2s_128_blake2s_init(block_state.snd, (uint32_t)0U, (uint32_t)32U);
   Hacl_Streaming_Blake2s_128_blake2s_128_state
   tmp = { .block_state = block_state, .buf = buf, .total_len = (uint64_t)(uint32_t)0U };

--- a/dist/gcc-compatible/Hacl_Streaming_Poly1305_128.c
+++ b/dist/gcc-compatible/Hacl_Streaming_Poly1305_128.c
@@ -58,7 +58,6 @@ Hacl_Streaming_Poly1305_128_init(uint8_t *k, Hacl_Streaming_Poly1305_128_poly130
   uint8_t *k_ = scrut.p_key;
   uint8_t *buf = scrut.buf;
   Lib_IntVector_Intrinsics_vec128 *block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_Poly1305_128_poly1305_init(block_state, k);
   memcpy(k_, k, (uint32_t)32U * sizeof (uint8_t));
   uint8_t *k_1 = k_;
@@ -312,7 +311,7 @@ Hacl_Streaming_Poly1305_128_finish(
   {
     ite1 = r % (uint32_t)16U;
   }
-  uint64_t prev_len_last = total_len - (uint64_t)ite1;
+  KRML_HOST_IGNORE(total_len - (uint64_t)ite1);
   uint32_t ite2;
   if (r % (uint32_t)16U == (uint32_t)0U && r > (uint32_t)0U)
   {

--- a/dist/gcc-compatible/Hacl_Streaming_Poly1305_256.c
+++ b/dist/gcc-compatible/Hacl_Streaming_Poly1305_256.c
@@ -58,7 +58,6 @@ Hacl_Streaming_Poly1305_256_init(uint8_t *k, Hacl_Streaming_Poly1305_256_poly130
   uint8_t *k_ = scrut.p_key;
   uint8_t *buf = scrut.buf;
   Lib_IntVector_Intrinsics_vec256 *block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_Poly1305_256_poly1305_init(block_state, k);
   memcpy(k_, k, (uint32_t)32U * sizeof (uint8_t));
   uint8_t *k_1 = k_;
@@ -312,7 +311,7 @@ Hacl_Streaming_Poly1305_256_finish(
   {
     ite1 = r % (uint32_t)16U;
   }
-  uint64_t prev_len_last = total_len - (uint64_t)ite1;
+  KRML_HOST_IGNORE(total_len - (uint64_t)ite1);
   uint32_t ite2;
   if (r % (uint32_t)16U == (uint32_t)0U && r > (uint32_t)0U)
   {

--- a/dist/gcc-compatible/Hacl_Streaming_Poly1305_32.c
+++ b/dist/gcc-compatible/Hacl_Streaming_Poly1305_32.c
@@ -53,7 +53,6 @@ Hacl_Streaming_Poly1305_32_init(uint8_t *k, Hacl_Streaming_Poly1305_32_poly1305_
   uint8_t *k_ = scrut.p_key;
   uint8_t *buf = scrut.buf;
   uint64_t *block_state = scrut.block_state;
-  KRML_HOST_IGNORE((void *)(uint8_t)0U);
   Hacl_Poly1305_32_poly1305_init(block_state, k);
   memcpy(k_, k, (uint32_t)32U * sizeof (uint8_t));
   uint8_t *k_1 = k_;

--- a/dist/gcc-compatible/INFO.txt
+++ b/dist/gcc-compatible/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
 F* version: 155853a14336aa0713dba7db5408f4c8ab512a06
-KaRaMeL version: db63c1de17565be0ec4989f58532717a04e3ff40
+KaRaMeL version: 6ecaa6ac744abc0eda450927bcd2927f8f124e1d
 Vale version: 0.3.19

--- a/dist/gcc-compatible/internal/Hacl_Bignum25519_51.h
+++ b/dist/gcc-compatible/internal/Hacl_Bignum25519_51.h
@@ -84,6 +84,7 @@ Hacl_Impl_Curve25519_Field51_fmul(
   FStar_UInt128_uint128 *uu___
 )
 {
+  KRML_HOST_IGNORE(uu___);
   uint64_t f10 = f1[0U];
   uint64_t f11 = f1[1U];
   uint64_t f12 = f1[2U];
@@ -167,6 +168,7 @@ Hacl_Impl_Curve25519_Field51_fmul2(
   FStar_UInt128_uint128 *uu___
 )
 {
+  KRML_HOST_IGNORE(uu___);
   uint64_t f10 = f1[0U];
   uint64_t f11 = f1[1U];
   uint64_t f12 = f1[2U];
@@ -371,6 +373,7 @@ static inline void Hacl_Impl_Curve25519_Field51_fmul1(uint64_t *out, uint64_t *f
 static inline void
 Hacl_Impl_Curve25519_Field51_fsqr(uint64_t *out, uint64_t *f, FStar_UInt128_uint128 *uu___)
 {
+  KRML_HOST_IGNORE(uu___);
   uint64_t f0 = f[0U];
   uint64_t f1 = f[1U];
   uint64_t f2 = f[2U];
@@ -446,6 +449,7 @@ Hacl_Impl_Curve25519_Field51_fsqr(uint64_t *out, uint64_t *f, FStar_UInt128_uint
 static inline void
 Hacl_Impl_Curve25519_Field51_fsqr2(uint64_t *out, uint64_t *f, FStar_UInt128_uint128 *uu___)
 {
+  KRML_HOST_IGNORE(uu___);
   uint64_t f10 = f[0U];
   uint64_t f11 = f[1U];
   uint64_t f12 = f[2U];

--- a/dist/msvc-compatible/internal/Hacl_Bignum_Base.h
+++ b/dist/msvc-compatible/internal/Hacl_Bignum_Base.h
@@ -32,6 +32,7 @@ extern "C" {
 
 #include <string.h>
 #include "krml/internal/types.h"
+#include "krml/internal/builtin.h"
 #include "krml/lowstar_endianness.h"
 #include "krml/internal/target.h"
 


### PR DESCRIPTION
I was moved by Karthik's heroic efforts to systematically get rid of all unused variables, and thought I'd try to revive my previous attempts to make it work *for realz* this time.

This is with the corresponding branch on krml

Note that i) the code compiles with all warnings removed from Makefile.basic and ii) krml now inserts IGNOREs for unused function *parameters* too

Thoughts, comments, etc. @karthikbhargavan @R1kM @polubelova @franziskuskiefer 