### PR TITLE
Lib_Memzero0.c: Fix compiler warning on 32-bit Windows

### DIFF
--- a/lib/c/Lib_Memzero0.c
+++ b/lib/c/Lib_Memzero0.c
@@ -36,7 +36,7 @@ void Lib_Memzero0_memzero0(void *dst, uint64_t len) {
   size_t len_ = (size_t) len;
 
   #ifdef _WIN32
-    SecureZeroMemory(dst, len);
+    SecureZeroMemory(dst, len_);
   #elif defined(__APPLE__) && defined(__MACH__)
     memset_s(dst, len_, 0, len_);
   #elif (defined(__linux__) && !defined(LINUX_NO_EXPLICIT_BZERO)) || defined(__FreeBSD__)


### PR DESCRIPTION
## Proposed changes

Fix the warning:

Lib_Memzero0.c(39,27): warning C4244: 'function': conversion from 'uint64_t' to 'SIZE_T', possible loss of data

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)