### PR TITLE
blake2: fix a typo in a specification

### DIFF
--- a/specs/Spec.Blake2.fst
+++ b/specs/Spec.Blake2.fst
@@ -535,7 +535,7 @@ let blake2s d kk k n = blake2 Blake2S d kk k n
 
 val blake2b:
     d:bytes
-  -> kk:size_nat{kk <= 64 /\ (if kk = 0 then length d < pow2 128 else length d + 128 < pow2 64)}
+  -> kk:size_nat{kk <= 64 /\ (if kk = 0 then length d < pow2 128 else length d + 128 < pow2 128)}
   -> k:lbytes kk
   -> nn:size_nat{1 <= nn /\ nn <= 64} ->
   Tot (lbytes nn)


### PR DESCRIPTION
This MR fixes a typo in the Blake2b specification.

When hashing with a key, the maximum message length should still be less than 2^128 but without one block (for a key), i.e., 2^128 - 128.

Let's wait for the CI to see if this change breaks things or not.