### PR TITLE
Improve Ed25519 Documentation

### DIFF
--- a/code/ed25519/Hacl.Ed25519.fsti
+++ b/code/ed25519/Hacl.Ed25519.fsti
@@ -51,7 +51,7 @@ val expand_keys:
 
   @param[out] signature Points to 64 bytes of valid memory, i.e., `uint8_t[64]`. Must not overlap the memory locations of `expanded_keys` nor `msg`.
   @param[in] expanded_keys Points to 96 bytes of valid memory, i.e., `uint8_t[96]`, containing the expanded keys obtained by invoking `expand_keys`.
-  @param[in] msglen Length of `msg`.
+  @param[in] msg_len Length of `msg`.
   @param[in] msg Points to `msg_len` bytes of valid memory containing the message, i.e., `uint8_t[msg_len]`.
 
   If one needs to sign several messages under the same private key, it is more efficient

--- a/code/ed25519/Hacl.Ed25519.fsti
+++ b/code/ed25519/Hacl.Ed25519.fsti
@@ -15,8 +15,8 @@ open Lib.Buffer
 
 Comment "Compute the public key from the private key.
 
-  The outparam `public_key`  points to 32 bytes of valid memory, i.e., uint8_t[32].
-  The argument `private_key` points to 32 bytes of valid memory, i.e., uint8_t[32]."]
+  @param[out] public_key Points to 32 bytes of valid memory, i.e., `uint8_t[32]`. Must not overlap the memory location of `private_key`.
+  @param[in] private_key Points to 32 bytes of valid memory containing the private key, i.e., `uint8_t[32]`."]
 val secret_to_public:
     public_key:lbuffer uint8 32ul
   -> private_key:lbuffer uint8 32ul ->
@@ -29,8 +29,8 @@ val secret_to_public:
 
 [@@ Comment "Compute the expanded keys for an Ed25519 signature.
 
-  The outparam `expanded_keys` points to 96 bytes of valid memory, i.e., uint8_t[96].
-  The argument `private_key`   points to 32 bytes of valid memory, i.e., uint8_t[32].
+  @param[out] expanded_keys Points to 96 bytes of valid memory, i.e., `uint8_t[96]`. Must not overlap the memory location of `private_key`.
+  @param[in] private_key Points to 32 bytes of valid memory containing the private key, i.e., `uint8_t[32]`.
 
   If one needs to sign several messages under the same private key, it is more efficient
   to call `expand_keys` only once and `sign_expanded` multiple times, for each message."]
@@ -49,11 +49,10 @@ val expand_keys:
 
 [@@ Comment "Create an Ed25519 signature with the (precomputed) expanded keys.
 
-  The outparam `signature`     points to 64 bytes of valid memory, i.e., uint8_t[64].
-  The argument `expanded_keys` points to 96 bytes of valid memory, i.e., uint8_t[96].
-  The argument `msg`    points to `msg_len` bytes of valid memory, i.e., uint8_t[msg_len].
-
-  The argument `expanded_keys` is obtained through `expand_keys`.
+  @param[out] signature Points to 64 bytes of valid memory, i.e., `uint8_t[64]`. Must not overlap the memory locations of `expanded_keys` nor `msg`.
+  @param[in] expanded_keys Points to 96 bytes of valid memory, i.e., `uint8_t[96]`, containing the expanded keys obtained by invoking `expand_keys`.
+  @param[in] msglen Length of `msg`.
+  @param[in] msg Points to `msg_len` bytes of valid memory containing the message, i.e., `uint8_t[msg_len]`.
 
   If one needs to sign several messages under the same private key, it is more efficient
   to call `expand_keys` only once and `sign_expanded` multiple times, for each message."]
@@ -76,9 +75,10 @@ val sign_expanded:
 
 [@@ Comment "Create an Ed25519 signature.
 
-  The outparam `signature`   points to 64 bytes of valid memory, i.e., uint8_t[64].
-  The argument `private_key` points to 32 bytes of valid memory, i.e., uint8_t[32].
-  The argument `msg`  points to `msg_len` bytes of valid memory, i.e., uint8_t[msg_len].
+  @param[out] signature Points to 64 bytes of valid memory, i.e., `uint8_t[64]`. Must not overlap the memory locations of `private_key` nor `msg`.
+  @param[in] private_key Points to 32 bytes of valid memory containing the private key, i.e., `uint8_t[32]`.
+  @param[in] msglen Length of `msg`.
+  @param[in] msg Points to `msg_len` bytes of valid memory containing the message, i.e., `uint8_t[msg_len]`.
 
   The function first calls `expand_keys` and then invokes `sign_expanded`.
 
@@ -99,11 +99,12 @@ val sign:
 
 [@@ Comment "Verify an Ed25519 signature.
 
-  The function returns `true` if the signature is valid and `false` otherwise.
+  @param public_key Points to 32 bytes of valid memory containing the public key, i.e., `uint8_t[32]`.
+  @param msglen Length of `msg`.
+  @param msg Points to `msg_len` bytes of valid memory containing the message, i.e., `uint8_t[msg_len]`.
+  @param signature Points to 64 bytes of valid memory containing the signature, i.e., `uint8_t[64]`.
 
-  The argument `public_key` points to 32 bytes of valid memory, i.e., uint8_t[32].
-  The argument `msg` points to `msg_len` bytes of valid memory, i.e., uint8_t[msg_len].
-  The argument `signature`  points to 64 bytes of valid memory, i.e., uint8_t[64]."]
+  @return Returns `true` if the signature is valid and `false` otherwise."]
 val verify:
     public_key:lbuffer uint8 32ul
   -> msg_len:size_t

--- a/code/ed25519/Hacl.Ed25519.fsti
+++ b/code/ed25519/Hacl.Ed25519.fsti
@@ -100,7 +100,7 @@ val sign:
 [@@ Comment "Verify an Ed25519 signature.
 
   @param public_key Points to 32 bytes of valid memory containing the public key, i.e., `uint8_t[32]`.
-  @param msglen Length of `msg`.
+  @param msg_len Length of `msg`.
   @param msg Points to `msg_len` bytes of valid memory containing the message, i.e., `uint8_t[msg_len]`.
   @param signature Points to 64 bytes of valid memory containing the signature, i.e., `uint8_t[64]`.
 

--- a/code/ed25519/Hacl.Ed25519.fsti
+++ b/code/ed25519/Hacl.Ed25519.fsti
@@ -77,7 +77,7 @@ val sign_expanded:
 
   @param[out] signature Points to 64 bytes of valid memory, i.e., `uint8_t[64]`. Must not overlap the memory locations of `private_key` nor `msg`.
   @param[in] private_key Points to 32 bytes of valid memory containing the private key, i.e., `uint8_t[32]`.
-  @param[in] msglen Length of `msg`.
+  @param[in] msg_len Length of `msg`.
   @param[in] msg Points to `msg_len` bytes of valid memory containing the message, i.e., `uint8_t[msg_len]`.
 
   The function first calls `expand_keys` and then invokes `sign_expanded`.


### PR DESCRIPTION
## Proposed changes

The documentation for Ed25519 receives additional clarity:

- Disjoint memory conditions noted on the outparams of functions, wherever applicable. This should signal clients to never pass pointers that overwrite the memory of other specific arguments (as doing so undermines the verification guarantees).
- Added Doxygen commands to mark the directions of parameters in functions that have outparams using `@param[out]` and `@param[in]`.
- Doxygen commands now allow documentation to be rendered in a more organized fashion when using templates.

These changes also aim to resolve the issues expressed in cryspen/hacl-packages#397.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [x] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
