### PR TITLE
Stabilize some Vale non-linear arithmetic proofs

### DIFF
--- a/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastSqr_helpers.fst
+++ b/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastSqr_helpers.fst
@@ -11,6 +11,8 @@ open Vale.Curve25519.Fast_lemmas_internal
 
 open FStar.Math.Lemmas
 
+#push-options "--z3cliopt smt.arith.nl=false"
+
 let lemma_dbl_pow2_six (z0 z1 z2 z3 z4 z5:nat) :
   Lemma (2*pow2_six z0 z1 z2 z3 z4 z5 == pow2_six (2*z0) (2*z1) (2*z2) (2*z3) (2*z4) (2*z5))
   =
@@ -50,10 +52,21 @@ let lemma_sqr_part3
   (ensures pow2_nine d0 d1 d2 d3 d4 d5 d6 d7 c ==
            pow2_eight (mul_nats a0 a0) r8 ((mul_nats a1 a1) + r9) r10 ((mul_nats a2 a2) + r11) r12 ((mul_nats a3 a3) + r13) r14)
   =
-  ()
+  calc (==) {
+    pow2_nine d0 d1 d2 d3 d4 d5 d6 d7 c;
+    (==) { () }
+    pow2_eight (pow2_64 * a0_sqr_hi + a0_sqr_lo) r8 (pow2_64 * a1_sqr_hi + a1_sqr_lo + r9) r10 (pow2_64 * a2_sqr_hi + a2_sqr_lo + r11) r12 (pow2_64 * a3_sqr_hi + a3_sqr_lo + r13) r14;
+    (==) {
+      assert_norm (mul_nats a0 a0 == a0 * a0);
+      assert_norm (mul_nats a1 a1 == a1 * a1);
+      assert_norm (mul_nats a2 a2 == a2 * a2);
+      assert_norm (mul_nats a3 a3 == a3 * a3)
+    }
+    pow2_eight (mul_nats a0 a0) r8 ((mul_nats a1 a1) + r9) r10 ((mul_nats a2 a2) + r11) r12 ((mul_nats a3 a3) + r13) r14;
+  }
 #pop-options
 
-#reset-options "--z3rlimit 100 --max_fuel 0 --max_ifuel 0 --using_facts_from 'FastSqr_helpers FStar.Pervasives Prims Vale.Def.Words_s Vale.Curve25519.Fast_defs'"
+#push-options "--z3rlimit 100 --max_fuel 0 --max_ifuel 0 --using_facts_from 'FastSqr_helpers FStar.Pervasives Prims Vale.Def.Words_s Vale.Curve25519.Fast_defs'"
 let lemma_sqr (a:int) (a0 a1 a2 a3
                r8 r9 r10 r11 r12 r13 rax rcx
                r8' r9' r10' r11' r12' r13' r14'
@@ -161,3 +174,7 @@ let lemma_sqr (a:int) (a0 a1 a2 a3
 }
 *)
   ()
+
+#pop-options
+
+#pop-options

--- a/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastSqr_helpers.fst
+++ b/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastSqr_helpers.fst
@@ -19,7 +19,7 @@ let lemma_dbl_pow2_six (z0 z1 z2 z3 z4 z5:nat) :
   ()
 
 
-#push-options "--z3rlimit 3000 --max_fuel 0 --max_ifuel 0"
+#push-options "--z3rlimit 300 --fuel 0 --ifuel 0"
 let lemma_sqr_part3
       (a:nat) (a0 a1 a2 a3:nat64)
       (a0_sqr_hi a0_sqr_lo
@@ -66,7 +66,9 @@ let lemma_sqr_part3
   }
 #pop-options
 
-#push-options "--z3rlimit 100 --max_fuel 0 --max_ifuel 0 --using_facts_from 'FastSqr_helpers FStar.Pervasives Prims Vale.Def.Words_s Vale.Curve25519.Fast_defs'"
+let aux (a b: nat) : Lemma (requires a == b) (ensures a * a == b * b) = ()
+
+#push-options "--z3rlimit 100 --fuel 0 --ifuel 0"
 let lemma_sqr (a:int) (a0 a1 a2 a3
                r8 r9 r10 r11 r12 r13 rax rcx
                r8' r9' r10' r11' r12' r13' r14'
@@ -87,93 +89,62 @@ let lemma_sqr (a:int) (a0 a1 a2 a3
             pow2_eight (mul_nats a0 a0) r8' ((mul_nats a1 a1) + r9') r10' ((mul_nats a2 a2) + r11') r12' ((mul_nats a3 a3) + r13') r14')
   (ensures  a*a == pow2_eight d0 d1 d2 d3 d4 d5 d6 d7)
   =
-  (); // work around Heisenbug
   assert (a < pow2_256); // PASSES
   assert_norm (pow2_256 == pow2 256); // PASSES
   pow2_plus 256 256;
   lemma_mul_pow2_bound 256 a a;
-  assert (a*a < pow2_256 * pow2_256); // PASSES
+  aux pow2_256 (pow2 256);
+  assert (a * a < pow2_256 * pow2_256); // PASSES
+
+
+
   assert (cf = 1 ==> pow2_nine d0 d1 d2 d3 d4 d5 d6 d7 cf >= pow2_512);
 
-  // Fails here, but succeeds in Vale!?
-  //assert_by_tactic (a*a == pow2_seven (mul_nats a0 a0) (2*(mul_nats a0 a1)) (2*(mul_nats a0 a2) + (mul_nats a1 a1))
-  //                                    (2*((mul_nats a0 a3) + (mul_nats a1 a2))) (2*(mul_nats a1 a3) + (mul_nats a2 a2)) (2*(mul_nats a2 a3)) (mul_nats a3 a3)) int_canon;
-  let lhs:int = pow2_eight (mul_nats a0 a0) r8' ((mul_nats a1 a1) + r9') r10' ((mul_nats a2 a2) + r11') r12' ((mul_nats a3 a3) + r13') r14' in
-  let squares = pow2_eight (mul_nats a0 a0) 0 (mul_nats a1 a1) 0 (mul_nats a2 a2) 0 (mul_nats a3 a3) 0 in
-  let regs = pow2_eight 0 r8' r9' r10' r11' r12' r13' r14' in
-  let rhs:int = squares + regs in
-  assert_by_tactic (lhs == rhs) int_canon; // PASSES
+  let squares = pow2_seven (mul_nats a0 a0) 0 (mul_nats a1 a1) 0 (mul_nats a2 a2) 0 (mul_nats a3 a3) in
+  let lhs_rem = pow2_seven 0 (2 * (mul_nats a0 a1)) (2 * (mul_nats a0 a2)) (2 * (mul_nats a0 a3 + mul_nats a1 a2)) (2 * (mul_nats a1 a3)) (2* (mul_nats a2 a3)) 0 in
 
-  assert_by_tactic (regs == pow2_64 * pow2_seven r8' r9' r10' r11' r12' r13' r14') int_canon;  // PASSES
-  assert (pow2_64 * pow2_seven r8' r9' r10' r11' r12' r13' r14' == pow2_64 * pow2_six (2*r8) (2*r9) (2*(r10+rax)) (2*(r11+rcx)) (2*r12) (2*r13));  // PASSES
-  assert_by_tactic (pow2_64 * pow2_six (2*r8) (2*r9) (2*(r10+rax)) (2*(r11+rcx)) (2*r12) (2*r13) == pow2_seven 0 (2*r8) (2*r9) (2*(r10+rax)) (2*(r11+rcx)) (2*r12) (2*r13)) int_canon; // PASSES
-  lemma_dbl_pow2_six r8 r9 (r10+rax) (r11+rcx) r12 r13;
-  assert (pow2_six (2*r8) (2*r9) (2*(r10+rax)) (2*(r11+rcx)) (2*r12) (2*r13) == 2 * pow2_six r8 r9 (r10+rax) (r11+rcx) r12 r13);  // PASSES
-  assert_by_tactic (pow2_six r8 r9 (r10+rax) (r11+rcx) r12 r13 == pow2_six r8 r9 r10 r11 r12 r13 + pow2_six 0 0 rax rcx 0 0) int_canon;  // PASSES
-  let larger:int = pow2_six  (mul_nats a0 a1) (mul_nats a0 a2) (mul_nats a0 a3) (mul_nats a1 a3) (mul_nats a2 a3) 0 in
-  assert_by_tactic (pow2_five (mul_nats a0 a1) (mul_nats a0 a2) (mul_nats a0 a3) (mul_nats a1 a3) (mul_nats a2 a3) == larger) int_canon;  // PASSES
-  let a1a2_six:int = pow2_six 0 0 (a1 * a2) 0 0 0 in
-  assert_by_tactic (pow2_six 0 0 rax rcx 0 0 == a1a2_six) int_canon; // PASSES
-  lemma_dbl_pow2_six (mul_nats a0 a1) (mul_nats a0 a2) (mul_nats a0 a3 + a1*a2) (mul_nats a1 a3) (mul_nats a2 a3) 0;
-  assert_by_tactic (pow2_64 * pow2_six (2*(mul_nats a0 a1)) (2*(mul_nats a0 a2)) (2*(mul_nats a0 a3 + a1*a2)) (2*(mul_nats a1 a3)) (2*(mul_nats a2 a3)) 0 ==
-                    pow2_seven 0 (2*(mul_nats a0 a1)) (2*(mul_nats a0 a2)) (2*(mul_nats a0 a3 + a1*a2)) (2*(mul_nats a1 a3)) (2*(mul_nats a2 a3)) 0) int_canon;  // PASSES
+  let rhs_rem = pow2_eight 0 r8' r9' r10' r11' r12' r13' r14' in
 
-  // The following unrolling is apparently needed
-  assert_by_tactic ( (36893488147419103232 * (a0 * a1) +
-    (680564733841876926926749214863536422912 * (a0 * a2) +
-    (12554203470773361527671578846415332832204710888928069025792 * (a0 * a3) +
-    (12554203470773361527671578846415332832204710888928069025792 * (a1 * a2) +
-    (231584178474632390847141970017375815706539969331281128078915168015826259279872 * (a1 * a3) +
-    (4271974071841820164790043412339104229205409044713305539894083215644439451561281100045924173873152 *
-    (a2 * a3)
-    )))))) == pow2_64 * pow2_six (2*(mul_nats a0 a1)) (2*(mul_nats a0 a2)) (2*(mul_nats a0 a3 + a1*a2)) (2*(mul_nats a1 a3)) (2*(mul_nats a2 a3)) 0) int_canon;
+  calc (==) {
+    lhs_rem;
+    (==) { assert_by_tactic (pow2_seven 0 (2 * (mul_nats a0 a1)) (2 * (mul_nats a0 a2)) (2 * (mul_nats a0 a3 + mul_nats a1 a2)) (2 * (mul_nats a1 a3)) (2* (mul_nats a2 a3)) 0 == (2 * pow2_64) * pow2_five (mul_nats a0 a1) (mul_nats a0 a2) (mul_nats a0 a3) (mul_nats a1 a3) (mul_nats a2 a3) + (2 * pow2_192 * mul_nats a1 a2)) int_canon }
+    (2 * pow2_64) * pow2_five (mul_nats a0 a1) (mul_nats a0 a2) (mul_nats a0 a3) (mul_nats a1 a3) (mul_nats a2 a3) + (2 * pow2_192 * mul_nats a1 a2);
+    (==) { }
+    (2 * pow2_64) * pow2_six r8 r9 r10 r11 r12 r13 + (2 * pow2_192 * mul_nats a1 a2);
+    (==) { assert_norm (mul_nats a1 a2 == a1 * a2) }
+    (2 * pow2_64) * pow2_six r8 r9 r10 r11 r12 r13 + (2 * pow2_192 * (pow2_64 * rcx + rax));
+    (==) { assert_by_tactic (
+      (2 * pow2_64) * pow2_six r8 r9 r10 r11 r12 r13 + (2 * pow2_192 * (pow2_64 * rcx + rax))
+        ==
+      pow2_64 * pow2_six (2*r8) (2*r9) (2*(r10+rax)) (2*(r11+rcx)) (2*r12) (2*r13)
+    ) int_canon }
+    pow2_64 * pow2_six (2*r8) (2*r9) (2*(r10+rax)) (2*(r11+rcx)) (2*r12) (2*r13);
+    (==) { }
+    pow2_64 * pow2_seven r8' r9' r10' r11' r12' r13' r14';
+    (==) { assert_by_tactic (
+         pow2_64 * pow2_seven r8' r9' r10' r11' r12' r13' r14' ==
+         pow2_eight 0 r8' r9' r10' r11' r12' r13' r14'
+      ) int_canon }
+    rhs_rem;
+  };
 
-  assert_by_tactic (rhs == pow2_eight (mul_nats a0 a0) (2*(mul_nats a0 a1)) ((2*(mul_nats a0 a2)) + mul_nats a1 a1) (2*(mul_nats a0 a3 + a1*a2)) ((2*(mul_nats a1 a3)) + mul_nats a2 a2) (2*(mul_nats a2 a3)) (mul_nats a3 a3) 0) int_canon;  // PASSES
-  let final_rhs:int = pow2_seven (mul_nats a0 a0) (2*(mul_nats a0 a1)) ((2*(mul_nats a0 a2)) + mul_nats a1 a1) (2*(mul_nats a0 a3 + a1*a2)) ((2*(mul_nats a1 a3)) + mul_nats a2 a2) (2*(mul_nats a2 a3)) (mul_nats a3 a3) in
-  assert_by_tactic (pow2_eight (mul_nats a0 a0) (2*(mul_nats a0 a1)) ((2*(mul_nats a0 a2)) + mul_nats a1 a1) (2*(mul_nats a0 a3 + a1*a2)) ((2*(mul_nats a1 a3)) + mul_nats a2 a2) (2*(mul_nats a2 a3)) (mul_nats a3 a3) 0 ==
-                    final_rhs) int_canon;   // PASSES
-  assert (pow2_nine d0 d1 d2 d3 d4 d5 d6 d7 cf == a*a);  // PASSES
+  calc (==) {
+    a * a;
+    (==) { }
+    pow2_seven (mul_nats a0 a0) (2*(mul_nats a0 a1)) (2*(mul_nats a0 a2) + (mul_nats a1 a1))
+                         (2*((mul_nats a0 a3) + (mul_nats a1 a2))) (2*(mul_nats a1 a3) + (mul_nats a2 a2)) (2*(mul_nats a2 a3)) (mul_nats a3 a3);
+    (==) { assert_by_tactic (pow2_seven (mul_nats a0 a0) (2*(mul_nats a0 a1)) (2*(mul_nats a0 a2) + (mul_nats a1 a1))
+                         (2*((mul_nats a0 a3) + (mul_nats a1 a2))) (2*(mul_nats a1 a3) + (mul_nats a2 a2)) (2*(mul_nats a2 a3)) (mul_nats a3 a3) == squares + lhs_rem) int_canon }
+    squares + lhs_rem;
+    (==) { }
+    squares + rhs_rem;
+    (==) { assert_by_tactic (squares + rhs_rem ==  pow2_eight (mul_nats a0 a0) r8' ((mul_nats a1 a1) + r9') r10' ((mul_nats a2 a2) + r11') r12' ((mul_nats a3 a3) + r13') r14') int_canon }
+ pow2_eight (mul_nats a0 a0) r8' ((mul_nats a1 a1) + r9') r10' ((mul_nats a2 a2) + r11') r12' ((mul_nats a3 a3) + r13') r14';
+  };
+
   assert (cf == 0);
   let ultimate_rhs:int = pow2_eight d0 d1 d2 d3 d4 d5 d6 d7 in
-  assert_by_tactic (pow2_nine d0 d1 d2 d3 d4 d5 d6 d7 cf == ultimate_rhs) int_canon;
-(*
-  calc {
-    pow2_nine d0 d1 d2 d3 d4 d5 d6 d7 cf
-
-    pow2_eight (mul_nats a0 a0) r8' ((mul_nats a1 a1) + r9') r10' ((mul_nats a2 a2) + r11') r12' ((mul_nats a3 a3) + r13') r14')
-
-    pow2_eight (mul_nats a0 a0) 0 (mul_nats a1 a1) 0 (mul_nats a2 a2) 0 (mul_nats a3 a3) 0 +
-    pow2_eight 0 r8' r9' r10' r11' r12' r13' r14'
-
-        calc {
-            pow2_eight 0 r8' r9' r10' r11' r12' r13' r14'
-            pow2_64 * pow2_six (2*r8) (2*r9) (2*(r10+rax)) (2*(r11+rcx)) (2*r12) (2*r13)
-            calc {
-                pow2_six (2*r8) (2*r9) (2*(r10+rax)) (2*(r11+rcx)) (2*r12) (2*r13)
-                2 * pow2_six r8 r9 (r10+rax) (r11+rcx) r12 r13)
-                calc {
-                    pow2_six r8 r9 (r10+rax) (r11+rcx) r12 r13)
-                    pow2_six r8 r9 r10 r11 r12 r13
-                        + pow2_six 0 0 rax rcx 0 0
-                    pow2_six (mul_nats a0 a1) (mul_nats a0 a2) (mul_nats a0 a3) (mul_nats a1 a3) (mul_nats a2 a3) 0
-                        + pow2_six 0 0 rax rcx 0 0
-                    pow2_six (mul_nats a0 a1) (mul_nats a0 a2) (mul_nats a0 a3) (mul_nats a1 a3) (mul_nats a2 a3) 0
-                        + pow2_six 0 0 (a1*a2) 0 0 0
-                    pow2_six (mul_nats a0 a1) (mul_nats a0 a2) (mul_nats a0 a3 + a1*a2) (mul_nats a1 a3) (mul_nats a2 a3) 0
-                }
-                2*pow2_six (mul_nats a0 a1) (mul_nats a0 a2) (mul_nats a0 a3 + a1*a2) (mul_nats a1 a3) (mul_nats a2 a3) 0
-                pow2_six (2*(mul_nats a0 a1)) (2*(mul_nats a0 a2)) (2*(mul_nats a0 a3 + a1*a2)) (2*(mul_nats a1 a3)) (2*(mul_nats a2 a3)) 0
-            }
-            pow2_64 * pow2_six (2*(mul_nats a0 a1)) (2*(mul_nats a0 a2)) (2*(mul_nats a0 a3 + a1*a2)) (2*(mul_nats a1 a3)) (2*(mul_nats a2 a3)) 0
-
-            pow2_seven 0 (2*(mul_nats a0 a1)) (2*(mul_nats a0 a2)) (2*(mul_nats a0 a3 + a1*a2)) (2*(mul_nats a1 a3)) (2*(mul_nats a2 a3)) 0
-        }
-    pow2_eight (mul_nats a0 a0) (2*(mul_nats a0 a1)) ((2*(mul_nats a0 a2)) + mul_nats a1 a1) (2*(mul_nats a0 a3 + a1*a2)) ((2*(mul_nats a1 a3)) + mul_nats a2 a2) (2*(mul_nats a2 a3)) (mul_nats a3 a3) 0
-
-    pow2_seven (mul_nats a0 a0) (2*(mul_nats a0 a1)) ((2*(mul_nats a0 a2)) + mul_nats a1 a1) (2*(mul_nats a0 a3 + a1*a2)) ((2*(mul_nats a1 a3)) + mul_nats a2 a2) (2*(mul_nats a2 a3)) (mul_nats a3 a3)
-}
-*)
-  ()
+  assert_by_tactic (pow2_nine d0 d1 d2 d3 d4 d5 d6 d7 cf == ultimate_rhs) int_canon
 
 #pop-options
 

--- a/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastSqr_helpers.fst
+++ b/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastSqr_helpers.fst
@@ -19,7 +19,7 @@ let lemma_dbl_pow2_six (z0 z1 z2 z3 z4 z5:nat) :
   ()
 
 
-#push-options "--z3rlimit 300 --fuel 0 --ifuel 0"
+#push-options "--z3rlimit 3000 --fuel 0 --ifuel 0"
 let lemma_sqr_part3
       (a:nat) (a0 a1 a2 a3:nat64)
       (a0_sqr_hi a0_sqr_lo


### PR DESCRIPTION
As described, disable non-linear arithmetic for unstable proofs in FastSqr_helpers, and flesh out proofs more.

Hopefully a step towards #1014 