### PR TITLE
nix: Ensure the correct bash gets used in shebangs

### DIFF
--- a/.nix/hacl.nix
+++ b/.nix/hacl.nix
@@ -84,6 +84,7 @@
 
     nativeBuildInputs =
       [
+        bash
         z3
         fstar
         python3


### PR DESCRIPTION
This makes sure the `patchShebang` invocations use the expected version of `bash`, which is then turned back to `use/bin/env bash` shebangs at the end of the script. It could be that we don't even need to patch shebangs at all but I can't test because building hacl-star takes too long on my machine.

This should fix the "regenerate hints and dist" CI workflow.