### PR TITLE
Include `alloca.h` in `Hacl_Bignum_Base.h` for mozilla dist

### DIFF
--- a/dist/package-mozilla.sh
+++ b/dist/package-mozilla.sh
@@ -99,6 +99,7 @@ $sed -i -z 's/\n\n\/\*\n  As per[^/]*\*\///g' mozilla/Hacl_P256.c
 
 # Add an include for "builtin.h" to Hacl_Bignum_Base.h
 sed -i -z 's!\(#include.*types.h"\)!\1\n#include "krml/internal/builtin.h"!g' mozilla/internal/Hacl_Bignum_Base.h
+sed -i -z 's!\(#include<string.h>\)!\1\n#include <alloca.h>!g' mozilla/internal/Hacl_Bignum_Base.h
 
 
 cat <<EOF > mozilla/Makefile.include


### PR DESCRIPTION
I didn't test it, but something like this should fix the issue.

Fixes #868 
