### PR TITLE
Fix includes in Nacl test

### DIFF
--- a/tests/naclbox-test.c
+++ b/tests/naclbox-test.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "Hacl_NaCl.h"
+#include "Hacl_Curve25519_51.h"
 
 #include "naclbox_vectors.h"
 #include "test_helpers.h"


### PR DESCRIPTION
CI was failing when compiling the NaCl tests because one of the Curve25519 functions was not found during compilation.
I'm not sure why this just started failing as the corresponding files haven't changed in about 2 years, however, explicitly adding the header inclusion fixes the issue.