### PR TITLE
Update some proofs for changes to F*'s Seq

### DIFF
--- a/code/sha2-mb/Hacl.Spec.SHA2.Equiv.fst
+++ b/code/sha2-mb/Hacl.Spec.SHA2.Equiv.fst
@@ -66,7 +66,8 @@ val seq_of_list_is_create8: #a:Type -> x0:a -> x1:a -> x2:a -> x3:a -> x4:a -> x
 
 let seq_of_list_is_create8 #a x0 x1 x2 x3 x4 x5 x6 x7 =
   let rp = Seq.seq_of_list [x0; x1; x2; x3; x4; x5; x6; x7] in
-  assert_norm (length rp == 8);
+  assert_norm (List.length [x0; x1; x2; x3; x4; x5; x6; x7] == 8);
+  assert (length rp == 8);
   let lp = create8 x0 x1 x2 x3 x4 x5 x6 x7 in
 
   let aux (i:nat{i < 8}) : Lemma (Seq.index lp i == Seq.index rp i) =

--- a/vale/code/crypto/sha/Vale.SHA.PPC64LE.SHA_helpers.fst
+++ b/vale/code/crypto/sha/Vale.SHA.PPC64LE.SHA_helpers.fst
@@ -76,8 +76,9 @@ let make_ordered_hash_def (abcd efgh:quad32) :
     let g = to_uint32 efgh.hi2 in
     let h = to_uint32 efgh.hi3 in
     let l = [a; b; c; d; e; f; g; h] in
+    assert_norm (List.length l == 8);
     let hash = seq_of_list l in
-    assert_norm (length hash == 8);
+    assert (length hash == 8);
     elim_of_list l;
     hash
 [@"opaque_to_smt"] let make_ordered_hash = opaque_make make_ordered_hash_def
@@ -285,8 +286,9 @@ let make_seperated_hash_def (a b c d e f g h:nat32) :
     let g = to_uint32 g in
     let h = to_uint32 h in
     let l = [a; b; c; d; e; f; g; h] in
+    assert_norm (List.length l == 8);
     let hash = seq_of_list l in
-    assert_norm (length hash == 8);
+    assert (length hash == 8);
     elim_of_list l;
     hash
 [@"opaque_to_smt"] let make_seperated_hash = opaque_make make_seperated_hash_def
@@ -314,8 +316,9 @@ let make_seperated_hash_quad32_def (a b c d e f g h:quad32) :
     let g = to_uint32 g.hi3 in
     let h = to_uint32 h.hi3 in
     let l = [a; b; c; d; e; f; g; h] in
+    assert_norm (List.length l == 8);
     let hash = seq_of_list l in
-    assert_norm (length hash == 8);
+    assert (length hash == 8);
     elim_of_list l;
     hash
 [@"opaque_to_smt"] let make_seperated_hash_quad32 = opaque_make make_seperated_hash_quad32_def

--- a/vale/code/crypto/sha/Vale.SHA.SHA_helpers.fst
+++ b/vale/code/crypto/sha/Vale.SHA.SHA_helpers.fst
@@ -78,8 +78,9 @@ let make_hash_def (abef cdgh:quad32) :
     let g = to_uint32 cdgh.lo1 in
     let h = to_uint32 cdgh.lo0 in
     let l = [a; b; c; d; e; f; g; h] in
+    assert_norm (List.length l == 8);
     let hash = seq_of_list l in
-    assert_norm (length hash == 8);
+    assert (length hash == 8);
     elim_of_list l;
     //assert_norm (index hash 2 == c);
     hash
@@ -108,8 +109,9 @@ let make_ordered_hash_def (abcd efgh:quad32) :
     let g = to_uint32 efgh.hi2 in
     let h = to_uint32 efgh.hi3 in
     let l = [a; b; c; d; e; f; g; h] in
+    assert_norm (List.length l == 8);
     let hash = seq_of_list l in
-    assert_norm (length hash == 8);
+    assert (length hash == 8);
     elim_of_list l;
     hash
 [@"opaque_to_smt"] let make_ordered_hash = opaque_make make_ordered_hash_def

--- a/vale/code/lib/collections/Vale.Lib.Seqs.fst
+++ b/vale/code/lib/collections/Vale.Lib.Seqs.fst
@@ -88,36 +88,35 @@ let seq_map_injective #a #b f s s' =
   assert (equal s s')
 
 let list_to_seq #a l =
-  FStar.Seq.Properties.seq_of_list l
+  Seq.seq_of_list l
 
 let reveal_opaque_rec (s:string) = norm_spec [zeta; delta_only [s]]
 
 let rec lemma_list_to_seq_rec (#a:Type) (l:list a) (s:seq a) (n:nat) : Lemma
-  (requires n + List.length l == Seq.length s /\ Seq.equal (Seq.slice s n (Seq.length s)) (FStar.Seq.Properties.seq_of_list l))
+  (requires n + List.length l == Seq.length s /\ Seq.equal (Seq.slice s n (Seq.length s)) (list_to_seq l))
   (ensures list_to_seq_post l s n)
   (decreases l)
   =
-  reveal_opaque_rec (`%FStar.Seq.Properties.seq_of_list) (FStar.Seq.Properties.seq_of_list #a);
   match l with
   | [] -> ()
   | h::t ->
     let lem (i:nat) : Lemma
       (requires i < List.length t)
-      (ensures Seq.index (Seq.slice s (n + 1) (Seq.length s)) i == Seq.index (FStar.Seq.Properties.seq_of_list t) i)
-      [SMTPat (Seq.index (FStar.Seq.Properties.seq_of_list t) i)]
+      (ensures Seq.index (Seq.slice s (n + 1) (Seq.length s)) i == Seq.index (list_to_seq t) i)
+      [SMTPat (Seq.index (list_to_seq t) i)]
       =
       calc (==) {
         Seq.index (Seq.slice s (n + 1) (Seq.length s)) i;
         == {}
         Seq.index (Seq.slice s n (Seq.length s)) (i + 1);
         == {}
-        Seq.index (FStar.Seq.Properties.seq_of_list l) (i + 1);
+        Seq.index (list_to_seq l) (i + 1);
         == {}
-        Seq.index (FStar.Seq.Properties.seq_of_list t) i;
+        Seq.index (list_to_seq t) i;
       }
       in
     lemma_list_to_seq_rec t s (n + 1);
-    assert (Seq.index (FStar.Seq.Properties.seq_of_list l) 0 == h);
+    assert (Seq.index (list_to_seq l) 0 == h);
     ()
 
 let lemma_list_to_seq #a l =


### PR DESCRIPTION
## Proposed changes

These are fixes for FStarLang/FStar#3203. 

For the SHA files, the proof was relying on the normalization of `seq_of_list` to consume the list and hence obtain the length. Since now `seq_of_list` does not have an exposed definition, this fails. Instead, we normalize the *list( to compute its length, and then the refinement on the result of `seq_of_list` (i.e. that the lenghts match) allow us to recover this assertion.

The last diff is just pointing to `seq_of_list` in its new location, and removing a now-useless reveal_opaque.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [x] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
