### PR TITLE
Explicitly use Z3 4.8.5

### DIFF
--- a/Hacl.fst.config.json
+++ b/Hacl.fst.config.json
@@ -10,7 +10,7 @@
     "--warn_error", "@240+241@247-272-274@319@328@331@332@337",
     "--trivial_pre_for_unannotated_effectful_fns", "false",
     "--hint_dir", "hints",
-    "--ext", "context_pruning"
+    "--z3version", "4.8.5"
   ],
   "include_dirs": [
     "lib",

--- a/Makefile.common
+++ b/Makefile.common
@@ -130,7 +130,7 @@ FSTAR_NO_FLAGS = $(FSTAR_EXE) $(FSTAR_HINTS) \
   --already_cached 'Prims FStar LowStar C Spec.Loops TestLib WasmSupport' \
   --warn_error '@240+241@247-272-274@319@328@331@332@337' \
   --cache_dir $(OUTPUT_DIR) --trivial_pre_for_unannotated_effectful_fns false \
-  --ext context_pruning
+  --z3version 4.8.5
 
 FSTAR = $(FSTAR_NO_FLAGS) $(OTHERFLAGS)
 

--- a/vale/Hacl.Vale.fst.config.json
+++ b/vale/Hacl.Vale.fst.config.json
@@ -18,7 +18,8 @@
     "--smtencoding.elim_box", "true",
     "--smtencoding.l_arith_repr", "native",
     "--smtencoding.nl_arith_repr", "wrapped",
-    "--hint_dir", "../hints"
+    "--hint_dir", "../hints",
+    "--z3version", "4.8.5"
   ],
   "include_dirs": [
     "../lib",


### PR DESCRIPTION
F* defaults to using Z3 4.8.5 but we may upgrade this soon to 4.13.3. Most projects have migrated to this version already. HACL* still has some proofs that we could not upgrade, so, for the time being, pass a flag to make F* use Z3 4.8.5.

We plan to keep supporting using F* with 4.8.5, but we'd like the default version to be newer.

Also, remove `--ext context_pruning` as it is now the default (it can be disabled with `--ext context_pruning=0`).

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
