### PR TITLE
CI: update action `create-pull-request`

### DIFF
--- a/.github/workflows/hintsanddist.yml
+++ b/.github/workflows/hintsanddist.yml
@@ -43,7 +43,7 @@ jobs:
           git clean -xfd
 
       - name: create pull request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.HACL_BOT }}
           branch: "hints-and-dist-main"


### PR DESCRIPTION
The update is required as v5 still uses Node.js 16 which was deprecated