### PR TITLE
Lib_Memzero0.c: use explicit_bzero on OpenBSD

### DIFF
--- a/lib/c/Lib_Memzero0.c
+++ b/lib/c/Lib_Memzero0.c
@@ -12,7 +12,7 @@
 #include <AvailabilityMacros.h>
 #endif
 
-#if (defined(__APPLE__) && defined(__MACH__)) || defined(__linux__)
+#if (defined(__APPLE__) && defined(__MACH__)) || defined(__linux__) || defined(__OpenBSD__)
 #define __STDC_WANT_LIB_EXT1__ 1
 #include <string.h>
 #endif
@@ -43,7 +43,7 @@ void Lib_Memzero0_memzero0(void *dst, uint64_t len) {
     SecureZeroMemory(dst, len_);
   #elif defined(__APPLE__) && defined(__MACH__) && defined(MAC_OS_X_VERSION_MIN_REQUIRED) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1090)
     memset_s(dst, len_, 0, len_);
-  #elif (defined(__linux__) && !defined(LINUX_NO_EXPLICIT_BZERO)) || defined(__FreeBSD__)
+  #elif (defined(__linux__) && !defined(LINUX_NO_EXPLICIT_BZERO)) || defined(__FreeBSD__) || defined(__OpenBSD__)
     explicit_bzero(dst, len_);
   #elif defined(__NetBSD__)
     explicit_memset(dst, 0, len_);


### PR DESCRIPTION
## Proposed changes

Hi, saw a the `#warning` to port to your platform when building OpenBSD. In this case `explicit_bzero` originated in OpenBSD. So if we assume FreeBSD has it, the same can be done for OpenBSD.

I was this building Python and assume this is the correct place to fix it.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
