### PR TITLE
Poly1305.Bitvectors: remove a flaky, unused lemma

### DIFF
--- a/vale/code/crypto/poly1305/x64/Vale.Poly1305.Bitvectors.fst
+++ b/vale/code/crypto/poly1305/x64/Vale.Poly1305.Bitvectors.fst
@@ -109,23 +109,6 @@ let lemma_bv128_64_64_and x x0 x1 y y0 y1 z z0 z1 =
           rewrite_eqs_from_context ();
           norm [delta])
 
-#push-options "--smtencoding.elim_box true --z3refresh --z3rlimit 20 --max_ifuel 2 --max_fuel 2"
-let int2bv_uext_64_128 (x1 : nat) :
-  Lemma  (requires (FStar.UInt.size x1 64))
-         (ensures (bv_uext #64 #64 (int2bv #64 x1) == int2bv #128 x1)) =
-   assert (64 <= 128);
-   pow2_le_compat 128 64;
-   assert (x1 < pow2 128);
-   modulo_lemma x1 (pow2 128); // x1 % pow2 128 = x1
-   assert (FStar.UInt.size x1 128);
-   let lhs = bv_uext #64 #64 (int2bv #64 x1) in
-   let rhs = int2bv #128 x1 in
-   assert (bv2list #128 lhs == bv2list #128 rhs);
-   bv2list_bij #128 lhs;
-   bv2list_bij #128 rhs;
-   assert (bv_uext #64 #64 (int2bv #64 x1) == int2bv #128 x1)
-#pop-options
-
 let lowerUpper128m (l:uint_t 64) (u:uint_t 64) : uint_t 128 =
   add_hide #128 (mul_hide #128 (uext #64 #64 u) 0x10000000000000000) (uext #64 #64 l)
 


### PR DESCRIPTION
Bitvectors are primitive in F*, and this proof can only work via Z3 figuring it out. There is no point in a big proof, unless we expand FStar.BV to expose more facts about bitvectors. That said, Z3 4.8.5 could not figure it out, so this proof was spelled out (though I'm not sure how it did so, except by randomizing the solver--- there is AFAICT no lemma about `bv2list` that could help).

Howver, Z3 4.13.3 works pretty reliably. This snippet made the lemma pass reliably in this file.

	#push-options "--split_queries always"
	let int2bv_uext_64_128 (x : nat) :
	  Lemma  (requires FStar.UInt.size x 64)
		 (ensures  bv_uext #64 #64 (int2bv #64 x) == int2bv #128 x)
	=
	  assert (bv_uext #64 #64 (int2bv #64 x) == int2bv #128 x);
	  ()
	#pop-options

And also works in plain F* (I am adding a test for it FStarLang/FStar#3905).

(Do note however that the assert seems to help... but it does not make a difference in a clean F* module. I am investigating why separately.)

However, this lemma is unused and does not have an SMT pattern, so this patch just removes it. We could expose it from the F* library if needed, perhaps with the sizes being arguments.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [x] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
