### PR TITLE
Nit: Use consistent instantiations in Streaming Blake2B 

### DIFF
--- a/code/streaming/Hacl.Streaming.Blake2b_32.fst
+++ b/code/streaming/Hacl.Streaming.Blake2b_32.fst
@@ -30,23 +30,23 @@ let alloca =
 
 [@ (Comment "  State allocation function when there is no key")]
 let malloc =
-  F.malloc (blake2b_32 0) () (Common.s Spec.Blake2B Core.M32) (Common.empty_key Spec.Blake2S)
+  F.malloc (blake2b_32 0) () (Common.s Spec.Blake2B Core.M32) (Common.empty_key Spec.Blake2B)
 
 [@ (Comment "  Re-initialization function when there is no key")]
 let reset =
-  F.reset (blake2b_32 0) () (Common.s Spec.Blake2B Core.M32) (Common.empty_key Spec.Blake2S)
+  F.reset (blake2b_32 0) () (Common.s Spec.Blake2B Core.M32) (Common.empty_key Spec.Blake2B)
 
 [@ (Comment "  Update function when there is no key; 0 = success, 1 = max length exceeded")]
 let update =
-  F.update (blake2b_32 0) (G.hide ()) (Common.s Spec.Blake2B Core.M32) (Common.empty_key Spec.Blake2S)
+  F.update (blake2b_32 0) (G.hide ()) (Common.s Spec.Blake2B Core.M32) (Common.empty_key Spec.Blake2B)
 
 [@ (Comment "  Finish function when there is no key")]
 let digest =
-  F.digest (blake2b_32 0) () (Common.s Spec.Blake2B Core.M32) (Common.empty_key Spec.Blake2S)
+  F.digest (blake2b_32 0) () (Common.s Spec.Blake2B Core.M32) (Common.empty_key Spec.Blake2B)
 
 [@ (Comment "  Free state function when there is no key")]
 let free =
-  F.free (blake2b_32 0) (G.hide ()) (Common.s Spec.Blake2B Core.M32) (Common.empty_key Spec.Blake2S)
+  F.free (blake2b_32 0) (G.hide ()) (Common.s Spec.Blake2B Core.M32) (Common.empty_key Spec.Blake2B)
 
 (* The one-shot hash *)
 [@@ Comment "Write the BLAKE2b digest of message `input` using key `key` into `output`.


### PR DESCRIPTION
The streaming functor for Blake2 currently only contains non-keyed versions, which require an instantiation with an empty key.
This PR ensures consistency of the empty key instantiation, i.e., call it with alg Blake2B in Streaming.Blake2B and Blake2S in Streaming.Blake2S. As the empty key is the same for Blake2B and Blake2S, this has no impact on verification or the generated code.