### PR TITLE
Vale.Def.Words.Seq: stabilize a tricky proof

### DIFF
--- a/code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst
+++ b/code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst
@@ -897,7 +897,7 @@ let aux (a b c:int)
   : Lemma (requires 0 <= b /\ c < a)
           (ensures 0 <= a + b -c) = ()
 
-#push-options "--z3rlimit 50 --fuel 0 --ifuel 0"
+#push-options "--z3rlimit 100 --fuel 0 --ifuel 0 --split_queries always"
 let lemma_barrett_reduce' x =
   assert_norm (S.q == 0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed);
   assert_norm (0x100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 == pow2 512);
@@ -951,7 +951,7 @@ let lemma_barrett_reduce' x =
          aux (pow2 264) r qml;
          assert (s >= 0);
          assert (s < 2 * l) by (
-           Tactics.set_rlimit 150;
+           Tactics.set_rlimit 250;
            ()
          );
          s
@@ -959,7 +959,7 @@ let lemma_barrett_reduce' x =
          let s = r - qml in
          assert (s >= 0);
          assert (s < 2 * l) by (
-           Tactics.set_rlimit 150;
+           Tactics.set_rlimit 250;
            ()
          );
          s

--- a/vale/code/lib/util/Vale.Def.Words.Seq.fst
+++ b/vale/code/lib/util/Vale.Def.Words.Seq.fst
@@ -80,12 +80,16 @@ let four_to_nat_to_four_8 (x:natN (pow2_norm 32)) :
   lemma_fundamental_div_mod_4 x;
   ()
 
+#push-options "--z3rlimit 20 --z3cliopt smt.arith.nl=true"
+(* Localized use of NL arith. The makefile passes the option to disable
+it in this file, so we reenable it here. *)
 let rec base_to_nat (base:pos) (cs : list (natN base)) : nat =
   match cs with
   | [] -> 0
   | c :: cs' -> c + base_to_nat base cs' * base
   (* NB: right-multiplying by base is a lot better than left-multiplying
   since it more closely matches the lemmas in FStar.Math.Lemmas. *)
+#pop-options
 
 (* If two lists represent the same number, their heads must match,
 otherwise their modulus wrt the base would differ. *)
@@ -145,16 +149,19 @@ let rec base_to_nat_inj (base:pos) (x y : list (natN base)) :
     assert (base_to_nat base xs == base_to_nat base ys);
     base_to_nat_inj base xs ys
 
+#push-options "--fuel 4"
+(* Fuel needed to prove length equality *)
 let four_to_nat_inj (x y : four (natN 256)) :
   Lemma (requires four_to_nat 8 x == four_to_nat 8 y)
         (ensures x == y)
   =
   let Mkfour x0 x1 x2 x3 = x in
   let Mkfour y0 y1 y2 y3 = y in
-  assert_norm (four_to_nat 8 x == base_to_nat 256 [x0; x1; x2; x3]);
-  assert_norm (four_to_nat 8 y == base_to_nat 256 [y0; y1; y2; y3]);
+  assert_norm (four_to_nat 8 (Mkfour x0 x1 x2 x3) == base_to_nat 256 [x0; x1; x2; x3]);
+  assert_norm (four_to_nat 8 (Mkfour y0 y1 y2 y3) == base_to_nat 256 [y0; y1; y2; y3]);
   base_to_nat_inj 256 [x0; x1; x2; x3] [y0; y1; y2; y3];
   ()
+#pop-options
 
 let nat_to_four_to_nat (x:four (natN 256)) :
   Lemma (nat_to_four 8 (four_to_nat 8 x) == x)


### PR DESCRIPTION
## Proposed changes

This is just stabilizing a proof, `nat_to_four_to_nat`, that I've seen fail a couple of times already. It's about the decomposition of a U32 into chunks four of U8 being unique. The proof is pretty hardcoded to both the 4 components and the 'size' of 256, which I think makes it more complex than needed. Instead I wrote a more generic lemma about any base representation being unique (modulo left zeroes).

I'm not sure this is the right place for this lemma, or whether something like this exists... but it does make the module a lot more robust. Perhaps a similar idea can be used for the analogous `four_to_nat_to_four_8` lemma, but it seems to work just fine.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [x] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
