### PR TITLE
nix: Use the correct dotnet runtime version in vale

### DIFF
--- a/.nix/vale.nix
+++ b/.nix/vale.nix
@@ -1,9 +1,9 @@
 {
-  dotnetPackages,
   fetchFromGitHub,
   fetchNuGet,
   fsharp,
   mono,
+  dotnet-runtime,
   scons,
   stdenv,
 }: let
@@ -63,7 +63,7 @@
         "runtimeOptions": {
           "framework": {
             "name": "Microsoft.NETCore.App",
-            "version": "6.0.0"
+            "version": "${dotnet-runtime.version}"
           }
         }
       }

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
       };
     in {
       packages = {
-        inherit hacl;
+        inherit hacl vale;
         default = hacl;
       };
     });


### PR DESCRIPTION
## Proposed changes

The `vale` nix file was hardcoding a dotnet version, which broke when using more recent nixpkgs. This fixes that.

## Types of changes

- [x] Build system maintenance

## Checklist

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [x] I have added necessary documentation (if appropriate)
- [x] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
