### PR TITLE
ci: minimize permissions

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions: {}
 
 defaults:
   run:

--- a/.github/workflows/hacl-packages-create-branch.yml
+++ b/.github/workflows/hacl-packages-create-branch.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     branches: [ main ]
 
+permissions:
+  pull-requests: write
+
 jobs:
   hacl-packages-create-branch:
     runs-on: ubuntu-latest

--- a/.github/workflows/hacl-packages-delete-branch.yml
+++ b/.github/workflows/hacl-packages-delete-branch.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [ closed ]
 
+permissions: {}
+
 jobs:
   hacl-packages-delete-branch:
     runs-on: ubuntu-latest

--- a/.github/workflows/hintsanddist.yml
+++ b/.github/workflows/hintsanddist.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   regenerate-hints-and-dist:
     runs-on: self-hosted

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   nix:
     runs-on: self-hosted


### PR DESCRIPTION
TIL we should not use the default set of permissions for github jobs, as it is too permissive.
Thus this PR minimizes permissions given to `GITHUB_TOKEN`.