### PR TITLE
Vale.{X64,PPC64LE}.QuickCodes: erasing ranges

### DIFF
--- a/vale/code/arch/ppc64le/Vale.PPC64LE.QuickCode.fst
+++ b/vale/code/arch/ppc64le/Vale.PPC64LE.QuickCode.fst
@@ -116,7 +116,7 @@ let t_proof (#a:Type0) (c:va_code) (mods:mods_t) (wp:quickProc_wp a) : Type =
     (ensures va_t_ensure c mods s0 k)
 
 // Code that returns a ghost value of type a
-[@@va_qattr]
+[@@va_qattr; erasable]
 noeq type quickCode (a:Type0) : va_code -> Type =
 | QProc:
     c:va_code ->

--- a/vale/code/arch/ppc64le/Vale.PPC64LE.QuickCode.fst
+++ b/vale/code/arch/ppc64le/Vale.PPC64LE.QuickCode.fst
@@ -23,19 +23,19 @@ type mod_t =
 unfold let mods_t = list mod_t
 unfold let va_mods_t = mods_t
 
-[@va_qattr] unfold let va_Mod_None = Mod_None
-[@va_qattr] unfold let va_Mod_ok = Mod_ok
-[@va_qattr] unfold let va_Mod_reg (r:reg) = Mod_reg r
-[@va_qattr] unfold let va_Mod_vec (v:vec) = Mod_vec v
-[@va_qattr] unfold let va_Mod_cr0 = Mod_cr0
-[@va_qattr] unfold let va_Mod_xer = Mod_xer
-[@va_qattr] unfold let va_Mod_mem = Mod_mem
-[@va_qattr] unfold let va_Mod_mem_layout = Mod_mem_layout
-[@va_qattr] unfold let va_Mod_mem_heaplet (n:heaplet_id) = Mod_mem_heaplet n
-[@va_qattr] unfold let va_Mod_stack = Mod_stack
-[@va_qattr] unfold let va_Mod_stackTaint = Mod_stackTaint
+[@@va_qattr] unfold let va_Mod_None = Mod_None
+[@@va_qattr] unfold let va_Mod_ok = Mod_ok
+[@@va_qattr] unfold let va_Mod_reg (r:reg) = Mod_reg r
+[@@va_qattr] unfold let va_Mod_vec (v:vec) = Mod_vec v
+[@@va_qattr] unfold let va_Mod_cr0 = Mod_cr0
+[@@va_qattr] unfold let va_Mod_xer = Mod_xer
+[@@va_qattr] unfold let va_Mod_mem = Mod_mem
+[@@va_qattr] unfold let va_Mod_mem_layout = Mod_mem_layout
+[@@va_qattr] unfold let va_Mod_mem_heaplet (n:heaplet_id) = Mod_mem_heaplet n
+[@@va_qattr] unfold let va_Mod_stack = Mod_stack
+[@@va_qattr] unfold let va_Mod_stackTaint = Mod_stackTaint
 
-[@va_qattr "opaque_to_smt"]
+[@@va_qattr; "opaque_to_smt"]
 let mod_eq (x y:mod_t) : Pure bool (requires True) (ensures fun b -> b == (x = y)) =
   match x with
   | Mod_None -> (match y with Mod_None -> true | _ -> false)
@@ -50,7 +50,7 @@ let mod_eq (x y:mod_t) : Pure bool (requires True) (ensures fun b -> b == (x = y
   | Mod_stack -> (match y with Mod_stack -> true | _ -> false)
   | Mod_stackTaint -> (match y with Mod_stackTaint -> true | _ -> false)
 
-[@va_qattr]
+[@@va_qattr]
 let update_state_mod (m:mod_t) (sM sK:state) : state =
   match m with
   | Mod_None -> sK
@@ -65,13 +65,13 @@ let update_state_mod (m:mod_t) (sM sK:state) : state =
   | Mod_stack -> va_update_stack sM sK
   | Mod_stackTaint -> va_update_stackTaint sM sK
 
-[@va_qattr]
+[@@va_qattr]
 let rec update_state_mods (mods:mods_t) (sM sK:state) : state =
   match mods with
   | [] -> sK
   | m::mods -> update_state_mod m sM (update_state_mods mods sM sK)
 
-[@va_qattr]
+[@@va_qattr]
 unfold let update_state_mods_norm (mods:mods_t) (sM sK:state) : state =
   norm [iota; zeta; delta_attr [`%qmodattr]; delta_only [`%update_state_mods; `%update_state_mod]] (update_state_mods mods sM sK)
 
@@ -79,16 +79,16 @@ let va_lemma_norm_mods (mods:mods_t) (sM sK:state) : Lemma
   (ensures update_state_mods mods sM sK == update_state_mods_norm mods sM sK)
   = ()
 
-[@va_qattr qmodattr]
+[@@va_qattr; qmodattr]
 let va_mod_reg_opr (r:reg_opr) : mod_t =
   Mod_reg r
-[@va_qattr qmodattr]
+[@@va_qattr; qmodattr]
 let va_mod_vec_opr (r:vec_opr) : mod_t =
   Mod_vec r
 
-[@va_qattr qmodattr] let va_mod_reg (r:reg) : mod_t = Mod_reg r
-[@va_qattr qmodattr] let va_mod_vec (x:vec) : mod_t = Mod_vec x
-[@va_qattr qmodattr] let va_mod_heaplet (h:heaplet_id) : mod_t = Mod_mem_heaplet h
+[@@va_qattr; qmodattr] let va_mod_reg (r:reg) : mod_t = Mod_reg r
+[@@va_qattr; qmodattr] let va_mod_vec (x:vec) : mod_t = Mod_vec x
+[@@va_qattr; qmodattr] let va_mod_heaplet (h:heaplet_id) : mod_t = Mod_mem_heaplet h
 
 let quickProc_wp (a:Type0) : Type u#1 = (s0:state) -> (wp_continue:state -> a -> Type0) -> Type0
 
@@ -116,7 +116,7 @@ let t_proof (#a:Type0) (c:va_code) (mods:mods_t) (wp:quickProc_wp a) : Type =
     (ensures va_t_ensure c mods s0 k)
 
 // Code that returns a ghost value of type a
-[@va_qattr]
+[@@va_qattr]
 noeq type quickCode (a:Type0) : va_code -> Type =
 | QProc:
     c:va_code ->
@@ -125,8 +125,8 @@ noeq type quickCode (a:Type0) : va_code -> Type =
     proof:t_proof c mods wp ->
     quickCode a c
 
-[@va_qattr]
+[@@va_qattr]
 unfold let va_quickCode = quickCode
 
-[@va_qattr]
+[@@va_qattr]
 unfold let va_QProc = QProc

--- a/vale/code/arch/ppc64le/Vale.PPC64LE.QuickCodes.fsti
+++ b/vale/code/arch/ppc64le/Vale.PPC64LE.QuickCodes.fsti
@@ -16,12 +16,12 @@ unfold let codes = va_codes
 unfold let fuel = va_fuel
 unfold let eval = eval_code
 
-[@va_qattr "opaque_to_smt"]
+[@@va_qattr; "opaque_to_smt"]
 let labeled_wrap (r:range) (msg:string) (p:Type0) : GTot Type0 = labeled r msg p
 
 // REVIEW: when used inside a function definition, 'labeled' can show up in an SMT query
 // as an uninterpreted function.  Make a wrapper around labeled that is interpreted:
-[@va_qattr "opaque_to_smt"]
+[@@va_qattr; "opaque_to_smt"]
 let label (r:range) (msg:string) (p:Type0) : Ghost Type (requires True) (ensures fun q -> q <==> p) =
   assert_norm (labeled_wrap r msg p <==> p);
   labeled_wrap r msg p
@@ -34,19 +34,19 @@ val lemma_label_bool (r:range) (msg:string) (b:bool) : Lemma
 // wrap "precedes" and LexCons to avoid issues with label (precedes ...)
 let precedes_wrap (#a:Type) (x y:a) : GTot Type0 = precedes x y
 
-[@va_qattr]
+[@@va_qattr]
 let rec mods_contains1 (allowed:mods_t) (found:mod_t) : bool =
   match allowed with
   | [] -> mod_eq Mod_None found
   | h::t -> mod_eq h found || mods_contains1 t found
 
-[@va_qattr]
+[@@va_qattr]
 let rec mods_contains (allowed:mods_t) (found:mods_t) : bool =
   match found with
   | [] -> true
   | h::t -> mods_contains1 allowed h && mods_contains allowed t
 
-[@va_qattr]
+[@@va_qattr]
 let if_code (b:bool) (c1:code) (c2:code) : code = if b then c1 else c2
 
 open FStar.Monotonic.Pure
@@ -69,12 +69,12 @@ noeq type quickCodes (a:Type0) : codes -> Type =
 | QAssertBy: #cs:codes -> r:range -> msg:string -> p:Type0 ->
     quickCodes unit [] -> quickCodes a cs -> quickCodes a cs
 
-[@va_qattr] unfold let va_QBind (#a:Type0) (#b:Type) (#c:code) (#cs:codes) (r:range) (msg:string) (qc:quickCode b c) (qcs:va_state -> b -> GTot (quickCodes a cs)) : quickCodes a (c::cs) = QBind r msg qc qcs
-[@va_qattr] unfold let va_QEmpty (#a:Type0) (v:a) : quickCodes a [] = QEmpty v
-[@va_qattr] unfold let va_QLemma (#a:Type0) (#cs:codes) (r:range) (msg:string) (pre:Type0) (post:(squash pre -> Type0)) (l:unit -> Lemma (requires pre) (ensures post ())) (qcs:quickCodes a cs) : quickCodes a cs = QLemma r msg pre post l qcs
-[@va_qattr] unfold let va_QSeq (#a:Type0) (#b:Type) (#c:code) (#cs:codes) (r:range) (msg:string) (qc:quickCode b c) (qcs:quickCodes a cs) : quickCodes a (c::cs) = QSeq r msg qc qcs
+[@@va_qattr] unfold let va_QBind (#a:Type0) (#b:Type) (#c:code) (#cs:codes) (r:range) (msg:string) (qc:quickCode b c) (qcs:va_state -> b -> GTot (quickCodes a cs)) : quickCodes a (c::cs) = QBind r msg qc qcs
+[@@va_qattr] unfold let va_QEmpty (#a:Type0) (v:a) : quickCodes a [] = QEmpty v
+[@@va_qattr] unfold let va_QLemma (#a:Type0) (#cs:codes) (r:range) (msg:string) (pre:Type0) (post:(squash pre -> Type0)) (l:unit -> Lemma (requires pre) (ensures post ())) (qcs:quickCodes a cs) : quickCodes a cs = QLemma r msg pre post l qcs
+[@@va_qattr] unfold let va_QSeq (#a:Type0) (#b:Type) (#c:code) (#cs:codes) (r:range) (msg:string) (qc:quickCode b c) (qcs:quickCodes a cs) : quickCodes a (c::cs) = QSeq r msg qc qcs
 
-[@va_qattr]
+[@@va_qattr]
 let va_qPURE
     (#cs:codes) (#pre:((unit -> GTot Type0) -> GTot Type0){is_monotonic pre}) (#a:Type0) (r:range) (msg:string)
     ($l:unit -> PURE unit (intro_pure_wp_monotonicity pre; pre)) (qcs:quickCodes a cs)
@@ -83,7 +83,7 @@ let va_qPURE
 
 (* REVIEW: this might be useful, but inference of pre doesn't work as well as for va_qPURE
   (need to provide pre explicitly; as a result, no need to put $ on l)
-[@va_qattr]
+[@@va_qattr]
 let va_qBindPURE
     (#a #b:Type0) (#cs:codes) (pre:(b -> GTot Type0) -> GTot Type0) (r:range) (msg:string)
     (l:unit -> PURE b pre) (qcs:va_state -> b -> GTot (quickCodes a cs))
@@ -91,7 +91,7 @@ let va_qBindPURE
   QBindPURE b r msg pre l qcs
 *)
 
-[@va_qattr]
+[@@va_qattr]
 let wp_proc (#a:Type0) (c:code) (qc:quickCode a c) (s0:va_state) (k:va_state -> a -> Type0) : Type0 =
   match qc with
   | QProc _ _ wp _ -> wp s0 k
@@ -100,14 +100,14 @@ let wp_Seq_t (a:Type0) = va_state -> a -> Type0
 let wp_Bind_t (a:Type0) = va_state -> a -> Type0
 let k_AssertBy (p:Type0) (_:va_state) () = p
 
-[@va_qattr]
+[@@va_qattr]
 let va_range1 = mk_range "" 0 0 0 0
 
 val empty_list_is_small (#a:Type) (x:list a) : Lemma
   ([] #a == x \/ [] #a << x)
 
 #push-options "--z3rlimit 20"
-[@va_qattr]
+[@@va_qattr]
 let rec wp (#a:Type0) (cs:codes) (qcs:quickCodes a cs) (mods:mods_t) (k:va_state -> a -> Type0) (s0:va_state) :
   Tot Type0 (decreases %[cs; 0; qcs])
   =
@@ -169,7 +169,7 @@ val wp_sound (#a:Type0) (cs:codes) (qcs:quickCodes a cs) (mods:mods_t) (k:va_sta
 
 unfold let block = va_Block
 
-[@va_qattr]
+[@@va_qattr]
 let wp_block (#a:Type) (#cs:codes) (qcs:va_state -> GTot (quickCodes a cs)) (mods:mods_t) (s0:va_state) (k:va_state -> a -> Type0) : Type0 =
   wp cs (qcs s0) mods k s0
 
@@ -180,13 +180,13 @@ val qblock_proof (#a:Type) (#cs:codes) (qcs:va_state -> GTot (quickCodes a cs)) 
     eval_code (block cs) s0 f0 sM /\ update_state_mods mods sM s0 == sM /\ state_inv sM /\ k sM g
   )
 
-[@"opaque_to_smt" va_qattr]
+[@@"opaque_to_smt"; va_qattr]
 let qblock (#a:Type) (#cs:codes) (mods:mods_t) (qcs:va_state -> GTot (quickCodes a cs)) : quickCode a (block cs) =
   QProc (block cs) mods (wp_block qcs mods) (qblock_proof qcs mods)
 
 ///// If, InlineIf
 
-[@va_qattr]
+[@@va_qattr]
 let wp_InlineIf (#a:Type) (#c1:code) (#c2:code) (b:bool) (qc1:quickCode a c1) (qc2:quickCode a c2) (mods:mods_t) (s0:va_state) (k:va_state -> a -> Type0) : Type0 =
   // REVIEW: this duplicates k
   (    b ==> mods_contains mods qc1.mods /\ QProc?.wp qc1 s0 k) /\
@@ -199,7 +199,7 @@ val qInlineIf_proof (#a:Type) (#c1:code) (#c2:code) (b:bool) (qc1:quickCode a c1
     eval_code (if_code b c1 c2) s0 f0 sM /\ update_state_mods mods sM s0 == sM /\ state_inv sM /\ k sM g
   )
 
-[@"opaque_to_smt" va_qattr]
+[@@"opaque_to_smt"; va_qattr]
 let va_qInlineIf (#a:Type) (#c1:code) (#c2:code) (mods:mods_t) (b:bool) (qc1:quickCode a c1) (qc2:quickCode a c2) : quickCode a (if_code b c1 c2) =
   QProc (if_code b c1 c2) mods (wp_InlineIf b qc1 qc2 mods) (qInlineIf_proof b qc1 qc2 mods)
 
@@ -211,7 +211,7 @@ noeq type cmp =
 | Cmp_lt : o1:cmp_opr -> o2:cmp_opr -> cmp
 | Cmp_gt : o1:cmp_opr -> o2:cmp_opr -> cmp
 
-[@va_qattr]
+[@@va_qattr]
 let cmp_to_ocmp (c:cmp) : ocmp =
   match c with
   | Cmp_eq o1 o2 -> va_cmp_eq o1 o2
@@ -221,7 +221,7 @@ let cmp_to_ocmp (c:cmp) : ocmp =
   | Cmp_lt o1 o2 -> va_cmp_lt o1 o2
   | Cmp_gt o1 o2 -> va_cmp_gt o1 o2
 
-[@va_qattr]
+[@@va_qattr]
 let valid_cmp (c:cmp) (s:va_state) : Type0 =
   match c with
   | Cmp_eq o1 _ -> valid_first_cmp_opr o1
@@ -231,7 +231,7 @@ let valid_cmp (c:cmp) (s:va_state) : Type0 =
   | Cmp_lt o1 _ -> valid_first_cmp_opr o1
   | Cmp_gt o1 _ -> valid_first_cmp_opr o1
 
-[@va_qattr]
+[@@va_qattr]
 let eval_cmp (s:va_state) (c:cmp) : GTot bool =
   match c with
   | Cmp_eq o1 o2 -> va_eval_cmp_opr s o1 =  va_eval_cmp_opr s o2
@@ -241,7 +241,7 @@ let eval_cmp (s:va_state) (c:cmp) : GTot bool =
   | Cmp_lt o1 o2 -> va_eval_cmp_opr s o1 <  va_eval_cmp_opr s o2
   | Cmp_gt o1 o2 -> va_eval_cmp_opr s o1 >  va_eval_cmp_opr s o2
 
-[@va_qattr]
+[@@va_qattr]
 let wp_If (#a:Type) (#c1:code) (#c2:code) (b:cmp) (qc1:quickCode a c1) (qc2:quickCode a c2) (mods:mods_t) (s0:va_state) (k:va_state -> a -> Type0) : Type0 =
   // REVIEW: this duplicates k
   valid_cmp b s0 /\ mods_contains1 mods Mod_cr0 /\
@@ -256,20 +256,20 @@ val qIf_proof (#a:Type) (#c1:code) (#c2:code) (b:cmp) (qc1:quickCode a c1) (qc2:
     eval_code (IfElse (cmp_to_ocmp b) c1 c2) s0 f0 sM /\ update_state_mods mods sM s0 == sM /\ state_inv sM /\ k sM g
   )
 
-[@"opaque_to_smt" va_qattr]
+[@@"opaque_to_smt"; va_qattr]
 let va_qIf (#a:Type) (#c1:code) (#c2:code) (mods:mods_t) (b:cmp) (qc1:quickCode a c1) (qc2:quickCode a c2) : quickCode a (IfElse (cmp_to_ocmp b) c1 c2) =
   QProc (IfElse (cmp_to_ocmp b) c1 c2) mods (wp_If b qc1 qc2 mods) (qIf_proof b qc1 qc2 mods)
 
 ///// While
 
-[@va_qattr]
+[@@va_qattr]
 let wp_While_inv
     (#a #d:Type) (#c:code) (qc:a -> quickCode a c) (mods:mods_t) (inv:va_state -> a -> Type0)
     (dec:va_state -> a -> d) (s1:va_state) (g1:a) (s2:va_state) (g2:a)
     : Type0 =
   s2.ok /\ inv s2 g2 /\ mods_contains mods (qc g2).mods /\ dec s2 g2 << dec s1 g1
 
-[@va_qattr]
+[@@va_qattr]
 let wp_While_body
     (#a #d:Type) (#c:code) (b:cmp) (qc:a -> quickCode a c) (mods:mods_t) (inv:va_state -> a -> Type0)
     (dec:va_state -> a -> d) (g1:a) (s1:va_state) (k:va_state -> a -> Type0)
@@ -279,7 +279,7 @@ let wp_While_body
     (     eval_cmp s1 b  ==> mods_contains mods (qc g1).mods /\ QProc?.wp (qc g1) s1' (wp_While_inv qc mods inv dec s1 g1)) /\
     (not (eval_cmp s1 b) ==> k s1' g1))
 
-[@va_qattr]
+[@@va_qattr]
 let wp_While
     (#a #d:Type) (#c:code) (b:cmp) (qc:a -> quickCode a c) (mods:mods_t) (inv:va_state -> a -> Type0)
     (dec:va_state -> a -> d) (g0:a) (s0:va_state) (k:va_state -> a -> Type0)
@@ -297,7 +297,7 @@ val qWhile_proof
     eval_code (While (cmp_to_ocmp b) c) s0 f0 sM /\ update_state_mods mods sM s0 == sM /\ state_inv sM /\ k sM g
   )
 
-[@"opaque_to_smt" va_qattr]
+[@@"opaque_to_smt"; va_qattr]
 let va_qWhile
     (#a #d:Type) (#c:code) (mods:mods_t) (b:cmp) (qc:a -> quickCode a c) (inv:va_state -> a -> Type0)
     (dec:va_state -> a -> d) (g0:a)
@@ -310,21 +310,21 @@ let va_qWhile
 let tAssertLemma (p:Type0) = unit -> Lemma (requires p) (ensures p)
 val qAssertLemma (p:Type0) : tAssertLemma p
 
-[@va_qattr]
+[@@va_qattr]
 let va_qAssert (#a:Type) (#cs:codes) (r:range) (msg:string) (e:Type0) (qcs:quickCodes a cs) : quickCodes a cs =
   QLemma r msg e (fun () -> e) (qAssertLemma e) qcs
 
 let tAssumeLemma (p:Type0) = unit -> Lemma (requires True) (ensures p)
 val qAssumeLemma (p:Type0) : tAssumeLemma p
 
-[@va_qattr]
+[@@va_qattr]
 let va_qAssume (#a:Type) (#cs:codes) (r:range) (msg:string) (e:Type0) (qcs:quickCodes a cs) : quickCodes a cs =
   QLemma r msg True (fun () -> e) (qAssumeLemma e) qcs
 
 let tAssertSquashLemma (p:Type0) = unit -> Ghost (squash p) (requires p) (ensures fun () -> p)
 val qAssertSquashLemma (p:Type0) : tAssertSquashLemma p
 
-[@va_qattr]
+[@@va_qattr]
 let va_qAssertSquash
     (#a:Type) (#cs:codes) (r:range) (msg:string) (e:Type0) (qcs:squash e -> GTot (quickCodes a cs))
   : quickCodes a ((Block [])::cs) =
@@ -334,11 +334,11 @@ let va_qAssertSquash
 //  unit -> Lemma (requires t_require s0 /\ wp [] qcs mods (fun _ _ -> p) s0) (ensures p)
 //val qAssertByLemma (#a:Type) (p:Type0) (qcs:quickCodes a []) (mods:mods_t) (s0:state) : tAssertByLemma p qcs mods s0
 //
-//[@va_qattr]
+//[@@va_qattr]
 //let va_qAssertBy (#a:Type) (#cs:codes) (mods:mods_t) (r:range) (msg:string) (p:Type0) (qcsBy:quickCodes unit []) (s0:state) (qcsTail:quickCodes a cs) : quickCodes a cs =
 //  QLemma r msg (t_require s0 /\ wp [] qcsBy mods (fun _ _ -> p) s0) (fun () -> p) (qAssertByLemma p qcsBy mods s0) qcsTail
 
-[@va_qattr]
+[@@va_qattr]
 let va_qAssertBy (#a:Type) (#cs:codes) (r:range) (msg:string) (p:Type0) (qcsBy:quickCodes unit []) (qcsTail:quickCodes a cs) : quickCodes a cs =
   QAssertBy r msg p qcsBy qcsTail
 
@@ -349,7 +349,7 @@ val wp_sound_code (#a:Type0) (c:code) (qc:quickCode a c) (k:va_state -> a -> Typ
   (requires t_require s0 /\ QProc?.wp qc s0 k)
   (ensures fun (sN, fN, gN) -> eval_code c s0 fN sN /\ update_state_mods qc.mods sN s0 == sN /\ state_inv sN /\ k sN gN)
 
-[@va_qattr]
+[@@va_qattr]
 let state_match (s0:va_state) (s1:va_state) : Type0 =
   s0.ok == s1.ok /\
   Regs.equal s0.regs s1.regs /\
@@ -364,7 +364,7 @@ val lemma_state_match (s0:va_state) (s1:va_state) : Lemma
   (requires state_match s0 s1)
   (ensures state_eq s0 s1)
 
-[@va_qattr]
+[@@va_qattr]
 let va_state_match (s0:va_state) (s1:va_state) : Pure Type0
   (requires True)
   (ensures fun b -> b ==> state_eq s0 s1)
@@ -372,7 +372,7 @@ let va_state_match (s0:va_state) (s1:va_state) : Pure Type0
   FStar.Classical.move_requires (lemma_state_match s0) s1;
   state_match s0 s1
 
-[@va_qattr]
+[@@va_qattr]
 unfold let wp_sound_code_pre (#a:Type0) (#c:code) (qc:quickCode a c) (s0:va_state) (k:(s0':va_state{s0 == s0'}) -> va_state -> a -> Type0) : Type0 =
   forall
       (ok:bool)

--- a/vale/code/arch/x64/Vale.X64.QuickCode.fst
+++ b/vale/code/arch/x64/Vale.X64.QuickCode.fst
@@ -114,7 +114,7 @@ let t_proof (#a:Type0) (c:va_code) (mods:mods_t) (wp:quickProc_wp a) : Type =
     (ensures va_t_ensure c mods s0 k)
 
 // Code that returns a ghost value of type a
-[@va_qattr]
+[@@va_qattr; erasable]
 noeq type quickCode (a:Type0) : va_code -> Type =
 | QProc:
     c:va_code ->

--- a/vale/code/arch/x64/Vale.X64.QuickCode.fst
+++ b/vale/code/arch/x64/Vale.X64.QuickCode.fst
@@ -21,18 +21,18 @@ type mod_t =
 unfold let mods_t = list mod_t
 unfold let va_mods_t = mods_t
 
-[@va_qattr] unfold let va_Mod_None = Mod_None
-[@va_qattr] unfold let va_Mod_ok = Mod_ok
-[@va_qattr] unfold let va_Mod_reg64 (r:reg_64) = Mod_reg (Reg 0 r)
-[@va_qattr] unfold let va_Mod_xmm (r:reg_xmm) = Mod_reg (Reg 1 r)
-[@va_qattr] unfold let va_Mod_flags = Mod_flags
-[@va_qattr] unfold let va_Mod_mem = Mod_mem
-[@va_qattr] unfold let va_Mod_mem_layout = Mod_mem_layout
-[@va_qattr] unfold let va_Mod_mem_heaplet (n:heaplet_id) = Mod_mem_heaplet n
-[@va_qattr] unfold let va_Mod_stack = Mod_stack
-[@va_qattr] unfold let va_Mod_stackTaint = Mod_stackTaint
+[@@va_qattr] unfold let va_Mod_None = Mod_None
+[@@va_qattr] unfold let va_Mod_ok = Mod_ok
+[@@va_qattr] unfold let va_Mod_reg64 (r:reg_64) = Mod_reg (Reg 0 r)
+[@@va_qattr] unfold let va_Mod_xmm (r:reg_xmm) = Mod_reg (Reg 1 r)
+[@@va_qattr] unfold let va_Mod_flags = Mod_flags
+[@@va_qattr] unfold let va_Mod_mem = Mod_mem
+[@@va_qattr] unfold let va_Mod_mem_layout = Mod_mem_layout
+[@@va_qattr] unfold let va_Mod_mem_heaplet (n:heaplet_id) = Mod_mem_heaplet n
+[@@va_qattr] unfold let va_Mod_stack = Mod_stack
+[@@va_qattr] unfold let va_Mod_stackTaint = Mod_stackTaint
 
-[@va_qattr "opaque_to_smt"]
+[@@va_qattr; "opaque_to_smt"]
 let mod_eq (x y:mod_t) : Pure bool (requires True) (ensures fun b -> b == (x = y)) =
   match x with
   | Mod_None -> (match y with Mod_None -> true | _ -> false)
@@ -45,7 +45,7 @@ let mod_eq (x y:mod_t) : Pure bool (requires True) (ensures fun b -> b == (x = y
   | Mod_stack -> (match y with Mod_stack -> true | _ -> false)
   | Mod_stackTaint -> (match y with Mod_stackTaint -> true | _ -> false)
 
-[@va_qattr]
+[@@va_qattr]
 let update_state_mod (m:mod_t) (sM sK:vale_state) : vale_state =
   match m with
   | Mod_None -> sK
@@ -58,13 +58,13 @@ let update_state_mod (m:mod_t) (sM sK:vale_state) : vale_state =
   | Mod_stack -> va_update_stack sM sK
   | Mod_stackTaint -> va_update_stackTaint sM sK
 
-[@va_qattr]
+[@@va_qattr]
 let rec update_state_mods (mods:mods_t) (sM sK:vale_state) : vale_state =
   match mods with
   | [] -> sK
   | m::mods -> update_state_mod m sM (update_state_mods mods sM sK)
 
-[@va_qattr]
+[@@va_qattr]
 unfold let update_state_mods_norm (mods:mods_t) (sM sK:vale_state) : vale_state =
   norm [iota; zeta; delta_attr [`%qmodattr]; delta_only [`%update_state_mods; `%update_state_mod]] (update_state_mods mods sM sK)
 
@@ -72,7 +72,7 @@ let va_lemma_norm_mods (mods:mods_t) (sM sK:vale_state) : Lemma
   (ensures update_state_mods mods sM sK == update_state_mods_norm mods sM sK)
   = ()
 
-[@va_qattr qmodattr]
+[@@va_qattr; qmodattr]
 let va_mod_dst_opr64 (o:operand64) : mod_t =
   match o with
   | OConst n -> Mod_None
@@ -80,13 +80,13 @@ let va_mod_dst_opr64 (o:operand64) : mod_t =
   | OMem _ -> Mod_None // TODO: support destination memory operands
   | OStack _ -> Mod_None // TODO: support destination stack operands
 
-[@va_qattr qmodattr]
+[@@va_qattr; qmodattr]
 let va_mod_reg_opr64 (o:reg_operand) : mod_t =
   match o with
   | OReg r -> Mod_reg (Reg 0 r)
 
-[@va_qattr qmodattr] let va_mod_xmm (x:reg_xmm) : mod_t = Mod_reg (Reg 1 x)
-[@va_qattr qmodattr] let va_mod_heaplet (h:heaplet_id) : mod_t = Mod_mem_heaplet h
+[@@va_qattr; qmodattr] let va_mod_xmm (x:reg_xmm) : mod_t = Mod_reg (Reg 1 x)
+[@@va_qattr; qmodattr] let va_mod_heaplet (h:heaplet_id) : mod_t = Mod_mem_heaplet h
 
 let quickProc_wp (a:Type0) : Type u#1 = (s0:vale_state) -> (wp_continue:vale_state -> a -> Type0) -> Type0
 
@@ -123,8 +123,8 @@ noeq type quickCode (a:Type0) : va_code -> Type =
     proof:t_proof c mods wp ->
     quickCode a c
 
-[@va_qattr]
+[@@va_qattr]
 unfold let va_quickCode = quickCode
 
-[@va_qattr]
+[@@va_qattr]
 unfold let va_QProc = QProc

--- a/vale/code/arch/x64/Vale.X64.QuickCodes.fsti
+++ b/vale/code/arch/x64/Vale.X64.QuickCodes.fsti
@@ -16,12 +16,12 @@ unfold let codes = va_codes
 unfold let fuel = va_fuel
 unfold let eval = eval_code
 
-[@va_qattr "opaque_to_smt"]
+[@@va_qattr; "opaque_to_smt"]
 let labeled_wrap (r:range) (msg:string) (p:Type0) : GTot Type0 = labeled r msg p
 
 // REVIEW: when used inside a function definition, 'labeled' can show up in an SMT query
 // as an uninterpreted function.  Make a wrapper around labeled that is interpreted:
-[@va_qattr "opaque_to_smt"]
+[@@va_qattr; "opaque_to_smt"]
 let label (r:range) (msg:string) (p:Type0) : Ghost Type (requires True) (ensures fun q -> q <==> p) =
   assert_norm (labeled_wrap r msg p <==> p);
   labeled_wrap r msg p
@@ -34,19 +34,19 @@ val lemma_label_bool (r:range) (msg:string) (b:bool) : Lemma
 // wrap "precedes" and LexCons to avoid issues with label (precedes ...)
 let precedes_wrap (#a:Type) (x y:a) : GTot Type0 = precedes x y
 
-[@va_qattr]
+[@@va_qattr]
 let rec mods_contains1 (allowed:mods_t) (found:mod_t) : bool =
   match allowed with
   | [] -> mod_eq Mod_None found
   | h::t -> mod_eq h found || mods_contains1 t found
 
-[@va_qattr]
+[@@va_qattr]
 let rec mods_contains (allowed:mods_t) (found:mods_t) : bool =
   match found with
   | [] -> true
   | h::t -> mods_contains1 allowed h && mods_contains allowed t
 
-[@va_qattr]
+[@@va_qattr]
 let if_code (b:bool) (c1:code) (c2:code) : code = if b then c1 else c2
 
 open FStar.Monotonic.Pure
@@ -69,12 +69,12 @@ noeq type quickCodes (a:Type0) : codes -> Type =
 | QAssertBy: #cs:codes -> r:range -> msg:string -> p:Type0 ->
     quickCodes unit [] -> quickCodes a cs -> quickCodes a cs
 
-[@va_qattr] unfold let va_QBind (#a:Type0) (#b:Type) (#c:code) (#cs:codes) (r:range) (msg:string) (qc:quickCode b c) (qcs:va_state -> b -> GTot (quickCodes a cs)) : quickCodes a (c::cs) = QBind r msg qc qcs
-[@va_qattr] unfold let va_QEmpty (#a:Type0) (v:a) : quickCodes a [] = QEmpty v
-[@va_qattr] unfold let va_QLemma (#a:Type0) (#cs:codes) (r:range) (msg:string) (pre:Type0) (post:(squash pre -> Type0)) (l:unit -> Lemma (requires pre) (ensures post ())) (qcs:quickCodes a cs) : quickCodes a cs = QLemma r msg pre post l qcs
-[@va_qattr] unfold let va_QSeq (#a:Type0) (#b:Type) (#c:code) (#cs:codes) (r:range) (msg:string) (qc:quickCode b c) (qcs:quickCodes a cs) : quickCodes a (c::cs) = QSeq r msg qc qcs
+[@@va_qattr] unfold let va_QBind (#a:Type0) (#b:Type) (#c:code) (#cs:codes) (r:range) (msg:string) (qc:quickCode b c) (qcs:va_state -> b -> GTot (quickCodes a cs)) : quickCodes a (c::cs) = QBind r msg qc qcs
+[@@va_qattr] unfold let va_QEmpty (#a:Type0) (v:a) : quickCodes a [] = QEmpty v
+[@@va_qattr] unfold let va_QLemma (#a:Type0) (#cs:codes) (r:range) (msg:string) (pre:Type0) (post:(squash pre -> Type0)) (l:unit -> Lemma (requires pre) (ensures post ())) (qcs:quickCodes a cs) : quickCodes a cs = QLemma r msg pre post l qcs
+[@@va_qattr] unfold let va_QSeq (#a:Type0) (#b:Type) (#c:code) (#cs:codes) (r:range) (msg:string) (qc:quickCode b c) (qcs:quickCodes a cs) : quickCodes a (c::cs) = QSeq r msg qc qcs
 
-[@va_qattr]
+[@@va_qattr]
 let va_qPURE
     (#cs:codes) (#pre:((unit -> GTot Type0) -> GTot Type0){is_monotonic pre}) (#a:Type0) (r:range) (msg:string)
     ($l:unit -> PURE unit (intro_pure_wp_monotonicity pre; pre)) (qcs:quickCodes a cs)
@@ -83,7 +83,7 @@ let va_qPURE
 
 (* REVIEW: this might be useful, but inference of pre doesn't work as well as for va_qPURE
   (need to provide pre explicitly; as a result, no need to put $ on l)
-[@va_qattr]
+[@@va_qattr]
 let va_qBindPURE
     (#a #b:Type0) (#cs:codes) (pre:(b -> GTot Type0) -> GTot Type0) (r:range) (msg:string)
     (l:unit -> PURE b pre) (qcs:va_state -> b -> GTot (quickCodes a cs))
@@ -91,7 +91,7 @@ let va_qBindPURE
   QBindPURE b r msg pre l qcs
 *)
 
-[@va_qattr]
+[@@va_qattr]
 let wp_proc (#a:Type0) (c:code) (qc:quickCode a c) (s0:va_state) (k:va_state -> a -> Type0) : Type0 =
   match qc with
   | QProc _ _ wp _ -> wp s0 k
@@ -100,13 +100,13 @@ let wp_Seq_t (a:Type0) = va_state -> a -> Type0
 let wp_Bind_t (a:Type0) = va_state -> a -> Type0
 let k_AssertBy (p:Type0) (_:va_state) () = p
 
-[@va_qattr]
+[@@va_qattr]
 let va_range1 = mk_range "" 0 0 0 0
 
 val empty_list_is_small (#a:Type) (x:list a) : Lemma
   ([] #a == x \/ [] #a << x)
 
-[@va_qattr]
+[@@va_qattr]
 let rec wp (#a:Type0) (cs:codes) (qcs:quickCodes a cs) (mods:mods_t) (k:va_state -> a -> Type0) (s0:va_state) :
   Tot Type0 (decreases %[cs; 0; qcs])
   =
@@ -167,7 +167,7 @@ val wp_sound (#a:Type0) (cs:codes) (qcs:quickCodes a cs) (mods:mods_t) (k:va_sta
 
 unfold let block = va_Block
 
-[@va_qattr]
+[@@va_qattr]
 let wp_block (#a:Type) (#cs:codes) (qcs:va_state -> GTot (quickCodes a cs)) (mods:mods_t) (s0:va_state) (k:va_state -> a -> Type0) : Type0 =
   wp cs (qcs s0) mods k s0
 
@@ -178,13 +178,13 @@ val qblock_proof (#a:Type) (#cs:codes) (qcs:va_state -> GTot (quickCodes a cs)) 
     eval_code (block cs) s0 f0 sM /\ update_state_mods mods sM s0 == sM /\ state_inv sM /\ k sM g
   )
 
-[@"opaque_to_smt" va_qattr]
+[@@"opaque_to_smt"; va_qattr]
 let qblock (#a:Type) (#cs:codes) (mods:mods_t) (qcs:va_state -> GTot (quickCodes a cs)) : quickCode a (block cs) =
   QProc (block cs) mods (wp_block qcs mods) (qblock_proof qcs mods)
 
 ///// If, InlineIf
 
-[@va_qattr]
+[@@va_qattr]
 let wp_InlineIf (#a:Type) (#c1:code) (#c2:code) (b:bool) (qc1:quickCode a c1) (qc2:quickCode a c2) (mods:mods_t) (s0:va_state) (k:va_state -> a -> Type0) : Type0 =
   // REVIEW: this duplicates k
   (    b ==> mods_contains mods qc1.mods /\ QProc?.wp qc1 s0 k) /\
@@ -197,7 +197,7 @@ val qInlineIf_proof (#a:Type) (#c1:code) (#c2:code) (b:bool) (qc1:quickCode a c1
     eval_code (if_code b c1 c2) s0 f0 sM /\ update_state_mods mods sM s0 == sM /\ state_inv sM /\ k sM g
   )
 
-[@"opaque_to_smt" va_qattr]
+[@@"opaque_to_smt"; va_qattr]
 let va_qInlineIf (#a:Type) (#c1:code) (#c2:code) (mods:mods_t) (b:bool) (qc1:quickCode a c1) (qc2:quickCode a c2) : quickCode a (if_code b c1 c2) =
   QProc (if_code b c1 c2) mods (wp_InlineIf b qc1 qc2 mods) (qInlineIf_proof b qc1 qc2 mods)
 
@@ -209,7 +209,7 @@ noeq type cmp =
 | Cmp_lt : o1:operand64{not (OMem? o1 || OStack? o1)} -> o2:operand64{not (OMem? o2 || OStack? o2)} -> cmp
 | Cmp_gt : o1:operand64{not (OMem? o1 || OStack? o1)} -> o2:operand64{not (OMem? o2 || OStack? o2)} -> cmp
 
-[@va_qattr]
+[@@va_qattr]
 let cmp_to_ocmp (c:cmp) : ocmp =
   match c with
   | Cmp_eq o1 o2 -> va_cmp_eq o1 o2
@@ -219,7 +219,7 @@ let cmp_to_ocmp (c:cmp) : ocmp =
   | Cmp_lt o1 o2 -> va_cmp_lt o1 o2
   | Cmp_gt o1 o2 -> va_cmp_gt o1 o2
 
-[@va_qattr]
+[@@va_qattr]
 let valid_cmp (c:cmp) (s:va_state) : Type0 =
   match c with
   | Cmp_eq o1 o2 -> valid_operand o1 s /\ valid_operand o2 s
@@ -229,7 +229,7 @@ let valid_cmp (c:cmp) (s:va_state) : Type0 =
   | Cmp_lt o1 o2 -> valid_operand o1 s /\ valid_operand o2 s
   | Cmp_gt o1 o2 -> valid_operand o1 s /\ valid_operand o2 s
 
-[@va_qattr]
+[@@va_qattr]
 let eval_cmp (s:va_state) (c:cmp) : GTot bool =
   match c with
   | Cmp_eq o1 o2 -> va_eval_opr64 s o1 =  va_eval_opr64 s o2
@@ -239,7 +239,7 @@ let eval_cmp (s:va_state) (c:cmp) : GTot bool =
   | Cmp_lt o1 o2 -> va_eval_opr64 s o1 <  va_eval_opr64 s o2
   | Cmp_gt o1 o2 -> va_eval_opr64 s o1 >  va_eval_opr64 s o2
 
-[@va_qattr]
+[@@va_qattr]
 let wp_If (#a:Type) (#c1:code) (#c2:code) (b:cmp) (qc1:quickCode a c1) (qc2:quickCode a c2) (mods:mods_t) (s0:va_state) (k:va_state -> a -> Type0) : Type0 =
   // REVIEW: this duplicates k
   valid_cmp b s0 /\ mods_contains1 mods Mod_flags /\
@@ -254,20 +254,20 @@ val qIf_proof (#a:Type) (#c1:code) (#c2:code) (b:cmp) (qc1:quickCode a c1) (qc2:
     eval_code (IfElse (cmp_to_ocmp b) c1 c2) s0 f0 sM /\ update_state_mods mods sM s0 == sM /\ state_inv sM /\ k sM g
   )
 
-[@"opaque_to_smt" va_qattr]
+[@@"opaque_to_smt"; va_qattr]
 let va_qIf (#a:Type) (#c1:code) (#c2:code) (mods:mods_t) (b:cmp) (qc1:quickCode a c1) (qc2:quickCode a c2) : quickCode a (IfElse (cmp_to_ocmp b) c1 c2) =
   QProc (IfElse (cmp_to_ocmp b) c1 c2) mods (wp_If b qc1 qc2 mods) (qIf_proof b qc1 qc2 mods)
 
 ///// While
 
-[@va_qattr]
+[@@va_qattr]
 let wp_While_inv
     (#a #d:Type) (#c:code) (qc:a -> quickCode a c) (mods:mods_t) (inv:va_state -> a -> Type0)
     (dec:va_state -> a -> d) (s1:va_state) (g1:a) (s2:va_state) (g2:a)
     : Type0 =
   s2.vs_ok /\ inv s2 g2 /\ mods_contains mods (qc g2).mods /\ dec s2 g2 << dec s1 g1
 
-[@va_qattr]
+[@@va_qattr]
 let wp_While_body
     (#a #d:Type) (#c:code) (b:cmp) (qc:a -> quickCode a c) (mods:mods_t) (inv:va_state -> a -> Type0)
     (dec:va_state -> a -> d) (g1:a) (s1:va_state) (k:va_state -> a -> Type0)
@@ -277,7 +277,7 @@ let wp_While_body
     (     eval_cmp s1 b  ==> mods_contains mods (qc g1).mods /\ QProc?.wp (qc g1) s1' (wp_While_inv qc mods inv dec s1 g1)) /\
     (not (eval_cmp s1 b) ==> k s1' g1))
 
-[@va_qattr]
+[@@va_qattr]
 let wp_While
     (#a #d:Type) (#c:code) (b:cmp) (qc:a -> quickCode a c) (mods:mods_t) (inv:va_state -> a -> Type0)
     (dec:va_state -> a -> d) (g0:a) (s0:va_state) (k:va_state -> a -> Type0)
@@ -295,7 +295,7 @@ val qWhile_proof
     eval_code (While (cmp_to_ocmp b) c) s0 f0 sM /\ update_state_mods mods sM s0 == sM /\ state_inv sM /\ k sM g
   )
 
-[@"opaque_to_smt" va_qattr]
+[@@"opaque_to_smt"; va_qattr]
 let va_qWhile
     (#a #d:Type) (#c:code) (mods:mods_t) (b:cmp) (qc:a -> quickCode a c) (inv:va_state -> a -> Type0)
     (dec:va_state -> a -> d) (g0:a)
@@ -308,21 +308,21 @@ let va_qWhile
 let tAssertLemma (p:Type0) = unit -> Lemma (requires p) (ensures p)
 val qAssertLemma (p:Type0) : tAssertLemma p
 
-[@va_qattr]
+[@@va_qattr]
 let va_qAssert (#a:Type) (#cs:codes) (r:range) (msg:string) (e:Type0) (qcs:quickCodes a cs) : quickCodes a cs =
   QLemma r msg e (fun () -> e) (qAssertLemma e) qcs
 
 let tAssumeLemma (p:Type0) = unit -> Lemma (requires True) (ensures p)
 val qAssumeLemma (p:Type0) : tAssumeLemma p
 
-[@va_qattr]
+[@@va_qattr]
 let va_qAssume (#a:Type) (#cs:codes) (r:range) (msg:string) (e:Type0) (qcs:quickCodes a cs) : quickCodes a cs =
   QLemma r msg True (fun () -> e) (qAssumeLemma e) qcs
 
 let tAssertSquashLemma (p:Type0) = unit -> Ghost (squash p) (requires p) (ensures fun () -> p)
 val qAssertSquashLemma (p:Type0) : tAssertSquashLemma p
 
-[@va_qattr]
+[@@va_qattr]
 let va_qAssertSquash
     (#a:Type) (#cs:codes) (r:range) (msg:string) (e:Type0) (qcs:squash e -> GTot (quickCodes a cs))
   : quickCodes a ((Block [])::cs) =
@@ -332,11 +332,11 @@ let va_qAssertSquash
 //  unit -> Lemma (requires t_require s0 /\ wp [] qcs mods (fun _ _ -> p) s0) (ensures p)
 //val qAssertByLemma (#a:Type) (p:Type0) (qcs:quickCodes a []) (mods:mods_t) (s0:state) : tAssertByLemma p qcs mods s0
 //
-//[@va_qattr]
+//[@@va_qattr]
 //let va_qAssertBy (#a:Type) (#cs:codes) (mods:mods_t) (r:range) (msg:string) (p:Type0) (qcsBy:quickCodes unit []) (s0:state) (qcsTail:quickCodes a cs) : quickCodes a cs =
 //  QLemma r msg (t_require s0 /\ wp [] qcsBy mods (fun _ _ -> p) s0) (fun () -> p) (qAssertByLemma p qcsBy mods s0) qcsTail
 
-[@va_qattr]
+[@@va_qattr]
 let va_qAssertBy (#a:Type) (#cs:codes) (r:range) (msg:string) (p:Type0) (qcsBy:quickCodes unit []) (qcsTail:quickCodes a cs) : quickCodes a cs =
   QAssertBy r msg p qcsBy qcsTail
 
@@ -347,23 +347,23 @@ val wp_sound_code (#a:Type0) (c:code) (qc:quickCode a c) (k:va_state -> a -> Typ
   (requires t_require s0 /\ QProc?.wp qc s0 k)
   (ensures fun (sN, fN, gN) -> eval_code c s0 fN sN /\ update_state_mods qc.mods sN s0 == sN /\ state_inv sN /\ k sN gN)
 
-[@va_qattr]
+[@@va_qattr]
 let rec regs_match_file (r0:Regs.t) (r1:Regs.t) (rf:reg_file_id) (k:nat{k <= n_regs rf}) : Type0 =
   if k = 0 then True
   else
     let r = Reg rf (k - 1) in
     Regs.sel r r0 == Regs.sel r r1 /\ regs_match_file r0 r1 rf (k - 1)
 
-[@va_qattr]
+[@@va_qattr]
 let rec regs_match (r0:Regs.t) (r1:Regs.t) (k:nat{k <= n_reg_files}) : Type0 =
   if k = 0 then True
   else regs_match_file r0 r1 (k - 1) (n_regs (k - 1)) /\ regs_match r0 r1 (k - 1)
 
-[@va_qattr]
+[@@va_qattr]
 let all_regs_match (r0:Regs.t) (r1:Regs.t) : Type0 =
   regs_match r0 r1 n_reg_files
 
-[@va_qattr]
+[@@va_qattr]
 let state_match (s0:va_state) (s1:va_state) : Type0 =
   s0.vs_ok == s1.vs_ok /\
   all_regs_match s0.vs_regs s1.vs_regs /\
@@ -376,7 +376,7 @@ val lemma_state_match (s0:va_state) (s1:va_state) : Lemma
   (requires state_match s0 s1)
   (ensures state_eq s0 s1)
 
-[@va_qattr]
+[@@va_qattr]
 let va_state_match (s0:va_state) (s1:va_state) : Pure Type0
   (requires True)
   (ensures fun b -> b ==> state_eq s0 s1)
@@ -384,7 +384,7 @@ let va_state_match (s0:va_state) (s1:va_state) : Pure Type0
   FStar.Classical.move_requires (lemma_state_match s0) s1;
   state_match s0 s1
 
-[@va_qattr]
+[@@va_qattr]
 unfold let wp_sound_code_pre (#a:Type0) (#c:code) (qc:quickCode a c) (s0:va_state) (k:(s0':va_state{s0 == s0'}) -> va_state -> a -> Type0) : Type0 =
   forall
       (ok:bool)

--- a/vale/code/arch/x64/Vale.X64.QuickCodes.fsti
+++ b/vale/code/arch/x64/Vale.X64.QuickCodes.fsti
@@ -2,6 +2,7 @@ module Vale.X64.QuickCodes
 // Optimized weakest precondition generation for 'quick' procedures
 open FStar.Mul
 open FStar.Range
+open FStar.Ghost { erased }
 open Vale.Def.Prop_s
 open Vale.Arch.HeapImpl
 open Vale.X64.Machine_s
@@ -11,22 +12,25 @@ open Vale.X64.State
 open Vale.X64.Decls
 open Vale.X64.QuickCode
 
+let erange = erased range
+
 unfold let code = va_code
 unfold let codes = va_codes
 unfold let fuel = va_fuel
 unfold let eval = eval_code
 
 [@@va_qattr; "opaque_to_smt"]
-let labeled_wrap (r:range) (msg:string) (p:Type0) : GTot Type0 = labeled r msg p
+noextract
+let labeled_wrap (r:erange) (msg:string) (p:Type0) : GTot Type0 = labeled r msg p
 
 // REVIEW: when used inside a function definition, 'labeled' can show up in an SMT query
 // as an uninterpreted function.  Make a wrapper around labeled that is interpreted:
 [@@va_qattr; "opaque_to_smt"]
-let label (r:range) (msg:string) (p:Type0) : Ghost Type (requires True) (ensures fun q -> q <==> p) =
+let label (r:erange) (msg:string) (p:Type0) : Ghost Type (requires True) (ensures fun q -> q <==> p) =
   assert_norm (labeled_wrap r msg p <==> p);
   labeled_wrap r msg p
 
-val lemma_label_bool (r:range) (msg:string) (b:bool) : Lemma
+val lemma_label_bool (r:erange) (msg:string) (b:bool) : Lemma
   (requires label r msg b)
   (ensures b)
   [SMTPat (label r msg b)]
@@ -51,32 +55,33 @@ let if_code (b:bool) (c1:code) (c2:code) : code = if b then c1 else c2
 
 open FStar.Monotonic.Pure
 
+[@@erasable]
 noeq type quickCodes (a:Type0) : codes -> Type =
 | QEmpty: a -> quickCodes a []
-| QSeq: #b:Type -> #c:code -> #cs:codes -> r:range -> msg:string ->
+| QSeq: #b:Type -> #c:code -> #cs:codes -> r:erange -> msg:string ->
     quickCode b c -> quickCodes a cs -> quickCodes a (c::cs)
-| QBind: #b:Type -> #c:code -> #cs:codes -> r:range -> msg:string ->
+| QBind: #b:Type -> #c:code -> #cs:codes -> r:erange -> msg:string ->
     quickCode b c -> (va_state -> b -> GTot (quickCodes a cs)) -> quickCodes a (c::cs)
 | QGetState: #cs:codes -> (va_state -> GTot (quickCodes a cs)) -> quickCodes a ((Block [])::cs)
-| QPURE: #cs:codes -> r:range -> msg:string -> pre:((unit -> GTot Type0) -> GTot Type0){is_monotonic pre} ->
+| QPURE: #cs:codes -> r:erange -> msg:string -> pre:((unit -> GTot Type0) -> GTot Type0){is_monotonic pre} ->
     (unit -> PURE unit (as_pure_wp pre)) -> quickCodes a cs -> quickCodes a cs
-//| QBindPURE: #cs:codes -> b:Type -> r:range -> msg:string -> pre:((b -> GTot Type0) -> GTot Type0) ->
+//| QBindPURE: #cs:codes -> b:Type -> r:erange -> msg:string -> pre:((b -> GTot Type0) -> GTot Type0) ->
 //    (unit -> PURE b pre) -> (va_state -> b -> GTot (quickCodes a cs)) -> quickCodes a ((Block [])::cs)
-| QLemma: #cs:codes -> r:range -> msg:string -> pre:Type0 -> post:(squash pre -> Type0) ->
+| QLemma: #cs:codes -> r:erange -> msg:string -> pre:Type0 -> post:(squash pre -> Type0) ->
     (unit -> Lemma (requires pre) (ensures post ())) -> quickCodes a cs -> quickCodes a cs
-| QGhost: #cs:codes -> b:Type -> r:range -> msg:string -> pre:Type0 -> post:(b -> Type0) ->
+| QGhost: #cs:codes -> b:Type -> r:erange -> msg:string -> pre:Type0 -> post:(b -> Type0) ->
     (unit -> Ghost b (requires pre) (ensures post)) -> (b -> GTot (quickCodes a cs)) -> quickCodes a ((Block [])::cs)
-| QAssertBy: #cs:codes -> r:range -> msg:string -> p:Type0 ->
+| QAssertBy: #cs:codes -> r:erange -> msg:string -> p:Type0 ->
     quickCodes unit [] -> quickCodes a cs -> quickCodes a cs
 
-[@@va_qattr] unfold let va_QBind (#a:Type0) (#b:Type) (#c:code) (#cs:codes) (r:range) (msg:string) (qc:quickCode b c) (qcs:va_state -> b -> GTot (quickCodes a cs)) : quickCodes a (c::cs) = QBind r msg qc qcs
+[@@va_qattr] unfold let va_QBind (#a:Type0) (#b:Type) (#c:code) (#cs:codes) (r:erange) (msg:string) (qc:quickCode b c) (qcs:va_state -> b -> GTot (quickCodes a cs)) : quickCodes a (c::cs) = QBind r msg qc qcs
 [@@va_qattr] unfold let va_QEmpty (#a:Type0) (v:a) : quickCodes a [] = QEmpty v
-[@@va_qattr] unfold let va_QLemma (#a:Type0) (#cs:codes) (r:range) (msg:string) (pre:Type0) (post:(squash pre -> Type0)) (l:unit -> Lemma (requires pre) (ensures post ())) (qcs:quickCodes a cs) : quickCodes a cs = QLemma r msg pre post l qcs
-[@@va_qattr] unfold let va_QSeq (#a:Type0) (#b:Type) (#c:code) (#cs:codes) (r:range) (msg:string) (qc:quickCode b c) (qcs:quickCodes a cs) : quickCodes a (c::cs) = QSeq r msg qc qcs
+[@@va_qattr] unfold let va_QLemma (#a:Type0) (#cs:codes) (r:erange) (msg:string) (pre:Type0) (post:(squash pre -> Type0)) (l:unit -> Lemma (requires pre) (ensures post ())) (qcs:quickCodes a cs) : quickCodes a cs = QLemma r msg pre post l qcs
+[@@va_qattr] unfold let va_QSeq (#a:Type0) (#b:Type) (#c:code) (#cs:codes) (r:erange) (msg:string) (qc:quickCode b c) (qcs:quickCodes a cs) : quickCodes a (c::cs) = QSeq r msg qc qcs
 
 [@@va_qattr]
 let va_qPURE
-    (#cs:codes) (#pre:((unit -> GTot Type0) -> GTot Type0){is_monotonic pre}) (#a:Type0) (r:range) (msg:string)
+    (#cs:codes) (#pre:((unit -> GTot Type0) -> GTot Type0){is_monotonic pre}) (#a:Type0) (r:erange) (msg:string)
     ($l:unit -> PURE unit (intro_pure_wp_monotonicity pre; pre)) (qcs:quickCodes a cs)
   : quickCodes a cs =
   QPURE r msg pre l qcs
@@ -85,7 +90,7 @@ let va_qPURE
   (need to provide pre explicitly; as a result, no need to put $ on l)
 [@@va_qattr]
 let va_qBindPURE
-    (#a #b:Type0) (#cs:codes) (pre:(b -> GTot Type0) -> GTot Type0) (r:range) (msg:string)
+    (#a #b:Type0) (#cs:codes) (pre:(b -> GTot Type0) -> GTot Type0) (r:erange) (msg:string)
     (l:unit -> PURE b pre) (qcs:va_state -> b -> GTot (quickCodes a cs))
   : quickCodes a ((Block [])::cs) =
   QBindPURE b r msg pre l qcs
@@ -101,7 +106,7 @@ let wp_Bind_t (a:Type0) = va_state -> a -> Type0
 let k_AssertBy (p:Type0) (_:va_state) () = p
 
 [@@va_qattr]
-let va_range1 = mk_range "" 0 0 0 0
+let va_range1 : erange = mk_range "" 0 0 0 0
 
 val empty_list_is_small (#a:Type) (x:list a) : Lemma
   ([] #a == x \/ [] #a << x)
@@ -309,14 +314,14 @@ let tAssertLemma (p:Type0) = unit -> Lemma (requires p) (ensures p)
 val qAssertLemma (p:Type0) : tAssertLemma p
 
 [@@va_qattr]
-let va_qAssert (#a:Type) (#cs:codes) (r:range) (msg:string) (e:Type0) (qcs:quickCodes a cs) : quickCodes a cs =
+let va_qAssert (#a:Type) (#cs:codes) (r:erange) (msg:string) (e:Type0) (qcs:quickCodes a cs) : quickCodes a cs =
   QLemma r msg e (fun () -> e) (qAssertLemma e) qcs
 
 let tAssumeLemma (p:Type0) = unit -> Lemma (requires True) (ensures p)
 val qAssumeLemma (p:Type0) : tAssumeLemma p
 
 [@@va_qattr]
-let va_qAssume (#a:Type) (#cs:codes) (r:range) (msg:string) (e:Type0) (qcs:quickCodes a cs) : quickCodes a cs =
+let va_qAssume (#a:Type) (#cs:codes) (r:erange) (msg:string) (e:Type0) (qcs:quickCodes a cs) : quickCodes a cs =
   QLemma r msg True (fun () -> e) (qAssumeLemma e) qcs
 
 let tAssertSquashLemma (p:Type0) = unit -> Ghost (squash p) (requires p) (ensures fun () -> p)
@@ -324,7 +329,7 @@ val qAssertSquashLemma (p:Type0) : tAssertSquashLemma p
 
 [@@va_qattr]
 let va_qAssertSquash
-    (#a:Type) (#cs:codes) (r:range) (msg:string) (e:Type0) (qcs:squash e -> GTot (quickCodes a cs))
+    (#a:Type) (#cs:codes) (r:erange) (msg:string) (e:Type0) (qcs:squash e -> GTot (quickCodes a cs))
   : quickCodes a ((Block [])::cs) =
   QGhost (squash e) r msg e (fun () -> e) (qAssertSquashLemma e) qcs
 
@@ -333,11 +338,11 @@ let va_qAssertSquash
 //val qAssertByLemma (#a:Type) (p:Type0) (qcs:quickCodes a []) (mods:mods_t) (s0:state) : tAssertByLemma p qcs mods s0
 //
 //[@@va_qattr]
-//let va_qAssertBy (#a:Type) (#cs:codes) (mods:mods_t) (r:range) (msg:string) (p:Type0) (qcsBy:quickCodes unit []) (s0:state) (qcsTail:quickCodes a cs) : quickCodes a cs =
+//let va_qAssertBy (#a:Type) (#cs:codes) (mods:mods_t) (r:erange) (msg:string) (p:Type0) (qcsBy:quickCodes unit []) (s0:state) (qcsTail:quickCodes a cs) : quickCodes a cs =
 //  QLemma r msg (t_require s0 /\ wp [] qcsBy mods (fun _ _ -> p) s0) (fun () -> p) (qAssertByLemma p qcsBy mods s0) qcsTail
 
 [@@va_qattr]
-let va_qAssertBy (#a:Type) (#cs:codes) (r:range) (msg:string) (p:Type0) (qcsBy:quickCodes unit []) (qcsTail:quickCodes a cs) : quickCodes a cs =
+let va_qAssertBy (#a:Type) (#cs:codes) (r:erange) (msg:string) (p:Type0) (qcsBy:quickCodes unit []) (qcsTail:quickCodes a cs) : quickCodes a cs =
   QAssertBy r msg p qcsBy qcsTail
 
 ///// Code
@@ -418,7 +423,7 @@ unfold let wp_sound_code_post (#a:Type0) (#c:code) (qc:quickCode a c) (s0:va_sta
   state_inv sN /\
   k s0 sN gN
 
-unfold let normal_steps : list string =
+unfold let normal_steps : erased (list string) =
   [
     `%Mkvale_state?.vs_ok;
     `%Mkvale_state?.vs_regs;


### PR DESCRIPTION
Ranges are for tagging terms for error reporting, and the fact that they extract (for normal OCaml applications) is arguably shady: their implementation is the internal `FStarC.Compiler.Range.Type.range`, which is included in fstar.lib like the rest of the compiler. This will be gone soon with a new build and leaner fstar.lib, and this would fail.

Regardless of that, it's anyway cleaner to erase these to make the generated OCaml simpler.

I'm not sure what place this has in the rest of the build, but maybe more things here can be erased (the `quickCodes` type?).

There's also no need to merge this yet if there are doubts, I'm working on forks of F*/krml/hacl and can post a PR when they all work together well, with this patch in it.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

*Not exactly sure how to tag this*

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
