### PR TITLE
Hacl.Spec.BignumQ.Lemmas: trying to stabilize proof

### DIFF
--- a/code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst
+++ b/code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst
@@ -897,6 +897,13 @@ let aux (a b c:int)
   : Lemma (requires 0 <= b /\ c < a)
           (ensures 0 <= a + b -c) = ()
 
+// The proof below fails to replay hints. And, when hints have been
+// used for the file, the query ends up failing, yet it succeeds when
+// hints are disabled. This is puzzling but something that's been
+// observed elsewhere, probably just due to Z3 randomness. In any case,
+// restarting the solver seems to avoid the problem...
+#restart-solver
+
 #push-options "--z3rlimit 100 --fuel 0 --ifuel 0 --split_queries always"
 let lemma_barrett_reduce' x =
   assert_norm (S.q == 0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed);


### PR DESCRIPTION
## Proposed changes

This proof is failing for me again after some changes to F* that shouldn't really impact it. It looks like the hint fails to replay (see below), and the solver fails to prove the full query when hints are being used on the file. Running without hints works just fine. We've seen other instances of this elsewhere, and I would think this is caused by some random internal state in the solver that is slightly different in either case.. but I'm not sure.

For now, it seems like restarting the solver does the trick. The hint replay fails, but the full query does work from the "clean" state. Even if hint hashes are disabled, which I suppose could be the trigger of this breaking.
```
Z3 says: unknown
(/home/guido/r/fstar/3089/everest-TEMP/hacl-star/code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst(968,9-968,15))       Query-stats (Hacl.Spec.BignumQ.Lemmas.lemma_barrett_reduce', 54)        failed {reason-unknown=unknown because canceled} (with hint) in 8660 milliseconds with fuel 0 and ifuel 0 and rlimit 250
Z3 says: unsat
(/home/guido/r/fstar/3089/everest-TEMP/hacl-star/code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst(968,9-968,15))       Query-stats (Hacl.Spec.BignumQ.Lemmas.lemma_barrett_reduce', 54)        succeeded in 1537 milliseconds with fuel 0 and ifuel 0 and rlimit 250                                                             
```

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [x] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)