### PR TITLE
Expand availability checks to cover all Apple platforms.

### DIFF
--- a/lib/c/Lib_Memzero0.c
+++ b/lib/c/Lib_Memzero0.c
@@ -10,6 +10,20 @@
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <AvailabilityMacros.h>
+// memset_s is available from macOS 10.9, iOS 7, watchOS 2, and on all tvOS and visionOS versions.
+#  if (defined(MAC_OS_X_VERSION_MIN_REQUIRED) && (MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9))
+#    define APPLE_HAS_MEMSET_S 1
+#  elif (defined(IPHONE_OS_VERSION_MIN_REQUIRED) && (IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0))
+#    define APPLE_HAS_MEMSET_S 1
+#  elif (defined(TARGET_OS_TV) && TARGET_OS_TV)
+#    define APPLE_HAS_MEMSET_S 1
+#  elif (defined(WATCH_OS_VERSION_MIN_REQUIRED) && (WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_2_0))
+#    define APPLE_HAS_MEMSET_S 1
+#  elif (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#    define APPLE_HAS_MEMSET_S 1
+#  else
+#    define APPLE_HAS_MEMSET_S 0
+#  endif
 #endif
 
 #if (defined(__APPLE__) && defined(__MACH__)) || defined(__linux__) || defined(__OpenBSD__)
@@ -41,7 +55,7 @@ void Lib_Memzero0_memzero0(void *dst, uint64_t len) {
 
   #ifdef _WIN32
     SecureZeroMemory(dst, len_);
-  #elif defined(__APPLE__) && defined(__MACH__) && defined(MAC_OS_X_VERSION_MIN_REQUIRED) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1090)
+  #elif defined(__APPLE__) && defined(__MACH__) && APPLE_HAS_MEMSET_S
     memset_s(dst, len_, 0, len_);
   #elif (defined(__linux__) && !defined(LINUX_NO_EXPLICIT_BZERO)) || defined(__FreeBSD__) || defined(__OpenBSD__)
     explicit_bzero(dst, len_);
@@ -52,7 +66,7 @@ void Lib_Memzero0_memzero0(void *dst, uint64_t len) {
     #warning "Your platform does not support any safe implementation of memzero -- consider a pull request!"
     volatile unsigned char *volatile dst_ = (volatile unsigned char *volatile) dst;
     size_t i = 0U;
-    while (i < len)
+    while (i < len_)
       dst_[i++] = 0U;
   #endif
 }


### PR DESCRIPTION
## Proposed changes

I'm a member of the CPython core team, responsible for maintaining (amongst other things) iOS builds. Python recently adopted the use of HACL*; however, compiling HACL* on iOS is now raising the compile time warnings:
```
../../Modules/_hacl/Lib_Memzero0.c:52:6: warning: "Your platform does not support any safe implementation of memzero -- consider a pull request!" [-W#warnings]
     #warning "Your platform does not support any safe implementation of memzero -- consider a pull request!"
../../Modules/_hacl/Lib_Memzero0.c:40:10: warning: unused variable 'len_' [-Wunused-variable]
```

`memset_s` is available on iOS (and other Apple platforms); this PR fills the platform identification gap, and resolves the unused variable warning for all other platforms.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [x] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)

## Further comments

`memset_s` is available on:
* macOS 10.9+
* iOS 7.0+
* All tvOS versions
* watchOS 2.0+
* All visionOS versions

This availability has been verified empirically using a small test program `example.c`:
```
#include <stdio.h>

void myfunc(void *dst, size_t len) {
    memset_s(dst, len, 0, len);
}
```
compiled as follows:
* macOS: `xcrun --sdk macosx clang -c -o example.o example.c -Wunguarded-availability -mmacosx-version-min=10.9`
* iOS: `xcrun --sdk iphoneos clang -c -o example.o example.c -Wunguarded-availability -miphoneos-version-min=7.0`
* tvOS: `xcrun --sdk appletvos clang -c -o example.o example.c -Wunguarded-availability -mtvos-version-min=1.0`
* watchOS: `xcrun --sdk watchos clang -c -o example.o example.c -Wunguarded-availability -mwatchos-version-min=2.0`
* visionOS: `xcrun --sdk xros clang -target arm64-apple-xros1.0 -c -o example.o example.c -Wunguarded-availability`

These builds will raise compilation warnings if the version minimums are reduced for macOS, iPhoneOS or watchOS.

Note that visionOS (referred to internally as xrOS) doesn't have a specific flag for minimum version compatibility; it relies on the version number in the target triple.
