### PR TITLE
Vale: work around Heisenbug

### DIFF
--- a/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastSqr_helpers.fst
+++ b/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastSqr_helpers.fst
@@ -74,6 +74,7 @@ let lemma_sqr (a:int) (a0 a1 a2 a3
             pow2_eight (mul_nats a0 a0) r8' ((mul_nats a1 a1) + r9') r10' ((mul_nats a2 a2) + r11') r12' ((mul_nats a3 a3) + r13') r14')
   (ensures  a*a == pow2_eight d0 d1 d2 d3 d4 d5 d6 d7)
   =
+  (); // work around Heisenbug
   assert (a < pow2_256); // PASSES
   assert_norm (pow2_256 == pow2 256); // PASSES
   pow2_plus 256 256;


### PR DESCRIPTION
## Proposed changes

A recent F* change caused a failure in this file, just by sheer coincidence. This reeks of a gensym clash or scoping bug, since almost any modification to the file makes it work. This PR just adds a `();` to the proof of the lemma.

The error is the following, abridged
 
```
* Error 228 at /home/guido/r/fstar/master/everest-TEMP/hacl-star/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastSqr_helpers.fst(98,2-98,18):
  - Tactic failed
  - "tc: tcc: Cannot type (3) FStar.Tactics.CanonCommSemiring.semiring_reflect FStar.Tactics.CanonCommSemiring.int_cr
  ([
    7, FStar.Pervasives.Native.snd (7, r13);
    6, FStar.Pervasives.Native.snd (6, r12);
    5, FStar.Pervasives.Native.snd (5, rcx);
    4, FStar.Pervasives.Native.snd (4, r11);
    3, FStar.Pervasives.Native.snd (3, rax);
    2,
    FStar.Pervasives.Native.snd (2,
      ((`7, FStar.Pervasives.Native.snd (7, r13)),
      FStar.Stubs.Reflection.V2.Data.Q_Explicit));
    1, FStar.Pervasives.Native.snd (1, r9);
    0, FStar.Pervasives.Native.snd (0, r8)
  ],
[....]
  Vale.Curve25519.Fast_defs.pow2_six 0 0 rax rcx 0 0 ==
any_result)). Error = (  - Expected type "Prims.int"; but "(`7, FStar.Pervasives.Native.snd (7, r13)), FStar.Stubs.Reflection.V2.Data.Q_Explicit" has type "FStar.Stubs.Reflection.Types.term * FStar.Stubs.Reflection.V2.Data.aqualv"
)"
  - See also FStar.Tactics.MApply.fst(41,13-41,30)

1 error was reported (see above)
```
The component with key `2` in the list above is indeed ill-typed: it's supposed to be an integer (probably r13) and not a composite value. I'm not sure what's causing it. I will take a look in F*, but we probably shouldn't break the everest build meanwhile.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
