### PR TITLE
Hacl.Spec.BignumQ.Lemmas: Try to stabilize proof

### DIFF
--- a/code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst
+++ b/code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst
@@ -952,6 +952,7 @@ let lemma_barrett_reduce' x =
          assert (s >= 0);
          assert (s < 2 * l) by (
            Tactics.set_rlimit 250;
+           Tactics.set_options "--retry 5";
            ()
          );
          s
@@ -960,6 +961,7 @@ let lemma_barrett_reduce' x =
          assert (s >= 0);
          assert (s < 2 * l) by (
            Tactics.set_rlimit 250;
+           Tactics.set_options "--retry 5";
            ()
          );
          s


### PR DESCRIPTION
The Barrett reduction proof in Ed25519 is notoriously flaky; while we should ultimately spell it out more to stabilize it, this is a stopgap measure where the faulty queries are annotated with --retry 5 to unblock CI.

Subsumes #881 
