### PR TITLE
Correct the iOS and watchOS preprocessor symbols.

### DIFF
--- a/dist/gcc-compatible/Lib_Memzero0.c
+++ b/dist/gcc-compatible/Lib_Memzero0.c
@@ -13,11 +13,11 @@
 // memset_s is available from macOS 10.9, iOS 7, watchOS 2, and on all tvOS and visionOS versions.
 #  if (defined(MAC_OS_X_VERSION_MIN_REQUIRED) && (MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9))
 #    define APPLE_HAS_MEMSET_S 1
-#  elif (defined(IPHONE_OS_VERSION_MIN_REQUIRED) && (IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0))
+#  elif (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0))
 #    define APPLE_HAS_MEMSET_S 1
 #  elif (defined(TARGET_OS_TV) && TARGET_OS_TV)
 #    define APPLE_HAS_MEMSET_S 1
-#  elif (defined(WATCH_OS_VERSION_MIN_REQUIRED) && (WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_2_0))
+#  elif (defined(__WATCH_OS_VERSION_MIN_REQUIRED) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_2_0))
 #    define APPLE_HAS_MEMSET_S 1
 #  elif (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 #    define APPLE_HAS_MEMSET_S 1

--- a/dist/msvc-compatible/Lib_Memzero0.c
+++ b/dist/msvc-compatible/Lib_Memzero0.c
@@ -13,11 +13,11 @@
 // memset_s is available from macOS 10.9, iOS 7, watchOS 2, and on all tvOS and visionOS versions.
 #  if (defined(MAC_OS_X_VERSION_MIN_REQUIRED) && (MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9))
 #    define APPLE_HAS_MEMSET_S 1
-#  elif (defined(IPHONE_OS_VERSION_MIN_REQUIRED) && (IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0))
+#  elif (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0))
 #    define APPLE_HAS_MEMSET_S 1
 #  elif (defined(TARGET_OS_TV) && TARGET_OS_TV)
 #    define APPLE_HAS_MEMSET_S 1
-#  elif (defined(WATCH_OS_VERSION_MIN_REQUIRED) && (WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_2_0))
+#  elif (defined(__WATCH_OS_VERSION_MIN_REQUIRED) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_2_0))
 #    define APPLE_HAS_MEMSET_S 1
 #  elif (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 #    define APPLE_HAS_MEMSET_S 1

--- a/dist/portable-gcc-compatible/Lib_Memzero0.c
+++ b/dist/portable-gcc-compatible/Lib_Memzero0.c
@@ -13,11 +13,11 @@
 // memset_s is available from macOS 10.9, iOS 7, watchOS 2, and on all tvOS and visionOS versions.
 #  if (defined(MAC_OS_X_VERSION_MIN_REQUIRED) && (MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9))
 #    define APPLE_HAS_MEMSET_S 1
-#  elif (defined(IPHONE_OS_VERSION_MIN_REQUIRED) && (IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0))
+#  elif (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0))
 #    define APPLE_HAS_MEMSET_S 1
 #  elif (defined(TARGET_OS_TV) && TARGET_OS_TV)
 #    define APPLE_HAS_MEMSET_S 1
-#  elif (defined(WATCH_OS_VERSION_MIN_REQUIRED) && (WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_2_0))
+#  elif (defined(__WATCH_OS_VERSION_MIN_REQUIRED) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_2_0))
 #    define APPLE_HAS_MEMSET_S 1
 #  elif (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 #    define APPLE_HAS_MEMSET_S 1

--- a/lib/c/Lib_Memzero0.c
+++ b/lib/c/Lib_Memzero0.c
@@ -13,11 +13,11 @@
 // memset_s is available from macOS 10.9, iOS 7, watchOS 2, and on all tvOS and visionOS versions.
 #  if (defined(MAC_OS_X_VERSION_MIN_REQUIRED) && (MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9))
 #    define APPLE_HAS_MEMSET_S 1
-#  elif (defined(IPHONE_OS_VERSION_MIN_REQUIRED) && (IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0))
+#  elif (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0))
 #    define APPLE_HAS_MEMSET_S 1
 #  elif (defined(TARGET_OS_TV) && TARGET_OS_TV)
 #    define APPLE_HAS_MEMSET_S 1
-#  elif (defined(WATCH_OS_VERSION_MIN_REQUIRED) && (WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_2_0))
+#  elif (defined(__WATCH_OS_VERSION_MIN_REQUIRED) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_2_0))
 #    define APPLE_HAS_MEMSET_S 1
 #  elif (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 #    define APPLE_HAS_MEMSET_S 1


### PR DESCRIPTION
## Proposed changes

Now I have egg on my face...

The fixes from #1036 and #1038 use the wrong symbols for iOS and watchOS 🤦 

Although macOS has both `MAC_OS_X_...` and `__MAC_OS_X_...` variants for preprocessor version availability symbols, iOS and watchOS only has the `__IPHONE_OS_...` and `__WATCH_OS_...` variants. Somewhere between my local testing and my PR, I dropped the prefix `__`. This doesn't *break* anything... but it doesn't *do* anything either, as the symbols aren't defined.

Apologies for the churn.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [x] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)

## Further comments

I've included the dist copies in this PR to expedite the update.

/cc @msprotz 