### PR TITLE
valedepend.py: ignore comments in .depend

### DIFF
--- a/tools/valedepend.py
+++ b/tools/valedepend.py
@@ -146,6 +146,8 @@ def compute_fstar_deps():
             if '(Warning ' in line:
                 # example: "(Warning 307) logic qualifier is deprecated"
                 continue
+            if line.startswith('#'):
+                continue
             if line.endswith(':'):
                 line = line + ' '
             # lines are of the form:


### PR DESCRIPTION
## Proposed changes

F* will now print comments in the .depend (https://github.com/FStarLang/FStar/pull/3550). This parsing tool should ignore them. I should have checked before, sorry!

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)