### PR TITLE
specify inline related attribute for Oracle Studio compiler

### DIFF
--- a/dist/karamel/include/krml/internal/target.h
+++ b/dist/karamel/include/krml/internal/target.h
@@ -82,6 +82,8 @@
 #    define KRML_NOINLINE __declspec(noinline)
 #  elif defined (__GNUC__)
 #    define KRML_NOINLINE __attribute__((noinline,unused))
+#  elif defined (__SUNPRO_C)
+#    define KRML_NOINLINE __attribute__((noinline))
 #  else
 #    define KRML_NOINLINE
 #    warning "The KRML_NOINLINE macro is not defined for this toolchain!"
@@ -94,6 +96,8 @@
 #  if defined(_MSC_VER)
 #    define KRML_MUSTINLINE inline __forceinline
 #  elif defined (__GNUC__)
+#    define KRML_MUSTINLINE inline __attribute__((always_inline))
+#  elif defined (__SUNPRO_C)
 #    define KRML_MUSTINLINE inline __attribute__((always_inline))
 #  else
 #    define KRML_MUSTINLINE inline


### PR DESCRIPTION
## Proposed changes

This change avoids warning/error when compiling with Oracle Studio by adding appropriate attributes for the inline enforcement. The `__SUNPRO_C` internal define  is documented in the Studio compiler man page for the `cc` command. The attribute values themselves are documented in https://docs.oracle.com/cd/E77782_01/pdf/E77788.pdf (section 2.10)

## Types of changes

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x]  I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)

## Further comments

While the `__SUNPRO_C` define has a distinct value for every version, for this change I am assuming fairly modern version, i.e. 12.x, so the value is not checked. Let me know if that's okay.