### PR TITLE
Nix: remove stale hints & misc

### DIFF
--- a/.nix/hacl.nix
+++ b/.nix/hacl.nix
@@ -1,9 +1,23 @@
-{ bash, dotnet-runtime, fetchFromGitHub, fstar, fstar-scripts, git, karamel, lib
-, ocamlPackages, openssl, python3, sd, stdenv, time, vale, which, writeTextFile
-, z3 }:
-
-let
-
+{
+  bash,
+  dotnet-runtime,
+  fetchFromGitHub,
+  fstar,
+  fstar-scripts,
+  git,
+  karamel,
+  lib,
+  ocamlPackages,
+  openssl,
+  python3,
+  sd,
+  stdenv,
+  time,
+  vale,
+  which,
+  writeTextFile,
+  z3,
+}: let
   runlim = stdenv.mkDerivation rec {
     name = "runlim";
     src = fetchFromGitHub {
@@ -26,9 +40,12 @@ let
 
     src = lib.cleanSourceWith {
       src = ./..;
-      filter = path: type:
-        let relPath = lib.removePrefix (toString ./.. + "/") (toString path);
-        in type == "directory" || lib.elem relPath [
+      filter = path: type: let
+        relPath = lib.removePrefix (toString ./.. + "/") (toString path);
+      in
+        type
+        == "directory"
+        || lib.elem relPath [
           ".gitignore"
           "Makefile"
           "Makefile.common"
@@ -40,7 +57,8 @@ let
           "dist/Makefile.tmpl"
           "dist/configure"
           "dist/package-mozilla.sh"
-        ] || lib.any (lib.flip lib.hasPrefix relPath) [
+        ]
+        || lib.any (lib.flip lib.hasPrefix relPath) [
           "code"
           "hints"
           "lib"
@@ -61,7 +79,8 @@ let
       echo "0.3.19" > vale/.vale_version
     '';
 
-    nativeBuildInputs = [ z3 fstar python3 which dotnet-runtime time runlim ]
+    nativeBuildInputs =
+      [z3 fstar python3 which dotnet-runtime time runlim]
       ++ (with ocamlPackages; [
         ocaml
         findlib
@@ -83,7 +102,7 @@ let
         sedlex
       ]);
 
-    buildInputs = [ openssl.dev ];
+    buildInputs = [openssl.dev];
 
     VALE_HOME = vale;
     FSTAR_HOME = fstar;
@@ -116,7 +135,7 @@ let
       dist-compare = stdenv.mkDerivation {
         name = "hacl-diff-compare";
         src = "${hacl.build-products}/dist.tar.gz";
-        phases = [ "unpackPhase" "buildPhase" "installPhase" ];
+        phases = ["unpackPhase" "buildPhase" "installPhase"];
         buildPhase = ''
           for file in ./*/*.c ./*/*.h
           do
@@ -134,7 +153,7 @@ let
       dist-list = stdenv.mkDerivation {
         name = "hacl-diff-list";
         src = "${hacl.build-products}/dist.tar.gz";
-        phases = [ "unpackPhase" "buildPhase" "installPhase" ];
+        phases = ["unpackPhase" "buildPhase" "installPhase"];
         buildPhase = ''
           diff -rq . ${../dist} 2>&1 \
             | sed 's/\/nix\/store\/[a-z0-9]\{32\}-//g' \
@@ -151,7 +170,7 @@ let
       build-products = stdenv.mkDerivation {
         name = "hacl-build-products";
         src = hacl;
-        buildInputs = [ git sd ];
+        buildInputs = [git sd];
         buildPhase = ''
           sd '${bash}/bin/bash' '/usr/bin/env bash' dist/configure
           sd '${bash}/bin/bash' '/usr/bin/env bash' dist/package-mozilla.sh
@@ -181,7 +200,7 @@ let
       };
       stats = stdenv.mkDerivation {
         name = "hacl-stats";
-        phases = [ "installPhase" ];
+        phases = ["installPhase"];
         installPhase = ''
           mkdir -p $out
           cat ${hacl}/log.txt \
@@ -200,7 +219,6 @@ let
         '';
       };
     };
-
   };
-
-in hacl
+in
+  hacl

--- a/.nix/hacl.nix
+++ b/.nix/hacl.nix
@@ -114,7 +114,7 @@
 
     buildPhase = ''
       RESOURCEMONITOR=1 make -j$NIX_BUILD_CORES ci 2>&1 | tee log.txt
-      bash ${fstar-scripts}/remove_stale_hints.sh || true
+      bash ${fstar-scripts}/remove_stale_hints.sh
     '';
 
     installPhase = ''

--- a/.nix/hacl.nix
+++ b/.nix/hacl.nix
@@ -114,6 +114,7 @@
 
     buildPhase = ''
       RESOURCEMONITOR=1 make -j$NIX_BUILD_CORES ci 2>&1 | tee log.txt
+      bash ${fstar-scripts}/remove_stale_hints.sh || true
     '';
 
     installPhase = ''

--- a/.nix/vale.nix
+++ b/.nix/vale.nix
@@ -1,18 +1,24 @@
-{ dotnetPackages, fetchFromGitHub, fetchNuGet, fsharp, mono, scons, stdenv }:
-
-let
+{
+  dotnetPackages,
+  fetchFromGitHub,
+  fetchNuGet,
+  fsharp,
+  mono,
+  scons,
+  stdenv,
+}: let
   FsLexYacc = fetchNuGet {
     pname = "FsLexYacc";
     version = "6.1.0";
     sha256 = "1v5myn62zqs431i046gscqw2v0c969fc7pdplx7z9cnpy0p2s4rv";
-    outputFiles = [ "build/*" ];
+    outputFiles = ["build/*"];
   };
 
   FsLexYaccRuntime = fetchNuGet {
     pname = "FsLexYacc.Runtime";
     version = "6.1.0";
     sha256 = "18vrx4lxsn4hkfishg4abv0d4q21dsph0bm4mdq5z8afaypp5cr7";
-    outputFiles = [ "lib/net40/*" ];
+    outputFiles = ["lib/net40/*"];
   };
 
   vale = stdenv.mkDerivation rec {
@@ -36,7 +42,7 @@ let
       cp -r ${FsLexYaccRuntime}/lib/dotnet/FsLexYacc.Runtime/* tools/FsLexYacc/FsLexYacc.Runtime.6.1.0/lib/net40/
     '';
 
-    buildInputs = [ FsLexYacc fsharp mono scons ];
+    buildInputs = [FsLexYacc fsharp mono scons];
 
     enableParallelBuilding = true;
 
@@ -63,4 +69,5 @@ let
       }
     '';
   };
-in vale
+in
+  vale

--- a/flake.nix
+++ b/flake.nix
@@ -13,23 +13,28 @@
     };
   };
 
-  outputs = { self, fstar, flake-utils, nixpkgs, karamel }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        fstarPackages = fstar.packages.${system};
-        karamel-home = karamel.packages.${system}.karamel.home;
-        vale = pkgs.callPackage ./.nix/vale.nix { };
-        hacl = pkgs.callPackage ./.nix/hacl.nix {
-          inherit (fstarPackages) ocamlPackages z3 fstar;
-          inherit vale;
-          karamel = karamel-home;
-          fstar-scripts = "${fstar}/.scripts";
-        };
-      in {
-        packages = {
-          inherit hacl;
-          default = hacl;
-        };
-      });
+  outputs = {
+    self,
+    fstar,
+    flake-utils,
+    nixpkgs,
+    karamel,
+  }:
+    flake-utils.lib.eachSystem ["x86_64-linux"] (system: let
+      pkgs = import nixpkgs {inherit system;};
+      fstarPackages = fstar.packages.${system};
+      karamel-home = karamel.packages.${system}.karamel.home;
+      vale = pkgs.callPackage ./.nix/vale.nix {};
+      hacl = pkgs.callPackage ./.nix/hacl.nix {
+        inherit (fstarPackages) ocamlPackages z3 fstar;
+        inherit vale;
+        karamel = karamel-home;
+        fstar-scripts = "${fstar}/.scripts";
+      };
+    in {
+      packages = {
+        inherit hacl;
+        default = hacl;
+      };
+    });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Hacl*";
+  description = "HACL*";
 
   inputs = {
     fstar.url = "github:fstarlang/fstar";


### PR DESCRIPTION
This PR updates the Nix code.
Mainly, it updates the build phase of HACL* to remove stale hints using a script from F* (see #890).
This wiil be useful for hints regeneration.
I also took the opportunity to format the code with a better formatter (alejandra), imo functions are much more readable this way.
Finally, I fixed a typo (Hacl* -> HACL*).