### PR TITLE
EverCrypr.Hash.alloca: remove strict_on_args attribute

### DIFF
--- a/providers/evercrypt/fst/EverCrypt.Hash.fst
+++ b/providers/evercrypt/fst/EverCrypt.Hash.fst
@@ -217,7 +217,6 @@ let frame_invariant #a l s h0 h1 =
   assert (repr_eq (repr s h0) (repr s h1))
 
 inline_for_extraction noextract
-[@@strict_on_arguments [0]]
 let alloca a =
   let s: state_s a =
     match a with


### PR DESCRIPTION
## Proposed changes

FStarLang/FStar#3107 changes the behavior of  `strict_on_args` slightly. Previously, if a strict_on_args function `f` appeared by itself, without any arguments, it could be unfolded (according to delta rules as usual). That PR fixes that problem, preventing the unfolding, which raises a compilation failure for libevercrypt:

```
Warning 2: in the arguments to EverCrypt.Hash.alloca, in the definition of tmp_block_state, after the definition of buf_1, in the last element of the sequence, after the definition of uu___, in top-level declaration EverCrypt.Hash.Incremental.digest_md5, in file EverCrypt_Hash: Reference to EverCrypt.Hash.alloca has no corresponding implementation; please provide a C implementation
Warning 2 is fatal, exiting.
gmake[1]: *** [Makefile:859: dist/wasm/Makefile.basic] Error 255
```

My understanding is that now some standalone occurrence of `alloca` remains, and since it doesn't have an implementation, the build fails. My "fix" in this PR is just removing the attribute for this definition. Looking at it again, I guess removing the `noextract` may be more sensible.. I'll update this bit with whether that works too.

Does this make sense?

Full error here: https://sprunge.us/xQxQsv

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [x] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)