### PR TITLE
Stabilize a proof in Lib.Vec.Lemmas, add hints for it

### DIFF
--- a/hints/Lib.Vec.Lemmas.fst.hints
+++ b/hints/Lib.Vec.Lemmas.fst.hints
@@ -1,5 +1,5 @@
 [
-  "T{o}tAêNW\ruÚ TÚ¨",
+  "]×Cð‹7˜D\n\bk˜nS—”",
   [
     [
       "Lib.Vec.Lemmas.lemma_repeat_gen_vec",
@@ -19,7 +19,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "d946357f0a52f7f61b07e6d026a9f6d6"
+      "76b9218780e6586b9a0f28877b812309"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_gen_vec",
@@ -46,7 +46,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "ef1b02abd8ef7480f6e584a330a9a6f3"
+      "61d9c5af15ad3a231cbfd930c17354b8"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_gen_vec",
@@ -64,7 +64,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "0d494eb23b8a55de8766d4dec1df5b4a"
+      "c9c7845544a2dfbee5a1d43b99a0985a"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeati_vec",
@@ -80,7 +80,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "17941421a6000e31a07566cc25b43e65"
+      "d42568de37ffab844e98b40c4ae5537b"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeati_vec",
@@ -98,7 +98,7 @@
         "token_correspondence_Lib.LoopCombinators.fixed_i"
       ],
       0,
-      "f7f456704a22904af01c93407ba70e71"
+      "874493478c74b64b62084be17dd8c361"
     ],
     [
       "Lib.Vec.Lemmas.len_is_w_n_blocksize",
@@ -112,7 +112,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "13a177817b2862c37ca616a186a5ffb4"
+      "9d634c5313ba30b20aef4701654bed84"
     ],
     [
       "Lib.Vec.Lemmas.len_is_w_n_blocksize",
@@ -127,7 +127,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "cb3fa6c61ba11d4bb92d530d994c4ac6"
+      "d9ae8be39f3e46f7f18424fbaa03d520"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_multi_vec_equiv_pre",
@@ -151,7 +151,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "f74691a572c17a62e91be076ba1e53d8"
+      "70f960cf4e548a3d9d549fc4bc1de65e"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_multi_vec_equiv_pre",
@@ -170,7 +170,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "27421b2245dfd3138f814e83dca0563b"
+      "37b359cd3a27a9f5df252988307879f3"
     ],
     [
       "Lib.Vec.Lemmas.get_block_v",
@@ -184,7 +184,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "9c94278800e037060071a1fc994be9cf"
+      "872013679f0687386c6c8011f90010fb"
     ],
     [
       "Lib.Vec.Lemmas.get_block_v",
@@ -213,7 +213,7 @@
         "typing_FStar.Seq.Base.length"
       ],
       0,
-      "6326d637d2d297116247194421c93154"
+      "d45ed035342bccc4bd1fa99a070c4069"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_slice_k",
@@ -236,7 +236,7 @@
         "refinement_interpretation_Tm_refine_d8d83307254a8900dd20598654272e42"
       ],
       0,
-      "80c141242a4aaa247c9282d7ace548f0"
+      "d167cec93c6670ee5e9c7e9546cb304d"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_slice_k",
@@ -266,7 +266,7 @@
         "refinement_interpretation_Tm_refine_d8d83307254a8900dd20598654272e42"
       ],
       0,
-      "bd2b206386b64dd6864c4ca4be89e3c9"
+      "9b3b5ef41b1931c48dab0a5f702c5841"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_slice_k",
@@ -286,7 +286,7 @@
         "refinement_interpretation_Tm_refine_d6b1a92117d4cdff80313427385685c8"
       ],
       0,
-      "be4b387ac291e4863758a46168da30f1"
+      "b04ba6b5853741b1577f5be944d4a3b2"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_slice",
@@ -313,7 +313,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "d250ff991a670f93b8f51aa88a98dacf"
+      "96a16235e558d1889f679ad05df0c1c6"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_slice",
@@ -336,7 +336,7 @@
         "refinement_interpretation_Tm_refine_d8d83307254a8900dd20598654272e42"
       ],
       0,
-      "104dfc05cf11d2b129abe1cec42764da"
+      "1641cc1702814d4c6a6cc82c6eb5f11d"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_slice",
@@ -355,7 +355,7 @@
         "refinement_interpretation_Tm_refine_d6b1a92117d4cdff80313427385685c8"
       ],
       0,
-      "608100774774dfa0854646aefa961f97"
+      "dece21a0a8ccedb31ae38edf56e0324a"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_multi_vec_step",
@@ -379,7 +379,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "a70b32ef07ef68e18fc6a8ceae6fbc46"
+      "fd12384e38ab68b16c403eef489131aa"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_multi_vec_step",
@@ -407,7 +407,7 @@
         "refinement_interpretation_Tm_refine_d8d83307254a8900dd20598654272e42"
       ],
       0,
-      "8da1ee45abe469dcba2951e90cc1e922"
+      "2cff0b612c0f5a82bedb202f487f3e5b"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_multi_vec_step",
@@ -426,7 +426,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "cd897cf60f724c62b76711f13ff25014"
+      "e8c3f8a07366fa039ef799c50f96816d"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_gen_blocks_multi_vec",
@@ -448,7 +448,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "3f524574102bd3317b53e3a20283ba91"
+      "829e23147dfdab656139a2eb7e29f8ec"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_gen_blocks_multi_vec",
@@ -456,11 +456,13 @@
       0,
       0,
       [
-        "@MaxIFuel_assumption", "@query", "equation_Prims.nat",
-        "equation_Prims.pos", "int_inversion", "int_typing",
-        "primitive_Prims.op_Addition", "primitive_Prims.op_Division",
-        "primitive_Prims.op_Modulus", "primitive_Prims.op_Multiply",
-        "primitive_Prims.op_Subtraction", "projection_inverse_BoxInt_proj_0",
+        "@MaxIFuel_assumption",
+        "@fuel_correspondence_Prims.pow2.fuel_instrumented", "@query",
+        "equation_Prims.nat", "equation_Prims.pos", "int_inversion",
+        "int_typing", "primitive_Prims.op_Addition",
+        "primitive_Prims.op_Division", "primitive_Prims.op_Modulus",
+        "primitive_Prims.op_Multiply", "primitive_Prims.op_Subtraction",
+        "projection_inverse_BoxInt_proj_0",
         "refinement_interpretation_Tm_refine_096438f6bdfa8da57c0b90fb63f06bdb",
         "refinement_interpretation_Tm_refine_0d5d3c38400eadf55263b743de2c168b",
         "refinement_interpretation_Tm_refine_34544e76bec95b90d561cc178295d795",
@@ -468,12 +470,13 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
         "refinement_interpretation_Tm_refine_6f77474ede8199333d3f4de9c694b4b9",
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5",
+        "refinement_interpretation_Tm_refine_7e0b9b2dbca36eab00de093c1b701c6d",
         "refinement_interpretation_Tm_refine_ba24c249c2bac9c9652dccf45aee8033",
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c",
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "ede754f46fa494591ba509228417ff67"
+      "8d2ccb305ad5cef309267298d5cac983"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_gen_blocks_multi_vec",
@@ -492,7 +495,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "4777e849ac5791fdf00cac0bf47f3332"
+      "1732d8d02e662fb6f118deabe3ee6a68"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_vec_equiv_pre",
@@ -512,7 +515,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "5c3c8c6183f9b7973e6852e19e5a04d8"
+      "35be3e0f19a17e5f3bf31f9766795190"
     ],
     [
       "Lib.Vec.Lemmas.repeat_gen_blocks_vec_equiv_pre",
@@ -530,7 +533,7 @@
         "refinement_interpretation_Tm_refine_7e0b9b2dbca36eab00de093c1b701c6d"
       ],
       0,
-      "394953622c3a175a8385ac1318d69772"
+      "9c027609bda9620e5372d1a5034dad38"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_gen_blocks_vec",
@@ -553,7 +556,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "0ddeb14e465043cc59ee00f79db8da8f"
+      "fd3d5175865230c97bd42a598019a0fb"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_gen_blocks_vec",
@@ -590,7 +593,7 @@
         "typing_Lib.Sequence.length"
       ],
       0,
-      "c3a0f0297cd5c811b9baf73a2040922e"
+      "d40ba9218fd06138710f17604b8c6023"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_gen_blocks_vec",
@@ -611,7 +614,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "0b0760244ae0dde2faabb5d651daa3fb"
+      "dec447ce7553e6ba2b013a94732232cd"
     ],
     [
       "Lib.Vec.Lemmas.repeat_blocks_multi_vec_equiv_pre",
@@ -627,7 +630,7 @@
         "refinement_interpretation_Tm_refine_d8d83307254a8900dd20598654272e42"
       ],
       0,
-      "bb6de6570d37b0709034f957aa9dc77c"
+      "a1dbd18244cc2986294621771f143383"
     ],
     [
       "Lib.Vec.Lemmas.repeat_blocks_multi_vec_equiv_pre",
@@ -646,7 +649,7 @@
         "refinement_interpretation_Tm_refine_d8d83307254a8900dd20598654272e42"
       ],
       0,
-      "115b8c1225944eecdf1e0e5195b0891e"
+      "c2dd2f85c6676e0ebd40a24274358539"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_blocks_multi_vec_equiv_pre",
@@ -667,7 +670,7 @@
         "typing_FStar.Seq.Base.length", "typing_Prims.pow2"
       ],
       0,
-      "3d569403898d676ab5ec8e0a4b136ffe"
+      "72c4f972e5d92fa7aeeefab0dfed41c3"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_blocks_multi_vec_equiv_pre",
@@ -696,7 +699,7 @@
         "typing_FStar.Seq.Base.length"
       ],
       0,
-      "4f94a9b7aa355c1a42a43b61e699325a"
+      "841aea912d388215b84d9e06cd4f5c33"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_blocks_multi_vec_equiv_pre",
@@ -710,7 +713,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "a4d77562971a27d80c484b8c29ae73dc"
+      "fcf01b770c60de7685a822f2b2504c07"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_blocks_multi_vec",
@@ -727,7 +730,7 @@
         "refinement_interpretation_Tm_refine_e90c2c89afe31ba2752cabd31cd7f6e7"
       ],
       0,
-      "d142c12dcab6cbe7a0d87b3db6b9322e"
+      "636393639e90848bf8bffb6803744de0"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_blocks_multi_vec",
@@ -750,7 +753,7 @@
         "typing_Lib.Sequence.length"
       ],
       0,
-      "9937044ae67a94f6ef8b7c011358c37b"
+      "364691f566de06b67b011d931655434f"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_blocks_multi_vec",
@@ -773,7 +776,7 @@
         "typing_Lib.Sequence.length"
       ],
       0,
-      "9bbf14280d39831395b910773bb92860"
+      "fb2ad85229679be06b5964c3c0cccdb2"
     ],
     [
       "Lib.Vec.Lemmas.repeat_blocks_vec_equiv_pre",
@@ -787,7 +790,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "219fce76c32df38d15cf5154e7a843c8"
+      "6b95e98a98c7c56fc45df5f23c51eb1d"
     ],
     [
       "Lib.Vec.Lemmas.repeat_blocks_vec_equiv_pre",
@@ -801,7 +804,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "9c9a6b5442c553371230ed78aa2d62c6"
+      "3ad398f09f82e6502063908438c1b804"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_blocks_vec_equiv_pre",
@@ -818,7 +821,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "757da4e2132f7cb787c79b8d52ae3959"
+      "179c3e639673a0d5acc02404cb8c96da"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_blocks_vec_equiv_pre",
@@ -844,7 +847,7 @@
         "token_correspondence_Lib.LoopCombinators.fixed_i"
       ],
       0,
-      "b02618f3c41fc42f93dae7d6dc777eb7"
+      "712be7671cb3c7a46d2228c0b96ee2b5"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_blocks_vec_equiv_pre",
@@ -871,7 +874,7 @@
         "token_correspondence_Lib.LoopCombinators.fixed_i"
       ],
       0,
-      "c2ab750b8673077b684b7cfdbab69e96"
+      "ca7ba8e66ed9c4359daca2642c75d82e"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_blocks_vec",
@@ -887,7 +890,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "3f3c4764a97b26003f9e5502331a3542"
+      "ab07c66de6cb3f60101c83b8f373aed3"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_blocks_vec",
@@ -912,7 +915,7 @@
         "typing_Lib.Sequence.length"
       ],
       0,
-      "c3dca49a9df05de5206e336b61bb8db9"
+      "27af9bfd21223f8d0c902b391f1e638b"
     ],
     [
       "Lib.Vec.Lemmas.lemma_repeat_blocks_vec",
@@ -937,7 +940,7 @@
         "typing_Lib.Sequence.length"
       ],
       0,
-      "62dc0434b9cb4ff68db57a884b43e6c8"
+      "f3deb64e9b2d4f2b86aaef82b84fad65"
     ],
     [
       "Lib.Vec.Lemmas.lemma_f_map_ind",
@@ -946,7 +949,7 @@
       0,
       [ "@query" ],
       0,
-      "ef100dcdacca99e968e6b30fa2954a58"
+      "5e8b442bcd831f91c1909edc218a3bde"
     ],
     [
       "Lib.Vec.Lemmas.lemma_f_map_ind",
@@ -964,7 +967,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "22e32d0939b0338037da187cec2ee6cf"
+      "b1667d7691fd640c25050e9a6df983a6"
     ],
     [
       "Lib.Vec.Lemmas.map_blocks_multi_vec_equiv_pre_k",
@@ -988,7 +991,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "07ecdfea67fe56986526d8b20334cdfa"
+      "30eedf3c2d7c36fd4e44109d391c7434"
     ],
     [
       "Lib.Vec.Lemmas.map_blocks_multi_vec_equiv_pre_k",
@@ -1002,7 +1005,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "5944159bcd6f3f8b6b573d7d284e9ff7"
+      "26215e30c6d06246aa519dbb0a3292fb"
     ],
     [
       "Lib.Vec.Lemmas.normalize_v_map",
@@ -1019,7 +1022,7 @@
         "refinement_interpretation_Tm_refine_7e0b9b2dbca36eab00de093c1b701c6d"
       ],
       0,
-      "dcec01ae0cda806da9bdb7a8c4ba11a1"
+      "67e97c51f0031d6e293781af766c9b6a"
     ],
     [
       "Lib.Vec.Lemmas.normalize_v_map",
@@ -1035,7 +1038,7 @@
         "refinement_interpretation_Tm_refine_7e0b9b2dbca36eab00de093c1b701c6d"
       ],
       0,
-      "ad35e999b734e62fb702f20af2735a47"
+      "ec40c6ccfd073708635d3c8f2d530db3"
     ],
     [
       "Lib.Vec.Lemmas.normalize_v_map",
@@ -1049,7 +1052,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "8ae3e26e8868f942ff7d78fe86f03d91"
+      "63206e5c46d5ad627d842ba868076461"
     ],
     [
       "Lib.Vec.Lemmas.map_blocks_multi_vec_equiv_pre",
@@ -1075,7 +1078,7 @@
         "refinement_interpretation_Tm_refine_f4f040c0afc8e02646bd007fb369c803"
       ],
       0,
-      "257c5691b12a5d76424d5a8f89ad388f"
+      "a9bf4ac3d2f85fc6fe85fd16a295f4e5"
     ],
     [
       "Lib.Vec.Lemmas.map_blocks_multi_vec_equiv_pre",
@@ -1101,7 +1104,7 @@
         "refinement_interpretation_Tm_refine_f4f040c0afc8e02646bd007fb369c803"
       ],
       0,
-      "9197f86a67b40e810ca0964b7fd57c42"
+      "bf820b199f196f40babac8e8eb431660"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_multi_vec_equiv_pre_k",
@@ -1119,7 +1122,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "1a12b9ff41665c6e839b117712f98d76"
+      "04b197664850abdffc39e7470c4cec7e"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_multi_vec_equiv_pre_k",
@@ -1158,7 +1161,7 @@
         "typing_FStar.Seq.Base.length"
       ],
       0,
-      "6081074cc2a975bc501d3525ed00fa38"
+      "35391e7ccaa409ca9e0851b2c857e93c"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_multi_vec_equiv_pre_k",
@@ -1198,7 +1201,25 @@
         "typing_FStar.Seq.Base.length"
       ],
       0,
-      "6b79070380e2e2437e7f86265861bc2e"
+      "58367a6a4e370fc021bfc0a8825c54f2"
+    ],
+    [
+      "Lib.Vec.Lemmas.lemma_map_blocks_multi_vec_equiv_pre_k",
+      4,
+      0,
+      0,
+      [
+        "@MaxIFuel_assumption", "@query", "equation_Prims.nat",
+        "equation_Prims.pos", "int_inversion", "primitive_Prims.op_Multiply",
+        "projection_inverse_BoxInt_proj_0",
+        "refinement_interpretation_Tm_refine_0d5d3c38400eadf55263b743de2c168b",
+        "refinement_interpretation_Tm_refine_3481cd680b4085d38b991b22047bd771",
+        "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
+        "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5",
+        "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
+      ],
+      0,
+      "9c1440bcda75531a6d26be8c1cd53d28"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_multi_vec_equiv_pre",
@@ -1219,7 +1240,7 @@
         "typing_FStar.Seq.Base.length"
       ],
       0,
-      "3e30d9450d99c202a1674b111d4f0125"
+      "e053b9544b8b7a303a261930ff792669"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_multi_vec_equiv_pre",
@@ -1262,7 +1283,7 @@
         "typing_Lib.Sequence.Lemmas.repeat_gen_blocks_map_f"
       ],
       0,
-      "ccd2e8f95e3fefb33f2b596c2e1dac53"
+      "3a38e9f5baa25d02bbb1f7d8ad5eb290"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_multi_vec_equiv_pre",
@@ -1304,7 +1325,7 @@
         "typing_Lib.Sequence.Lemmas.map_blocks_multi_acc"
       ],
       0,
-      "cc8e9590f1dee13a1324b97ff4524a46"
+      "ba57df5eed61242690ca6eecc85c43a0"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_multi_vec",
@@ -1324,7 +1345,7 @@
         "typing_Lib.Sequence.length"
       ],
       0,
-      "d6772ce064633a02d8919cb046143052"
+      "0a2749f73a75a89bff3e5b88d79af508"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_multi_vec",
@@ -1351,7 +1372,7 @@
         "typing_FStar.Seq.Base.empty"
       ],
       0,
-      "8c02f4d4239e9fac276f733a53807199"
+      "aaba5252a2470edc7a427809f5f002f8"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_multi_vec",
@@ -1381,7 +1402,7 @@
         "typing_FStar.Seq.Base.empty"
       ],
       0,
-      "a5adf25483accf92c670932bf567bdf7"
+      "a5e860578f0ebc94cabc319be15a9995"
     ],
     [
       "Lib.Vec.Lemmas.map_blocks_vec_equiv_pre_k",
@@ -1404,7 +1425,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "1b201a801efc9f898514f6af566fc0d9"
+      "af34fb08df39025575753dd9cd1e0141"
     ],
     [
       "Lib.Vec.Lemmas.map_blocks_vec_equiv_pre_k",
@@ -1432,7 +1453,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "7dece6b7a6594d5fdc4e23d9deb57884"
+      "74f14433bc2717bf535e9789bcb31586"
     ],
     [
       "Lib.Vec.Lemmas.map_blocks_vec_equiv_pre",
@@ -1453,7 +1474,7 @@
         "refinement_interpretation_Tm_refine_f4f040c0afc8e02646bd007fb369c803"
       ],
       0,
-      "2b1862df3fe71f282894a5d329240626"
+      "60a05e78c8673a46a7100a88c4fe17a4"
     ],
     [
       "Lib.Vec.Lemmas.map_blocks_vec_equiv_pre",
@@ -1474,7 +1495,7 @@
         "refinement_interpretation_Tm_refine_f4f040c0afc8e02646bd007fb369c803"
       ],
       0,
-      "be9c31097076b4ad4fdd7a1994768d3f"
+      "efde9c910806e1ea05ff704163a577e1"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_vec_equiv_pre_k_aux",
@@ -1498,7 +1519,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "14f8e187303d71f42946e5c12b9d7522"
+      "e0ed0b1abcabe258bb90f38773dc55f4"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_vec_equiv_pre_k_aux",
@@ -1533,7 +1554,7 @@
         "token_correspondence_Lib.Sequence.Lemmas.l_shift"
       ],
       0,
-      "2cbe79a9c7ec73dee98193bc04c49640"
+      "977bd7aa836aafe39ccc230f45579157"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_vec_equiv_pre_k_aux",
@@ -1566,7 +1587,7 @@
         "token_correspondence_Lib.Sequence.Lemmas.l_shift"
       ],
       0,
-      "cc4d475c94f40ce7f1429e753127d241"
+      "fd67d2c6a2dd23c7b5c1df78fab7891d"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_vec_equiv_pre_k",
@@ -1582,7 +1603,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "771ad26d95c042ab52f77f06e44b3d12"
+      "f0f2858dce51125b0f2e157329998b5d"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_vec_equiv_pre_k",
@@ -1616,7 +1637,7 @@
         "refinement_interpretation_Tm_refine_fe0ca3f3b25cc9d377244449d02c257b"
       ],
       0,
-      "13288df7236a612e8717aae7affa0bab"
+      "3a02c778eb13bf54397f2afbab7e6b17"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_vec_equiv_pre_k",
@@ -1650,7 +1671,7 @@
         "refinement_interpretation_Tm_refine_fe0ca3f3b25cc9d377244449d02c257b"
       ],
       0,
-      "e3935ab90261d06fe40ad087bc406c79"
+      "b832e41e7bbb9443b7e75236d6068391"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_vec_equiv_pre",
@@ -1667,7 +1688,7 @@
         "refinement_interpretation_Tm_refine_e37a8a81b6e72b6dae52414929365d29"
       ],
       0,
-      "069e79b909a21ec0db2ec764209b12dd"
+      "fc21c0f9fa232040752564ac34eb1b09"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_vec_equiv_pre",
@@ -1713,7 +1734,7 @@
         "typing_Lib.Sequence.Lemmas.map_blocks_acc"
       ],
       0,
-      "fd7969c4745bd891333c4866b2c099fd"
+      "377a212eb18f22df1b00179069f1db7f"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_vec_equiv_pre",
@@ -1758,7 +1779,7 @@
         "typing_Lib.Sequence.Lemmas.map_blocks_acc"
       ],
       0,
-      "345be09fee67d65d13479329a2adc852"
+      "862d361f1b33eb041e6a28aa8ea03acb"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_vec",
@@ -1777,7 +1798,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "9e4007958170f106d3a1562271e180b7"
+      "6a549194c7d78aad6ab1e5c3425fef9e"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_vec",
@@ -1821,7 +1842,7 @@
         "typing_FStar.Seq.Base.empty", "typing_Lib.Sequence.map_blocks"
       ],
       0,
-      "e7a2a0245b1897df42bb37f3b6e39cad"
+      "0488bf07d7b04f0f05793f14bbfc4294"
     ],
     [
       "Lib.Vec.Lemmas.lemma_map_blocks_vec",
@@ -1865,7 +1886,7 @@
         "typing_FStar.Seq.Base.empty", "typing_Lib.Sequence.map_blocks"
       ],
       0,
-      "7de08efb592282b680c7864ed95d7976"
+      "ad76b48cef7fec4b20cfc1e935b88f91"
     ]
   ]
 ]

--- a/lib/Lib.Vec.Lemmas.fst
+++ b/lib/Lib.Vec.Lemmas.fst
@@ -483,6 +483,11 @@ let lemma_map_blocks_multi_vec_equiv_pre_k #a w blocksize n hi_f f f_v i b_v pre
       Seq.index (f_v i b_v) k;
     } in
 
+  let acc_v : map_blocks_a a blocksize hi_f (w * i) =
+    assert (n <= hi_f);
+    assert_spinoff ((w * blocksize) * i == blocksize * (w * i));
+    acc_v
+  in
   calc (==) {
     map_blocks_multi_acc blocksize (w * i) hi_f w b_v f acc_v;
     (==) { map_blocks_multi_acc_is_map_blocks_multi blocksize (w * i) hi_f w b_v f acc_v }


### PR DESCRIPTION
## Proposed changes

A proof in Lib.Vec.Lemmas fails sporadically. This PR adds a few asserts and regenerates hints for that file.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [x] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
