### PR TITLE
Lib.Sequence: fix a flaky proof

### DIFF
--- a/lib/Lib.Sequence.fst
+++ b/lib/Lib.Sequence.fst
@@ -268,6 +268,12 @@ let mod_prop n a b =
 
 #push-options "--z3rlimit 200"
 
+// This proof is somehow very brittle on Z3 4.8.5.
+// For a small percentage of seeds, it fails after taking a rather long
+// time. For most others, it succeeds very quickly. Use a retry until we
+// can upgrade.
+#push-options "--retry 5"
+#restart-solver
 let rec index_map_blocks_multi #a bs max n inp f i =
   let map_blocks_a = map_blocks_a a bs max in
   let map_blocks_f = map_blocks_f #a bs max inp f in
@@ -285,6 +291,7 @@ let rec index_map_blocks_multi #a bs max n inp f i =
     Seq.lemma_index_app2 s s' i;
     mod_prop bs (n-1) i
   end
+#pop-options
 
 let map_blocks #a blocksize inp f g =
   let len = length inp in


### PR DESCRIPTION
This proof is somehow very brittle on Z3 4.8.5. For a small percentage of seeds, it fails after taking a rather long time. For most others, it succeeds very quickly. Use a retry until we can upgrade.

I confirmed this is very robust with a newer Z3.

---

Not a great fix, sorry about that, but it really does seem like Z3 just goes off the rails randomly, and there's not apparently much to do on the F* side.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [x] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
