### PR TITLE
Makefile: fail early if no 'time'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,9 @@ else ifeq ($(shell uname -s),FreeBSD)
     SED := sed -i ''
     TIME := /usr/bin/time
 else
+  ifeq ($(shell which time),)
+    $(error 'time' not found, try apt-get install time)
+  endif
   SED := sed -i
   TIME := $(shell which time) -q -f '%E'
 endif


### PR DESCRIPTION
While most Unix machines will have it, some Docker containers may not. Failing early is clearer, otherwise we get:

    /usr/bin/bash: line 1: -q: command not found

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
