### PR TITLE
Makefile: make sure to recompile Meta_Interface.cmxs when F* changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -461,7 +461,9 @@ min-test-unstaged: $(filter-out \
 obj/Meta_Interface.ml: CODEGEN = Plugin
 obj/Meta_Interface.ml: obj/Meta.Interface.fst.checked
 
-obj/Meta_Interface.cmxs: obj/Meta_Interface.ml
+# If fstar.exe was changed in the slightest, this object
+# must be recompiled
+obj/Meta_Interface.cmxs: obj/Meta_Interface.ml $(FSTAR_EXE)
 	$(OCAMLSHARED) $< -o $@
 
 obj/Test_Lowstarize.ml: CODEGEN = Plugin

--- a/Makefile.common
+++ b/Makefile.common
@@ -32,6 +32,8 @@ ifndef FSTAR_HOME
   endif
 endif
 
+FSTAR_EXE := $(FSTAR_HOME)/bin/fstar.exe
+
 ifndef FSTAR_ULIB
 FSTAR_ULIB := $(shell if test -d "$(FSTAR_HOME)/ulib" ; then echo "$(FSTAR_HOME)/ulib" ; else echo "$(FSTAR_HOME)/lib/fstar" ; fi)
 endif
@@ -105,7 +107,7 @@ endif
 # 331: name is being ignored
 # 332: abstract keyword
 # 337: special treatment of @ is deprecated + Multiple decreases clauses on definition
-FSTAR_NO_FLAGS = $(FSTAR_HOME)/bin/fstar.exe $(FSTAR_HINTS) \
+FSTAR_NO_FLAGS = $(FSTAR_EXE) $(FSTAR_HINTS) \
   --odir $(OUTPUT_DIR) --cache_checked_modules $(FSTAR_INCLUDES) --cmi \
   --already_cached 'Prims FStar LowStar C Spec.Loops TestLib WasmSupport' \
   --warn_error '@240+241@247-272-274@319@328@331@332@337' \


### PR DESCRIPTION
## Proposed changes

Small makefile improvement to recompile this object if F* changes, as it is very dependent on the exact binary and will likely not load if not recompiled. It also now sets FSTAR_EXE unconditionally.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)

