### PR TITLE
Nit: calc steps do not need parentheses

### DIFF
--- a/code/bignum/Hacl.Spec.AlmostMontgomery.Lemmas.fst
+++ b/code/bignum/Hacl.Spec.AlmostMontgomery.Lemmas.fst
@@ -101,11 +101,11 @@ let almost_mont_mul_is_mont_mul_lemma pbits rLen n mu a b =
   let c1 = M.mont_mul pbits rLen n mu (a % n) (b % n) in
   calc (==) {
     c1;
-    (==) { M.mont_mul_lemma pbits rLen n mu (a % n) (b % n) }
+    == { M.mont_mul_lemma pbits rLen n mu (a % n) (b % n) }
     (a % n) * (b % n) * d % n;
-    (==) { M.lemma_mod_mul_distr3 (a % n) b d n }
+    == { M.lemma_mod_mul_distr3 (a % n) b d n }
     (a % n) * b * d % n;
-    (==) {
+    == {
       Math.Lemmas.paren_mul_right (a % n) b d;
       Math.Lemmas.lemma_mod_mul_distr_l a (b * d) n;
       Math.Lemmas.paren_mul_right a b d }

--- a/code/bignum/Hacl.Spec.Bignum.Addition.fst
+++ b/code/bignum/Hacl.Spec.Bignum.Addition.fst
@@ -92,17 +92,17 @@ let bn_add_carry_lemma_loop_step #t #aLen a c_in i (c1, res1) =
 
   calc (==) {
     v c * pow2 (pbits * i) + bn_v #t #i res;
-    (==) { bn_eval_snoc #t #(i - 1) res1 e }
+    == { bn_eval_snoc #t #(i - 1) res1 e }
     v c * pow2 (pbits * i) + bn_v #t #(i - 1) res1 + v e * pow2 (pbits * (i - 1));
-    (==) { }
+    == { }
     v c * pow2 (pbits * i) + eval_ aLen a (i - 1) + v c_in - (v e + v c * pow2 pbits - v a.[i - 1]) * pow2 (pbits * (i - 1)) + v e * pow2 (pbits * (i - 1));
-    (==) { Math.Lemmas.distributivity_sub_left (v e) (v e + v c * pow2 pbits - v a.[i - 1]) (pow2 (pbits * (i - 1))) }
+    == { Math.Lemmas.distributivity_sub_left (v e) (v e + v c * pow2 pbits - v a.[i - 1]) (pow2 (pbits * (i - 1))) }
     v c * pow2 (pbits * i) + eval_ aLen a (i - 1) + v c_in + (v e - v e - v c * pow2 pbits + v a.[i - 1]) * pow2 (pbits * (i - 1));
-    (==) { Math.Lemmas.distributivity_sub_left (v a.[i - 1]) (v c * pow2 pbits) (pow2 (pbits * (i - 1))) }
+    == { Math.Lemmas.distributivity_sub_left (v a.[i - 1]) (v c * pow2 pbits) (pow2 (pbits * (i - 1))) }
     v c * pow2 (pbits * i) + eval_ aLen a (i - 1) + v c_in + v a.[i - 1] * pow2 (pbits * (i - 1)) - v c * pow2 pbits * pow2 (pbits * (i - 1));
-    (==) { Math.Lemmas.paren_mul_right (v c) (pow2 pbits) (pow2 (pbits * (i - 1))); Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
+    == { Math.Lemmas.paren_mul_right (v c) (pow2 pbits) (pow2 (pbits * (i - 1))); Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
     eval_ aLen a (i - 1) + v c_in + v a.[i - 1] * pow2 (pbits * (i - 1));
-    (==) { bn_eval_unfold_i #t #aLen a i }
+    == { bn_eval_unfold_i #t #aLen a i }
     eval_ aLen a i + v c_in;
   };
   assert (v c * pow2 (pbits * i) + bn_v #t #i res == eval_ aLen a i + v c_in)
@@ -172,21 +172,21 @@ let bn_add_lemma_loop_step #t #aLen a b i (c1, res1) =
 
   calc (==) {
     v c * pow2 (pbits * i) + bn_v #t #i res;
-    (==) { bn_eval_snoc #t #(i - 1) res1 e }
+    == { bn_eval_snoc #t #(i - 1) res1 e }
     v c * pow2 (pbits * i) + bn_v #t #(i - 1) res1 + v e * pow2 (pbits * (i - 1));
-    (==) { }
+    == { }
     v c * pow2 (pbits * i) + eval_ aLen a (i - 1) + eval_ aLen b (i - 1) - (v e + v c * pow2 pbits - v a.[i - 1] - v b.[i - 1]) * pow2 (pbits * (i - 1)) + v e * pow2 (pbits * (i - 1));
-    (==) { Math.Lemmas.distributivity_sub_left (v e) (v e + v c * pow2 pbits - v a.[i - 1] - v b.[i - 1]) (pow2 (pbits * (i - 1))) }
+    == { Math.Lemmas.distributivity_sub_left (v e) (v e + v c * pow2 pbits - v a.[i - 1] - v b.[i - 1]) (pow2 (pbits * (i - 1))) }
     v c * pow2 (pbits * i) + eval_ aLen a (i - 1) + eval_ aLen b (i - 1) + (v e - v e - v c * pow2 pbits + v a.[i - 1] + v b.[i - 1]) * pow2 (pbits * (i - 1));
-    (==) { Math.Lemmas.distributivity_sub_left (v a.[i - 1] + v b.[i - 1]) (v c1 * pow2 pbits) (pow2 (pbits * (i - 1))) }
+    == { Math.Lemmas.distributivity_sub_left (v a.[i - 1] + v b.[i - 1]) (v c1 * pow2 pbits) (pow2 (pbits * (i - 1))) }
     v c * pow2 (pbits * i) + eval_ aLen a (i - 1) + eval_ aLen b (i - 1) + (v a.[i - 1] + v b.[i - 1]) * pow2 (pbits * (i - 1)) - v c * pow2 pbits * pow2 (pbits * (i - 1));
-    (==) { Math.Lemmas.paren_mul_right (v c) (pow2 pbits) (pow2 (pbits * (i - 1))); Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
+    == { Math.Lemmas.paren_mul_right (v c) (pow2 pbits) (pow2 (pbits * (i - 1))); Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
     eval_ aLen a (i - 1) + eval_ aLen b (i - 1) + (v a.[i - 1] + v b.[i - 1]) * pow2 (pbits * (i - 1));
-    (==) { Math.Lemmas.distributivity_add_left (v a.[i - 1]) (v b.[i - 1]) (pow2 (pbits * (i - 1))) }
+    == { Math.Lemmas.distributivity_add_left (v a.[i - 1]) (v b.[i - 1]) (pow2 (pbits * (i - 1))) }
     eval_ aLen a (i - 1) + eval_ aLen b (i - 1) + v a.[i - 1] * pow2 (pbits * (i - 1)) + v b.[i - 1] * pow2 (pbits * (i - 1));
-    (==) { bn_eval_unfold_i #t #aLen a i }
+    == { bn_eval_unfold_i #t #aLen a i }
     eval_ aLen a i + eval_ aLen b (i - 1) + v b.[i - 1] * pow2 (pbits * (i - 1));
-    (==) { bn_eval_unfold_i #t #aLen b i }
+    == { bn_eval_unfold_i #t #aLen b i }
     eval_ aLen a i + eval_ aLen b i;
   };
   assert (v c * pow2 (pbits * i) + bn_v #t #i res == eval_ aLen a i + eval_ aLen b i)
@@ -254,15 +254,15 @@ let bn_add_concat_lemma #t #aLen #bLen a b c0 res0 =
   assert (bn_v res == bn_v #t #bLen res0 + pow2 (pbits * bLen) * bn_v res1);
   calc (==) {
     bn_v #t #bLen res0 + pow2 (pbits * bLen) * bn_v res1;
-    (==) { }
+    == { }
     eval_ bLen a0 bLen + eval_ bLen b bLen - v c0 * pow2 (pbits * bLen) + pow2 (pbits * bLen) * (bn_v a1 + v c0 - v c1 * pow2 (pbits * (aLen - bLen)));
-    (==) { Math.Lemmas.distributivity_sub_right (pow2 (pbits * bLen)) (bn_v a1 + v c0) (v c1 * pow2 (pbits * (aLen - bLen))) }
+    == { Math.Lemmas.distributivity_sub_right (pow2 (pbits * bLen)) (bn_v a1 + v c0) (v c1 * pow2 (pbits * (aLen - bLen))) }
     eval_ bLen a0 bLen + eval_ bLen b bLen - v c0 * pow2 (pbits * bLen) + pow2 (pbits * bLen) * (bn_v a1 + v c0) - pow2 (pbits * bLen) * v c1 * pow2 (pbits * (aLen - bLen));
-    (==) { Math.Lemmas.paren_mul_right (pow2 (pbits * bLen)) (v c1) (pow2 (pbits * (aLen - bLen))); Math.Lemmas.pow2_plus (pbits * bLen) (pbits * (aLen - bLen)) }
+    == { Math.Lemmas.paren_mul_right (pow2 (pbits * bLen)) (v c1) (pow2 (pbits * (aLen - bLen))); Math.Lemmas.pow2_plus (pbits * bLen) (pbits * (aLen - bLen)) }
     eval_ bLen a0 bLen + eval_ bLen b bLen - v c0 * pow2 (pbits * bLen) + pow2 (pbits * bLen) * (bn_v a1 + v c0) - v c1 * pow2 (pbits * aLen);
-    (==) { Math.Lemmas.distributivity_sub_right (pow2 (pbits * bLen)) (bn_v a1) (v c0) }
+    == { Math.Lemmas.distributivity_sub_right (pow2 (pbits * bLen)) (bn_v a1) (v c0) }
     eval_ bLen a0 bLen + eval_ bLen b bLen + pow2 (pbits * bLen) * bn_v a1 - v c1 * pow2 (pbits * aLen);
-    (==) { bn_eval_split_i a bLen; bn_eval_extensionality_j a (sub a 0 bLen) bLen }
+    == { bn_eval_split_i a bLen; bn_eval_extensionality_j a (sub a 0 bLen) bLen }
     eval_ aLen a aLen + eval_ bLen b bLen - v c1 * pow2 (pbits * aLen);
   }
 
@@ -342,17 +342,17 @@ let bn_sub_carry_lemma_loop_step #t #aLen a c_in i (c1, res1) =
 
   calc (==) {
     bn_v #t #i res - v c * pow2 (pbits * i);
-    (==) { bn_eval_snoc #t #(i - 1) res1 e }
+    == { bn_eval_snoc #t #(i - 1) res1 e }
     bn_v #t #(i - 1) res1 + v e * pow2 (pbits * (i - 1)) - v c * pow2 (pbits * i);
-    (==) { }
+    == { }
     eval_ aLen a (i - 1) - v c_in + (v a.[i - 1] - v e + v c * pow2 pbits) * pow2 (pbits * (i - 1)) + v e * pow2 (pbits * (i - 1)) - v c * pow2 (pbits * i);
-    (==) { Math.Lemmas.distributivity_sub_left (v a.[i - 1] + v c * pow2 pbits) (v e) (pow2 (pbits * (i - 1))) }
+    == { Math.Lemmas.distributivity_sub_left (v a.[i - 1] + v c * pow2 pbits) (v e) (pow2 (pbits * (i - 1))) }
     eval_ aLen a (i - 1) - v c_in + (v a.[i - 1] + v c * pow2 pbits) * pow2 (pbits * (i - 1)) - v c * pow2 (pbits * i);
-    (==) { Math.Lemmas.distributivity_add_left (v a.[i - 1]) (v c * pow2 pbits) (pow2 (pbits * (i - 1))) }
+    == { Math.Lemmas.distributivity_add_left (v a.[i - 1]) (v c * pow2 pbits) (pow2 (pbits * (i - 1))) }
     eval_ aLen a (i - 1) - v c_in + v a.[i - 1] * pow2 (pbits * (i - 1)) + v c * pow2 pbits * pow2 (pbits * (i - 1)) - v c * pow2 (pbits * i);
-    (==) { Math.Lemmas.paren_mul_right (v c) (pow2 pbits) (pow2 (pbits * (i - 1))); Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
+    == { Math.Lemmas.paren_mul_right (v c) (pow2 pbits) (pow2 (pbits * (i - 1))); Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
     eval_ aLen a (i - 1) - v c_in + v a.[i - 1] * pow2 (pbits * (i - 1));
-    (==) { bn_eval_unfold_i a i }
+    == { bn_eval_unfold_i a i }
     eval_ aLen a i - v c_in;
   };
   assert (bn_v #t #i res - v c * pow2 (pbits * i) == eval_ aLen a i - v c_in)
@@ -421,21 +421,21 @@ let bn_sub_lemma_loop_step #t #aLen a b i (c1, res1) =
 
   calc (==) {
     bn_v #t #i res - v c * pow2 (pbits * i);
-    (==) { bn_eval_snoc #t #(i - 1) res1 e }
+    == { bn_eval_snoc #t #(i - 1) res1 e }
     bn_v #t #(i - 1) res1 + v e * pow2 (pbits * (i - 1)) - v c * pow2 (pbits * i);
-    (==) { }
+    == { }
     eval_ aLen a (i - 1) - eval_ aLen b (i - 1) + (v a.[i - 1] - v b.[i - 1] + v c * pow2 pbits - v e) * pow2 (pbits * (i - 1)) + v e * pow2 (pbits * (i - 1)) - v c * pow2 (pbits * i);
-    (==) { Math.Lemmas.distributivity_sub_left (v a.[i - 1] - v b.[i - 1] + v c * pow2 pbits) (v e) (pow2 (pbits * (i - 1))) }
+    == { Math.Lemmas.distributivity_sub_left (v a.[i - 1] - v b.[i - 1] + v c * pow2 pbits) (v e) (pow2 (pbits * (i - 1))) }
     eval_ aLen a (i - 1) - eval_ aLen b (i - 1) + (v a.[i - 1] - v b.[i - 1] + v c * pow2 pbits) * pow2 (pbits * (i - 1)) - v c * pow2 (pbits * i);
-    (==) { Math.Lemmas.distributivity_add_left (v a.[i - 1] - v b.[i - 1]) (v c * pow2 pbits) (pow2 (pbits * (i - 1))) }
+    == { Math.Lemmas.distributivity_add_left (v a.[i - 1] - v b.[i - 1]) (v c * pow2 pbits) (pow2 (pbits * (i - 1))) }
     eval_ aLen a (i - 1) - eval_ aLen b (i - 1) + (v a.[i - 1] - v b.[i - 1]) * pow2 (pbits * (i - 1)) + v c * pow2 pbits * pow2 (pbits * (i - 1)) - v c * pow2 (pbits * i);
-    (==) { Math.Lemmas.paren_mul_right (v c) (pow2 pbits) (pow2 (pbits * (i - 1))); Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
+    == { Math.Lemmas.paren_mul_right (v c) (pow2 pbits) (pow2 (pbits * (i - 1))); Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
     eval_ aLen a (i - 1) - eval_ aLen b (i - 1) + (v a.[i - 1] - v b.[i - 1]) * pow2 (pbits * (i - 1));
-    (==) { Math.Lemmas.distributivity_sub_left (v a.[i - 1]) (v b.[i - 1]) (pow2 (pbits * (i - 1))) }
+    == { Math.Lemmas.distributivity_sub_left (v a.[i - 1]) (v b.[i - 1]) (pow2 (pbits * (i - 1))) }
     eval_ aLen a (i - 1) - eval_ aLen b (i - 1) + v a.[i - 1] * pow2 (pbits * (i - 1)) - v b.[i - 1] * pow2 (pbits * (i - 1));
-    (==) { bn_eval_unfold_i a i }
+    == { bn_eval_unfold_i a i }
     eval_ aLen a i - eval_ aLen b (i - 1) - v b.[i - 1] * pow2 (pbits * (i - 1));
-    (==) { bn_eval_unfold_i b i }
+    == { bn_eval_unfold_i b i }
     eval_ aLen a i - eval_ aLen b i;
   };
   assert (bn_v #t #i res - v c * pow2 (pbits * i) == eval_ aLen a i - eval_ aLen b i)
@@ -502,15 +502,15 @@ let bn_sub_concat_lemma #t #aLen #bLen a b c0 res0 =
   assert (bn_v res == bn_v #t #bLen res0 + pow2 (pbits * bLen) * bn_v res1);
   calc (==) {
     bn_v #t #bLen res0 + pow2 (pbits * bLen) * bn_v res1;
-    (==) { }
+    == { }
     eval_ bLen a0 bLen - eval_ bLen b bLen + v c0 * pow2 (pbits * bLen) + pow2 (pbits * bLen) * (bn_v a1 - v c0 + v c1 * pow2 (pbits * (aLen - bLen)));
-    (==) { Math.Lemmas.distributivity_sub_right (pow2 (pbits * bLen)) (bn_v a1 + v c1 * pow2 (pbits * (aLen - bLen))) (v c0) }
+    == { Math.Lemmas.distributivity_sub_right (pow2 (pbits * bLen)) (bn_v a1 + v c1 * pow2 (pbits * (aLen - bLen))) (v c0) }
     eval_ bLen a0 bLen - eval_ bLen b bLen + v c0 * pow2 (pbits * bLen) + pow2 (pbits * bLen) * (bn_v a1 + v c1 * pow2 (pbits * (aLen - bLen))) - pow2 (pbits * bLen) * v c0;
-    (==) { Math.Lemmas.distributivity_add_right (pow2 (pbits * bLen)) (bn_v a1) (v c1 * pow2 (pbits * (aLen - bLen))) }
+    == { Math.Lemmas.distributivity_add_right (pow2 (pbits * bLen)) (bn_v a1) (v c1 * pow2 (pbits * (aLen - bLen))) }
     eval_ bLen a0 bLen - eval_ bLen b bLen + pow2 (pbits * bLen) * bn_v a1 + pow2 (pbits * bLen) * v c1 * pow2 (pbits * (aLen - bLen));
-    (==) { Math.Lemmas.paren_mul_right (pow2 (pbits * bLen)) (v c1) (pow2 (pbits * (aLen - bLen))); Math.Lemmas.pow2_plus (pbits * bLen) (pbits * (aLen - bLen)) }
+    == { Math.Lemmas.paren_mul_right (pow2 (pbits * bLen)) (v c1) (pow2 (pbits * (aLen - bLen))); Math.Lemmas.pow2_plus (pbits * bLen) (pbits * (aLen - bLen)) }
     eval_ bLen a0 bLen - eval_ bLen b bLen + pow2 (pbits * bLen) * bn_v a1 + v c1 * pow2 (pbits * aLen);
-    (==) { bn_eval_split_i a bLen; bn_eval_extensionality_j a (sub a 0 bLen) bLen }
+    == { bn_eval_split_i a bLen; bn_eval_extensionality_j a (sub a 0 bLen) bLen }
     eval_ aLen a aLen - eval_ bLen b bLen + v c1 * pow2 (pbits * aLen);
   }
 

--- a/code/bignum/Hacl.Spec.Bignum.Convert.fst
+++ b/code/bignum/Hacl.Spec.Bignum.Convert.fst
@@ -291,17 +291,17 @@ let bn_to_bytes_be_lemma_aux #t len b i =
 
   calc (==) {
     v b.[e1] / pow2 (8 * e) % pow2 8;
-    (==) { bn_eval_index b e1 }
+    == { bn_eval_index b e1 }
     (bn_v b / pow2 (pbits * e1) % pow2 (pbits)) / pow2 (8 * e) % pow2 8;
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 (bn_v b) (pbits * e1) (pbits + pbits * e1) }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 (bn_v b) (pbits * e1) (pbits + pbits * e1) }
     (bn_v b % pow2 (pbits + pbits * e1) / pow2 (pbits * e1)) / pow2 (8 * e) % pow2 8;
-    (==) { Math.Lemmas.division_multiplication_lemma (bn_v b % pow2 (pbits + pbits * e1)) (pow2 (pbits * e1)) (pow2 (8 * e)) }
+    == { Math.Lemmas.division_multiplication_lemma (bn_v b % pow2 (pbits + pbits * e1)) (pow2 (pbits * e1)) (pow2 (8 * e)) }
     (bn_v b % pow2 (pbits + pbits * e1)) / (pow2 (pbits * e1) * pow2 (8 * e)) % pow2 8;
-    (==) { Math.Lemmas.pow2_plus (pbits * e1) (8 * e) }
+    == { Math.Lemmas.pow2_plus (pbits * e1) (8 * e) }
     (bn_v b % pow2 (pbits + pbits * e1)) / pow2 (pbits * e1 + 8 * e) % pow2 8;
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 (bn_v b) (8 * e2) (pbits + pbits * e1) }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 (bn_v b) (8 * e2) (pbits + pbits * e1) }
     (bn_v b / pow2 (8 * e2)) % pow2 (pbits + pbits * e1 - 8 * e2) % pow2 8;
-    (==) { Math.Lemmas.pow2_modulo_modulo_lemma_1 (bn_v b / pow2 (8 * e2)) 8 (pbits + pbits * e1 - 8 * e2) }
+    == { Math.Lemmas.pow2_modulo_modulo_lemma_1 (bn_v b / pow2 (8 * e2)) 8 (pbits + pbits * e1 - 8 * e2) }
     (bn_v b / pow2 (8 * (numb * len - i - 1))) % pow2 8;
     }
 

--- a/code/bignum/Hacl.Spec.Bignum.Definitions.fst
+++ b/code/bignum/Hacl.Spec.Bignum.Definitions.fst
@@ -106,13 +106,13 @@ val bn_eval_split_i_aux: p:nat -> a:nat -> b:nat -> c:nat -> i:nat -> Lemma
 let bn_eval_split_i_aux p a b c i =
   calc (==) {
     pow2 (p * (i + 1)) * c;
-    (==) { Math.Lemmas.pow2_plus (p * i) p }
+    == { Math.Lemmas.pow2_plus (p * i) p }
     pow2 (p * i) * pow2 p * c;
-    (==) { Math.Lemmas.paren_mul_right (pow2 (p * i)) (pow2 p) c }
+    == { Math.Lemmas.paren_mul_right (pow2 (p * i)) (pow2 p) c }
     pow2 (p * i) * (pow2 p * c);
-    (==) { }
+    == { }
     pow2 (p * i) * (a - b);
-    (==) { Math.Lemmas.distributivity_sub_right (pow2 (p * i)) a b }
+    == { Math.Lemmas.distributivity_sub_right (pow2 (p * i)) a b }
     pow2 (p * i) * a - pow2 (p * i) * b;
   }
 
@@ -140,13 +140,13 @@ let rec bn_eval_split_i #t #len b i =
       assert (bn_v b1 == v b.[i] + pow2 pbits * bn_v (slice b (i + 1) len));
       calc (==) {
         bn_v b;
-        (==) { bn_eval_split_i b (i + 1) }
+        == { bn_eval_split_i b (i + 1) }
         bn_v (slice b 0 (i + 1)) + pow2 (pbits * (i + 1)) * bn_v (slice b (i + 1) len);
-        (==) { bn_eval_split_i_aux pbits (bn_v b1) (v b.[i]) (bn_v (slice b (i + 1) len)) i }
+        == { bn_eval_split_i_aux pbits (bn_v b1) (v b.[i]) (bn_v (slice b (i + 1) len)) i }
         bn_v (slice b 0 (i + 1)) + pow2 (pbits * i) * bn_v b1 - pow2 (pbits * i) * v b.[i];
-        (==) { bn_eval_unfold_i (slice b 0 (i + 1)) (i + 1)}
+        == { bn_eval_unfold_i (slice b 0 (i + 1)) (i + 1)}
         eval_ (i + 1) (slice b 0 (i + 1)) i + pow2 (pbits * i) * bn_v b1;
-        (==) { bn_eval_extensionality_j (slice b 0 (i + 1)) (slice b 0 i) i }
+        == { bn_eval_extensionality_j (slice b 0 (i + 1)) (slice b 0 i) i }
         eval_ i (slice b 0 i) i + pow2 (pbits * i) * bn_v b1;
       }; () end end
 
@@ -180,13 +180,13 @@ let rec bn_eval_bound #t #len b i =
     assert (eval_ len b i == eval_ len b (i - 1) + pow2 (pbits * (i - 1)) * v b.[i - 1]);
     calc (<) {
       eval_ len b (i - 1) + pow2 (pbits * (i - 1)) * v b.[i - 1];
-      (<) { bn_eval_bound #t #len b (i - 1) }
+      < { bn_eval_bound #t #len b (i - 1) }
       pow2 (pbits * (i - 1)) + pow2 (pbits * (i - 1)) * v b.[i - 1];
-      (==) { Math.Lemmas.distributivity_add_right (pow2 (pbits * (i - 1))) 1 (v b.[i - 1]) }
+      == { Math.Lemmas.distributivity_add_right (pow2 (pbits * (i - 1))) 1 (v b.[i - 1]) }
       pow2 (pbits * (i - 1)) * (1 + v b.[i - 1]);
-      (<=) { Math.Lemmas.lemma_mult_le_left (pow2 (pbits * (i - 1))) (1 + v b.[i - 1]) (pow2 pbits) }
+      <= { Math.Lemmas.lemma_mult_le_left (pow2 (pbits * (i - 1))) (1 + v b.[i - 1]) (pow2 pbits) }
       pow2 (pbits * (i - 1)) * pow2 pbits;
-      (==) { Math.Lemmas.pow2_plus (pbits * (i - 1)) pbits }
+      == { Math.Lemmas.pow2_plus (pbits * (i - 1)) pbits }
       pow2 (pbits * i);
     };
     assert (eval_ len b i < pow2 (pbits * i))
@@ -201,19 +201,19 @@ let bn_eval_index #t #len b i =
 
   calc (==) {
     bn_v b / pow2 (pbits * i) % pow2 pbits;
-    (==) { bn_eval_split_i #t #len b i }
+    == { bn_eval_split_i #t #len b i }
     (bn_v (slice b 0 i) + pow2 (pbits * i) * bn_v (slice b i len)) / pow2 (pbits * i) % pow2 pbits;
-    (==) { Math.Lemmas.division_addition_lemma (bn_v (slice b 0 i)) (pow2 (pbits * i)) (bn_v (slice b i len)) }
+    == { Math.Lemmas.division_addition_lemma (bn_v (slice b 0 i)) (pow2 (pbits * i)) (bn_v (slice b i len)) }
     (bn_v (slice b 0 i) / pow2 (pbits * i) + bn_v (slice b i len)) % pow2 pbits;
-    (==) { bn_eval_bound (slice b 0 i) i; Math.Lemmas.small_division_lemma_1 (bn_v (slice b 0 i)) (pow2 (pbits * i)) }
+    == { bn_eval_bound (slice b 0 i) i; Math.Lemmas.small_division_lemma_1 (bn_v (slice b 0 i)) (pow2 (pbits * i)) }
     bn_v (slice b i len) % pow2 pbits;
-    (==) { bn_eval_split_i (slice b i len) 1 }
+    == { bn_eval_split_i (slice b i len) 1 }
     (bn_v (slice b i (i + 1)) + pow2 pbits * bn_v (slice b (i + 1) len)) % pow2 pbits;
-    (==) { Math.Lemmas.modulo_addition_lemma (bn_v (slice b i (i + 1))) (pow2 pbits) (bn_v (slice b (i + 1) len)) }
+    == { Math.Lemmas.modulo_addition_lemma (bn_v (slice b i (i + 1))) (pow2 pbits) (bn_v (slice b (i + 1) len)) }
     bn_v (slice b i (i + 1)) % pow2 pbits;
-    (==) { bn_eval1 (slice b i (i + 1)); Seq.lemma_index_slice b i (i + 1) 0 }
+    == { bn_eval1 (slice b i (i + 1)); Seq.lemma_index_slice b i (i + 1) 0 }
     v b.[i] % pow2 pbits;
-    (==) { Math.Lemmas.modulo_lemma (v b.[i]) (pow2 pbits) }
+    == { Math.Lemmas.modulo_lemma (v b.[i]) (pow2 pbits) }
     v b.[i];
   };
   assert (bn_v b / pow2 (pbits * i) % pow2 pbits == v b.[i])
@@ -229,11 +229,11 @@ let bn_eval_lt #t len a b k =
 
   calc (==) {
     eval_ len b k - eval_ len a k;
-    (==) { bn_eval_unfold_i b k }
+    == { bn_eval_unfold_i b k }
     eval_ len b (k - 1) + v b.[k - 1] * pow2 (pbits * (k - 1)) - eval_ len a k;
-    (==) { bn_eval_unfold_i a k }
+    == { bn_eval_unfold_i a k }
     eval_ len b (k - 1) + v b.[k - 1] * pow2 (pbits * (k - 1)) - eval_ len a (k - 1) - v a.[k - 1] * pow2 (pbits * (k - 1));
-    (==) { Math.Lemmas.distributivity_sub_left (v b.[k - 1]) (v a.[k - 1]) (pow2 (pbits * (k - 1))) }
+    == { Math.Lemmas.distributivity_sub_left (v b.[k - 1]) (v a.[k - 1]) (pow2 (pbits * (k - 1))) }
     eval_ len b (k - 1) - eval_ len a (k - 1) + (v b.[k - 1] - v a.[k - 1]) * pow2 (pbits * (k - 1));
   };
   bn_eval_bound a (k - 1);
@@ -271,24 +271,24 @@ let bn_update_sub_eval #t #aLen #bLen a b i =
 
   calc (==) {
     bn_v a' + c;
-    (==) { bn_eval_split_i a' i }
+    == { bn_eval_split_i a' i }
     bn_v (slice a' 0 i) + pow2 (pbits * i) * bn_v (slice a' i aLen) + c;
-    (==) { eq_intro (slice a 0 i) (slice a' 0 i) }
+    == { eq_intro (slice a 0 i) (slice a' 0 i) }
     bn_v (slice a 0 i) + pow2 (pbits * i) * bn_v (slice a' i aLen) + c;
-    (==) { bn_eval_split_i (slice a' i aLen) bLen }
+    == { bn_eval_split_i (slice a' i aLen) bLen }
     bn_v (slice a 0 i) + pow2 (pbits * i) * (bn_v (sub a' i bLen) + pow2 (pbits * bLen) * bn_v (slice a' (i + bLen) aLen)) + c;
-    (==) { eq_intro (slice a' (i + bLen) aLen) (slice a (i + bLen) aLen) }
+    == { eq_intro (slice a' (i + bLen) aLen) (slice a (i + bLen) aLen) }
     bn_v (slice a 0 i) + pow2 (pbits * i) * (bn_v (sub a' i bLen) + pow2 (pbits * bLen) * bn_v (slice a (i + bLen) aLen)) + c;
-    (==) {eq_intro (sub a' i bLen) b }
+    == {eq_intro (sub a' i bLen) b }
     bn_v (slice a 0 i) + pow2 (pbits * i) * (bn_v b + pow2 (pbits * bLen) * bn_v (slice a (i + bLen) aLen)) + c;
-    (==) { Math.Lemmas.distributivity_add_right (pow2 (pbits * i)) (bn_v b) (pow2 (pbits * bLen) * bn_v (slice a (i + bLen) aLen)) }
+    == { Math.Lemmas.distributivity_add_right (pow2 (pbits * i)) (bn_v b) (pow2 (pbits * bLen) * bn_v (slice a (i + bLen) aLen)) }
     bn_v (slice a 0 i) + pow2 (pbits * i) * bn_v b + pow2 (pbits * i) * (pow2 (pbits * bLen) * bn_v (slice a (i + bLen) aLen)) + c;
-    (==) { Math.Lemmas.paren_mul_right (pow2 (pbits * i)) (pow2 (pbits * bLen)) (bn_v (slice a (i + bLen) aLen));
+    == { Math.Lemmas.paren_mul_right (pow2 (pbits * i)) (pow2 (pbits * bLen)) (bn_v (slice a (i + bLen) aLen));
            Math.Lemmas.pow2_plus (pbits * i) (pbits * bLen) }
     bn_v (slice a 0 i) + pow2 (pbits * i) * bn_v b + pow2 (pbits * (i + bLen)) * bn_v (slice a (i + bLen) aLen) + c;
-    (==) { bn_eval_split_i (slice a 0 (i + bLen)) i }
+    == { bn_eval_split_i (slice a 0 (i + bLen)) i }
     bn_v (slice a 0 (i + bLen)) + pow2 (pbits * i) * bn_v b + pow2 (pbits * (i + bLen)) * bn_v (slice a (i + bLen) aLen);
-    (==) { bn_eval_split_i a (i + bLen) }
+    == { bn_eval_split_i a (i + bLen) }
     bn_v a + pow2 (pbits * i) * bn_v b;
     }
 
@@ -323,11 +323,11 @@ let bn_concat_lemma #t #aLen #bLen a b =
   let res = concat a b in
   calc (==) {
     bn_v res;
-    (==) { bn_eval_split_i res aLen }
+    == { bn_eval_split_i res aLen }
     bn_v (slice res 0 aLen) + pow2 (pbits * aLen) * bn_v (slice res aLen (aLen + bLen));
-    (==) { eq_intro (slice res 0 aLen) a }
+    == { eq_intro (slice res 0 aLen) a }
     bn_v a + pow2 (pbits * aLen) * bn_v (slice res aLen (aLen + bLen));
-    (==) { eq_intro (slice res aLen (aLen + bLen)) b }
+    == { eq_intro (slice res aLen (aLen + bLen)) b }
     bn_v a + pow2 (pbits * aLen) * bn_v b;
     }
 

--- a/code/bignum/Hacl.Spec.Bignum.Karatsuba.fst
+++ b/code/bignum/Hacl.Spec.Bignum.Karatsuba.fst
@@ -274,15 +274,15 @@ let bn_lshift_add_lemma #t #aLen a b1 i =
 
   calc (==) {
     bn_v a' + v c * p;
-    (==) { bn_update_sub_eval a r' i }
+    == { bn_update_sub_eval a r' i }
     bn_v a - bn_v r * pow2 (pbits * i) + bn_v r' * pow2 (pbits * i) + v c * p;
-    (==) { bn_add1_lemma r b1 }
+    == { bn_add1_lemma r b1 }
     bn_v a - bn_v r * pow2 (pbits * i) + (bn_v r + v b1 - v c * pow2 (pbits * (aLen - i))) * pow2 (pbits * i) + v c * p;
-    (==) { Math.Lemmas.distributivity_add_left (bn_v r) (v b1 - v c * pow2 (pbits * (aLen - i))) (pow2 (pbits * i)) }
+    == { Math.Lemmas.distributivity_add_left (bn_v r) (v b1 - v c * pow2 (pbits * (aLen - i))) (pow2 (pbits * i)) }
     bn_v a + (v b1 - v c * pow2 (pbits * (aLen - i))) * pow2 (pbits * i) + v c * p;
-    (==) { Math.Lemmas.distributivity_sub_left (v b1) (v c * pow2 (pbits * (aLen - i))) (pow2 (pbits * i)) }
+    == { Math.Lemmas.distributivity_sub_left (v b1) (v c * pow2 (pbits * (aLen - i))) (pow2 (pbits * i)) }
     bn_v a + v b1 * pow2 (pbits * i) - (v c * pow2 (pbits * (aLen - i))) * pow2 (pbits * i) + v c * p;
-    (==) { Math.Lemmas.paren_mul_right (v c) (pow2 (pbits * (aLen - i))) (pow2 (pbits * i));
+    == { Math.Lemmas.paren_mul_right (v c) (pow2 (pbits * (aLen - i))) (pow2 (pbits * i));
            Math.Lemmas.pow2_plus (pbits * (aLen - i)) (pbits * i) }
     bn_v a + v b1 * pow2 (pbits * i);
     }
@@ -323,15 +323,15 @@ let bn_lshift_add_early_stop_lemma #t #aLen #bLen a b i =
 
   calc (==) {
     bn_v a' + v c * p;
-    (==) { bn_update_sub_eval a r' i }
+    == { bn_update_sub_eval a r' i }
     bn_v a - bn_v r * pow2 (pbits * i) + bn_v r' * pow2 (pbits * i) + v c * p;
-    (==) { bn_add_lemma r b }
+    == { bn_add_lemma r b }
     bn_v a - bn_v r * pow2 (pbits * i) + (bn_v r + bn_v b - v c * pow2 (pbits * bLen)) * pow2 (pbits * i) + v c * p;
-    (==) { Math.Lemmas.distributivity_add_left (bn_v r) (bn_v b - v c * pow2 (pbits * bLen)) (pow2 (pbits * i)) }
+    == { Math.Lemmas.distributivity_add_left (bn_v r) (bn_v b - v c * pow2 (pbits * bLen)) (pow2 (pbits * i)) }
     bn_v a + (bn_v b - v c * pow2 (pbits * bLen)) * pow2 (pbits * i) + v c * p;
-    (==) { Math.Lemmas.distributivity_sub_left  (bn_v b) (v c * pow2 (pbits * bLen)) (pow2 (pbits * i)) }
+    == { Math.Lemmas.distributivity_sub_left  (bn_v b) (v c * pow2 (pbits * bLen)) (pow2 (pbits * i)) }
     bn_v a + bn_v b * pow2 (pbits * i) - (v c * pow2 (pbits * bLen)) * pow2 (pbits * i) + v c * p;
-    (==) { Math.Lemmas.paren_mul_right (v c) (pow2 (pbits * bLen)) (pow2 (pbits * i));
+    == { Math.Lemmas.paren_mul_right (v c) (pow2 (pbits * bLen)) (pow2 (pbits * i));
            Math.Lemmas.pow2_plus (pbits * bLen) (pbits * i) }
     bn_v a + bn_v b * pow2 (pbits * i);
     }
@@ -389,20 +389,20 @@ let bn_karatsuba_res_lemma #t #aLen r01 r23 c5 t45 =
 
   calc (==) {
     bn_v res2 + v c8 * pow2 (pbits * aLen4);
-    (==) { bn_lshift_add_lemma res1 c7 aLen3 }
+    == { bn_lshift_add_lemma res1 c7 aLen3 }
     bn_v res1 + v c7 * pow2 (pbits * aLen3);
-    (==) { Math.Lemmas.small_mod (v c5 + v c6) (pow2 pbits) }
+    == { Math.Lemmas.small_mod (v c5 + v c6) (pow2 pbits) }
     bn_v res1 + (v c5 + v c6) * pow2 (pbits * aLen3);
-    (==) { bn_lshift_add_early_stop_lemma res0 t45 aLen2 }
+    == { bn_lshift_add_early_stop_lemma res0 t45 aLen2 }
     bn_v res0 + bn_v t45 * pow2 (pbits * aLen2) - v c6 * pow2 (pbits * aLen3) + (v c5 + v c6) * pow2 (pbits * aLen3);
-    (==) { Math.Lemmas.distributivity_add_left (v c5) (v c6) (pow2 (pbits * aLen3)) }
+    == { Math.Lemmas.distributivity_add_left (v c5) (v c6) (pow2 (pbits * aLen3)) }
     bn_v res0 + bn_v t45 * pow2 (pbits * aLen2) + v c5 * pow2 (pbits * aLen3);
-    (==) { Math.Lemmas.pow2_plus (pbits * aLen) (pbits * aLen2) }
+    == { Math.Lemmas.pow2_plus (pbits * aLen) (pbits * aLen2) }
     bn_v res0 + bn_v t45 * pow2 (pbits * aLen2) + v c5 * (pow2 (pbits * aLen) * pow2 (pbits * aLen2));
-    (==) { Math.Lemmas.paren_mul_right (v c5) (pow2 (pbits * aLen)) (pow2 (pbits * aLen2));
+    == { Math.Lemmas.paren_mul_right (v c5) (pow2 (pbits * aLen)) (pow2 (pbits * aLen2));
       Math.Lemmas.distributivity_add_left (bn_v t45) (v c5 * pow2 (pbits * aLen)) (pow2 (pbits * aLen2)) }
     bn_v res0 + (bn_v t45 + v c5 * pow2 (pbits * aLen)) * pow2 (pbits * aLen2);
-    (==) { bn_concat_lemma r01 r23 }
+    == { bn_concat_lemma r01 r23 }
     bn_v r23 * pow2 (pbits * aLen) + (v c5 * pow2 (pbits * aLen) + bn_v t45) * pow2 (pbits * aLen2) + bn_v r01;
     }
 
@@ -430,11 +430,11 @@ let bn_middle_karatsuba_carry_bound #t aLen a0 a1 b0 b1 res c =
 
   calc (<) {
     bn_v a0 * bn_v b1 + bn_v a1 * bn_v b0;
-    (<) { Math.Lemmas.lemma_mult_lt_sqr (bn_v a0) (bn_v b1) p }
+    < { Math.Lemmas.lemma_mult_lt_sqr (bn_v a0) (bn_v b1) p }
     p * p + bn_v a1 * bn_v b0;
-    (<) { Math.Lemmas.lemma_mult_lt_sqr (bn_v a1) (bn_v b0) p }
+    < { Math.Lemmas.lemma_mult_lt_sqr (bn_v a1) (bn_v b0) p }
     p * p + p * p;
-    (==) { K.lemma_double_p (bits t) aLen }
+    == { K.lemma_double_p (bits t) aLen }
     pow2 (pbits * aLen) + pow2 (pbits * aLen);
     };
 

--- a/code/bignum/Hacl.Spec.Bignum.Lib.fst
+++ b/code/bignum/Hacl.Spec.Bignum.Lib.fst
@@ -27,9 +27,9 @@ let limb_get_ith_bit_lemma #t a i =
   let tmp2 = tmp1 &. uint #t 1 in
   calc (==) {
     v (limb_get_ith_bit a i);
-    (==) { }
+    == { }
     v tmp2;
-    (==) {
+    == {
       shift_left_lemma #t #SEC (mk_int 1) 1ul;
       assert_norm (1 * pow2 1 == 2);
       FStar.Math.Lemmas.small_mod 2 (modulus t);
@@ -37,9 +37,9 @@ let limb_get_ith_bit_lemma #t a i =
       assert (mod_mask #t #SEC 1ul == uint #t #SEC 1)
     }
     v (tmp1 `logand` mod_mask 1ul);
-    (==) { mod_mask_lemma tmp1 1ul }
+    == { mod_mask_lemma tmp1 1ul }
     v tmp1 % pow2 (v 1ul);
-    (==) { }
+    == { }
     v a / pow2 i % 2;
   }
 
@@ -66,15 +66,15 @@ let bn_get_ith_bit_aux_lemma #t #len b ind =
 
   calc (==) {
     v b.[i] / pow2 j;
-    (==) { bn_eval_index b i }
+    == { bn_eval_index b i }
     (bn_v b / pow2 (pbits * i) % pow2 pbits) / pow2 j;
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 (bn_v b / pow2 (pbits * i)) j pbits }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 (bn_v b / pow2 (pbits * i)) j pbits }
     (bn_v b / pow2 (pbits * i) / pow2 j) % pow2 (pbits - j);
-    (==) { Math.Lemmas.division_multiplication_lemma (bn_v b) (pow2 (pbits * i)) (pow2 j) }
+    == { Math.Lemmas.division_multiplication_lemma (bn_v b) (pow2 (pbits * i)) (pow2 j) }
     (bn_v b / (pow2 (pbits * i) * pow2 j)) % pow2 (pbits - j);
-    (==) { Math.Lemmas.pow2_plus (pbits * i) j }
+    == { Math.Lemmas.pow2_plus (pbits * i) j }
     (bn_v b / pow2 (pbits * i + j)) % pow2 (pbits - j);
-    (==) {
+    == {
       Math.Lemmas.euclidean_division_definition ind pbits;
       Math.Lemmas.euclidean_div_axiom ind pbits }
     (bn_v b / pow2 ind) % pow2 (pbits - j);
@@ -95,9 +95,9 @@ let bn_get_ith_bit_lemma #t #len b ind =
 
   calc (==) {
     v b.[i] / pow2 j % 2;
-    (==) { bn_get_ith_bit_aux_lemma b ind }
+    == { bn_get_ith_bit_aux_lemma b ind }
     (bn_v b / pow2 ind) % pow2 (pbits - j) % 2;
-    (==) { assert_norm (pow2 1 = 2);
+    == { assert_norm (pow2 1 = 2);
            Math.Lemmas.pow2_modulo_modulo_lemma_1 (bn_v b / pow2 ind) 1 (pbits - j) }
     (bn_v b / pow2 ind) % 2;
     };
@@ -143,9 +143,9 @@ let bn_lt_pow2_index_lemma #t #len b ind =
   assert (bn_v b < pow2 (i * pbits + pbits));
   calc (==) {
     i * pbits + pbits;
-    (==) { }
+    == { }
     i * pbits + 1 * pbits;
-    (==) {
+    == {
       Math.Lemmas.distributivity_add_left i 1 pbits;
       Math.Lemmas.swap_mul pbits (i+1)
     }
@@ -199,25 +199,25 @@ let bn_set_ith_bit_lemma #t #len input ind =
 
   calc (==) {
     bn_v inp <: int;
-    (==) {
+    == {
       bn_eval_split_i #t #len inp (i + 1);
       bn_eval_split_i #t #len input (i + 1);
       bn_eval_extensionality_j (slice inp (i + 1) len) (slice input (i + 1) len) (len - i - 1)
     }
     bn_v (slice inp 0 (i + 1));
-    (==) { bn_eval_split_i #t #(i + 1) (slice inp 0 (i + 1)) i }
+    == { bn_eval_split_i #t #(i + 1) (slice inp 0 (i + 1)) i }
     bn_v (slice inp 0 i) + pow2 (i * pbits) * bn_v (slice inp i (i + 1));
-    (==) { bn_eval1 (slice inp i (i + 1)) }
+    == { bn_eval1 (slice inp i (i + 1)) }
     bn_v (slice inp 0 i) + pow2 (i * pbits) * v inp.[i];
-    (==) { bn_eval_extensionality_j input inp i }
+    == { bn_eval_extensionality_j input inp i }
     bn_v (slice input 0 i) + pow2 (i * pbits) * v inp.[i];
-    (==) { }
+    == { }
     bn_v (slice input 0 i) + pow2 (i * pbits) * (v input.[i] + v b);
-    (==) { Math.Lemmas.distributivity_add_right (pow2 (i * pbits)) (v input.[i]) (v b) }
+    == { Math.Lemmas.distributivity_add_right (pow2 (i * pbits)) (v input.[i]) (v b) }
     bn_v (slice input 0 i) + pow2 (i * pbits) * v input.[i] + pow2 (i * pbits) * v b;
-    (==) { Math.Lemmas.pow2_plus (i * pbits) j; Math.Lemmas.euclidean_division_definition ind pbits }
+    == { Math.Lemmas.pow2_plus (i * pbits) j; Math.Lemmas.euclidean_division_definition ind pbits }
     bn_v (slice input 0 i) + pow2 (i * pbits) * v input.[i] + pow2 ind;
-    (==) { }
+    == { }
     bn_v input + pow2 ind;
   }
 
@@ -240,11 +240,11 @@ let bn_div_pow2_lemma #t #len c i =
   Math.Lemmas.nat_times_nat_is_nat pbits i;
   calc (==) {
     bn_v c / pow2 (pbits * i);
-    (==) { bn_eval_split_i c i }
+    == { bn_eval_split_i c i }
     (bn_v (slice c 0 i) + pow2 (pbits * i) * bn_v (slice c i len)) / pow2 (pbits * i);
-    (==) { Math.Lemmas.division_addition_lemma (bn_v (slice c 0 i)) (pow2 (pbits * i)) (bn_v (slice c i len)) }
+    == { Math.Lemmas.division_addition_lemma (bn_v (slice c 0 i)) (pow2 (pbits * i)) (bn_v (slice c i len)) }
     bn_v (slice c 0 i) / pow2 (pbits * i) + bn_v (slice c i len);
-    (==) { bn_eval_bound (slice c 0 i) i; Math.Lemmas.small_division_lemma_1 (bn_v (slice c 0 i)) (pow2 (pbits * i)) }
+    == { bn_eval_bound (slice c 0 i) i; Math.Lemmas.small_division_lemma_1 (bn_v (slice c 0 i)) (pow2 (pbits * i)) }
     bn_v (slice c i len);
   };
   assert (bn_v (slice c i len) == bn_v c / pow2 (pbits * i))
@@ -262,11 +262,11 @@ let bn_mod_pow2_lemma #t #aLen a i =
   Math.Lemmas.nat_times_nat_is_nat pbits i;
   calc (==) {
     bn_v a % pow2 (pbits * i);
-    (==) { bn_eval_split_i a i }
+    == { bn_eval_split_i a i }
     (bn_v (slice a 0 i) + pow2 (pbits * i) * bn_v (slice a i aLen)) % pow2 (pbits * i);
-    (==) { Math.Lemmas.modulo_addition_lemma (bn_v (slice a 0 i)) (pow2 (pbits * i)) (bn_v (slice a i aLen)) }
+    == { Math.Lemmas.modulo_addition_lemma (bn_v (slice a 0 i)) (pow2 (pbits * i)) (bn_v (slice a i aLen)) }
     (bn_v (slice a 0 i)) % pow2 (pbits * i);
-    (==) { bn_eval_bound (slice a 0 i) i; Math.Lemmas.small_mod (bn_v (slice a 0 i)) (pow2 (pbits * i)) }
+    == { bn_eval_bound (slice a 0 i) i; Math.Lemmas.small_mod (bn_v (slice a 0 i)) (pow2 (pbits * i)) }
     bn_v (slice a 0 i);
     }
 
@@ -502,25 +502,25 @@ let bn_get_bits_limb_aux_lemma #t #nLen n ind =
 
   calc (==) {
     bn_v n / pow2 ind % pow2 pbits;
-    (==) { Math.Lemmas.euclidean_division_definition res (pow2 (pbits - j)) }
+    == { Math.Lemmas.euclidean_division_definition res (pow2 (pbits - j)) }
     res / pow2 (pbits - j) * pow2 (pbits - j) + res % pow2 (pbits - j);
-    (==) { Math.Lemmas.pow2_modulo_modulo_lemma_1 (bn_v n / pow2 ind) (pbits - j) pbits }
+    == { Math.Lemmas.pow2_modulo_modulo_lemma_1 (bn_v n / pow2 ind) (pbits - j) pbits }
     res / pow2 (pbits - j) * pow2 (pbits - j) + bn_v n / pow2 ind % pow2 (pbits - j);
-    (==) { bn_get_ith_bit_aux_lemma n ind }
+    == { bn_get_ith_bit_aux_lemma n ind }
     res / pow2 (pbits - j) * pow2 (pbits - j) + v p1;
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 (bn_v n / pow2 ind) (pbits - j) pbits }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 (bn_v n / pow2 ind) (pbits - j) pbits }
     bn_v n / pow2 ind / pow2 (pbits - j) % pow2 j * pow2 (pbits - j) + v p1;
-    (==) { Math.Lemmas.division_multiplication_lemma (bn_v n) (pow2 ind) (pow2 (pbits - j)) }
+    == { Math.Lemmas.division_multiplication_lemma (bn_v n) (pow2 ind) (pow2 (pbits - j)) }
     bn_v n / (pow2 ind * pow2 (pbits - j)) % pow2 j * pow2 (pbits - j) + v p1;
-    (==) { Math.Lemmas.pow2_plus ind (pbits - j) }
+    == { Math.Lemmas.pow2_plus ind (pbits - j) }
     bn_v n / pow2 (ind + pbits - j) % pow2 j * pow2 (pbits - j) + v p1;
-    (==) { Math.Lemmas.euclidean_division_definition ind pbits }
+    == { Math.Lemmas.euclidean_division_definition ind pbits }
     bn_v n / pow2 (i * pbits + pbits) % pow2 j * pow2 (pbits - j) + v p1;
-    (==) { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (bn_v n / pow2 (i * pbits + pbits)) pbits (pbits - j) }
+    == { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (bn_v n / pow2 (i * pbits + pbits)) pbits (pbits - j) }
     bn_v n / pow2 (i * pbits + pbits) * pow2 (pbits - j) % pow2 pbits + v p1;
-    (==) { Math.Lemmas.distributivity_add_left i 1 pbits }
+    == { Math.Lemmas.distributivity_add_left i 1 pbits }
     bn_v n / pow2 ((i + 1) * pbits) * pow2 (pbits - j) % pow2 pbits + v p1;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (bn_v n / pow2 ((i + 1) * pbits)) (pow2 (pbits - j)) (pow2 pbits) }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (bn_v n / pow2 ((i + 1) * pbits)) (pow2 (pbits - j)) (pow2 pbits) }
     bn_v n / pow2 ((i + 1) * pbits) % pow2 pbits * pow2 (pbits - j) % pow2 pbits + v p1;
     }
 
@@ -552,11 +552,11 @@ let bn_get_bits_limb_lemma #t #nLen n ind =
       let p2 = n.[i + 1] <<. (size (pbits - j)) in
       calc (==) {
 	v p2 % pow2 (pbits - j);
-	(==) { }
+	== { }
 	v n.[i + 1] * pow2 (pbits - j) % pow2 pbits % pow2 (pbits - j);
-	(==) { Math.Lemmas.pow2_modulo_modulo_lemma_1 (v n.[i + 1] * pow2 (pbits - j)) (pbits - j) pbits }
+	== { Math.Lemmas.pow2_modulo_modulo_lemma_1 (v n.[i + 1] * pow2 (pbits - j)) (pbits - j) pbits }
 	v n.[i + 1] * pow2 (pbits - j) % pow2 (pbits - j);
-	(==) { Math.Lemmas.multiple_modulo_lemma (v n.[i + 1]) (pow2 (pbits - j)) }
+	== { Math.Lemmas.multiple_modulo_lemma (v n.[i + 1]) (pow2 (pbits - j)) }
 	0;
 	};
       let p3 = p1 |. p2 in

--- a/code/bignum/Hacl.Spec.Bignum.ModInv.fst
+++ b/code/bignum/Hacl.Spec.Bignum.ModInv.fst
@@ -35,15 +35,15 @@ let mod_inv_prime_lemma n a =
 
   calc (==) {
     Lib.NatMod.pow_mod #n a (n - 2) * a % n;
-    (==) { Lib.NatMod.lemma_pow_mod #n a (n - 2) }
+    == { Lib.NatMod.lemma_pow_mod #n a (n - 2) }
     Lib.NatMod.pow a (n - 2) % n * a % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (Lib.NatMod.pow a (n - 2)) a n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (Lib.NatMod.pow a (n - 2)) a n }
     Lib.NatMod.pow a (n - 2) * a % n;
-    (==) { Lib.NatMod.lemma_pow1 a; Lib.NatMod.lemma_pow_add a (n - 2) 1 }
+    == { Lib.NatMod.lemma_pow1 a; Lib.NatMod.lemma_pow_add a (n - 2) 1 }
     Lib.NatMod.pow a (n - 1) % n;
-    (==) { pow_eq a (n - 1) }
+    == { pow_eq a (n - 1) }
     Fermat.pow a (n - 1) % n;
-    (==) { Fermat.fermat_alt n a }
+    == { Fermat.fermat_alt n a }
     1;
     }
 

--- a/code/bignum/Hacl.Spec.Bignum.ModInvLimb.fst
+++ b/code/bignum/Hacl.Spec.Bignum.ModInvLimb.fst
@@ -80,13 +80,13 @@ let mod_inv_limb_inv_vb_is_even #t n0 i ub0 vb0 =
   assert (pow2 (bits t - i + 1) % 2 == 0);
   calc (==) {
     pow2 (bits t - i + 1) % 2;
-    (==) { }
+    == { }
     (v ub0 * 2 * v alpha - v vb0 * v beta) % 2;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l (v ub0 * 2 * v alpha) (- v vb0 * v beta) 2 }
+    == { Math.Lemmas.lemma_mod_plus_distr_l (v ub0 * 2 * v alpha) (- v vb0 * v beta) 2 }
     (- v vb0 * v beta) % 2;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (- v vb0) (v beta) 2 }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (- v vb0) (v beta) 2 }
     (- v vb0) % 2;
-    (==) { aux_mod_2_neg (v vb0) } // flaky without the lemma call
+    == { aux_mod_2_neg (v vb0) } // flaky without the lemma call
     v vb0 % 2;
   }
 
@@ -115,15 +115,15 @@ let mod_inv_limb_inv_step_even #t n0 i ub0 vb0 =
   assert (ub * 2 * v alpha - vb * v beta == v ub0 / 2 * 2 * v alpha - v vb0 / 2 * v beta);
   calc (==) {
     2 * (ub * 2 * v alpha - vb * v beta);
-    (==) { }
+    == { }
     2 * (v ub0 / 2 * 2 * v alpha - v vb0 / 2 * v beta);
-    (==) { Math.Lemmas.distributivity_sub_right 2 (v ub0 / 2 * 2 * v alpha) (v vb0 / 2 * v beta) }
+    == { Math.Lemmas.distributivity_sub_right 2 (v ub0 / 2 * 2 * v alpha) (v vb0 / 2 * v beta) }
     2 * v ub0 / 2 * 2 * v alpha - 2 * (v vb0 / 2) * v beta;
-    (==) { Math.Lemmas.div_exact_r (v ub0) 2 }
+    == { Math.Lemmas.div_exact_r (v ub0) 2 }
     v ub0 * 2 * v alpha - 2 * (v vb0 / 2) * v beta;
-    (==) { mod_inv_limb_inv_vb_is_even n0 i ub0 vb0; Math.Lemmas.div_exact_r (v vb0) 2 }
+    == { mod_inv_limb_inv_vb_is_even n0 i ub0 vb0; Math.Lemmas.div_exact_r (v vb0) 2 }
     v ub0 * 2 * v alpha - v vb0 * v beta;
-    (==) {assert (pow2 (pbits - i + 1) == v ub0 * 2 * v alpha - v vb0 * v beta) }
+    == {assert (pow2 (pbits - i + 1) == v ub0 * 2 * v alpha - v vb0 * v beta) }
     pow2 (pbits - i + 1);
     };
   assert (2 * (ub * 2 * v alpha - vb * v beta) == pow2 (pbits - i + 1))
@@ -151,31 +151,31 @@ let mod_inv_limb_inv_step_odd #t n0 i ub0 vb0 =
 
   calc (==) {
     2 * (ub * 2 * v alpha - vb * v beta);
-    (==) { Math.Lemmas.small_mod ((v ub0 + v beta) / 2) (pow2 pbits) }
+    == { Math.Lemmas.small_mod ((v ub0 + v beta) / 2) (pow2 pbits) }
     2 * ((v ub0 + v beta) / 2 * 2 * v alpha - vb * v beta);
-    (==) { Math.Lemmas.small_mod (v vb0 / 2 + v alpha) (pow2 pbits) }
+    == { Math.Lemmas.small_mod (v vb0 / 2 + v alpha) (pow2 pbits) }
     2 * ((v ub0 + v beta) / 2 * 2 * v alpha - (v vb0 / 2 + v alpha) * v beta);
-    (==) { Math.Lemmas.distributivity_sub_right 2 ((v ub0 + v beta) / 2 * 2 * v alpha) ((v vb0 / 2 + v alpha) * v beta) }
+    == { Math.Lemmas.distributivity_sub_right 2 ((v ub0 + v beta) / 2 * 2 * v alpha) ((v vb0 / 2 + v alpha) * v beta) }
     2 * (v ub0 + v beta) / 2 * 2 * v alpha - 2 * (v vb0 / 2 + v alpha) * v beta;
-    (==) { Math.Lemmas.div_exact_r (v ub0 + v beta) 2 }
+    == { Math.Lemmas.div_exact_r (v ub0 + v beta) 2 }
     (v ub0 + v beta) * 2 * v alpha - 2 * (v vb0 / 2 + v alpha) * v beta;
-    (==) { Math.Lemmas.paren_mul_right 2 (v vb0 / 2 + v alpha) (v beta) }
+    == { Math.Lemmas.paren_mul_right 2 (v vb0 / 2 + v alpha) (v beta) }
     (v ub0 + v beta) * 2 * v alpha - 2 * ((v vb0 / 2 + v alpha) * v beta);
-    (==) { Math.Lemmas.distributivity_add_left (v vb0 / 2) (v alpha) (v beta) }
+    == { Math.Lemmas.distributivity_add_left (v vb0 / 2) (v alpha) (v beta) }
     (v ub0 + v beta) * 2 * v alpha - 2 * (v vb0 / 2 * v beta + v alpha * v beta);
-    (==) { Math.Lemmas.distributivity_add_right 2 (v vb0 / 2 * v beta) (v alpha * v beta);
+    == { Math.Lemmas.distributivity_add_right 2 (v vb0 / 2 * v beta) (v alpha * v beta);
            Math.Lemmas.paren_mul_right 2 (v vb0 / 2) (v beta);
            Math.Lemmas.paren_mul_right 2 (v alpha) (v beta) }
     (v ub0 + v beta) * 2 * v alpha - (2 * (v vb0 / 2) * v beta + 2 * v alpha * v beta);
-    (==) { mod_inv_limb_inv_vb_is_even n0 i ub0 vb0; Math.Lemmas.div_exact_r (v vb0) 2 }
+    == { mod_inv_limb_inv_vb_is_even n0 i ub0 vb0; Math.Lemmas.div_exact_r (v vb0) 2 }
     (v ub0 + v beta) * 2 * v alpha - (v vb0 * v beta + 2 * v alpha * v beta);
-    (==) { Math.Lemmas.distributivity_add_left (v ub0) (v beta) (2 * v alpha) }
+    == { Math.Lemmas.distributivity_add_left (v ub0) (v beta) (2 * v alpha) }
     v ub0 * 2 * v alpha + v beta * 2 * v alpha - (v vb0 * v beta + 2 * v alpha * v beta);
-    (==) { Math.Lemmas.paren_mul_right (v beta) 2 (v alpha); Math.Lemmas.swap_mul (v beta) (2 * v alpha) }
+    == { Math.Lemmas.paren_mul_right (v beta) 2 (v alpha); Math.Lemmas.swap_mul (v beta) (2 * v alpha) }
     v ub0 * 2 * v alpha + 2 * v alpha * v beta - v vb0 * v beta - 2 * v alpha * v beta;
-    (==) { }
+    == { }
     v ub0 * 2 * v alpha - v vb0 * v beta;
-    (==) { assert (pow2 (pbits - i + 1) == v ub0 * 2 * v alpha - v vb0 * v beta) }
+    == { assert (pow2 (pbits - i + 1) == v ub0 * 2 * v alpha - v vb0 * v beta) }
     pow2 (pbits - i + 1);
   };
   assert (2 * (ub * 2 * v alpha - vb * v beta) == pow2 (pbits - i + 1))
@@ -257,11 +257,11 @@ let mod_inv_limb_lemma #t n0 =
   mod_inv_limb_inv n0 pbits;
   calc (==) {
     (1 + v vb * v n0) % pow2 pbits;
-    (==) { }
+    == { }
     (v ub * 2 * v alpha) % pow2 pbits;
-    (==) { Math.Lemmas.pow2_plus 1 (pbits - 1) }
+    == { Math.Lemmas.pow2_plus 1 (pbits - 1) }
     (v ub * pow2 pbits) % pow2 pbits;
-    (==) { Math.Lemmas.cancel_mul_mod (v ub) (pow2 pbits) }
+    == { Math.Lemmas.cancel_mul_mod (v ub) (pow2 pbits) }
     0;
   };
   assert ((1 + v vb * v n0) % pow2 pbits == 0)

--- a/code/bignum/Hacl.Spec.Bignum.ModReduction.fst
+++ b/code/bignum/Hacl.Spec.Bignum.ModReduction.fst
@@ -66,13 +66,13 @@ let bn_mod_slow_precomp_lemma #t #len n mu r2 a =
 
   calc (==) {
     bn_v res;
-    (==) { M.to_mont_lemma (bits t) len (bn_v n) (v mu) (bn_v a_mod) }
+    == { M.to_mont_lemma (bits t) len (bn_v n) (v mu) (bn_v a_mod) }
     bn_v a_mod * r % bn_v n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (bn_v a_mod) r (bn_v n) }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (bn_v a_mod) r (bn_v n) }
     bn_v a_mod % bn_v n * r % bn_v n;
-    (==) {  }
+    == {  }
     (bn_v a * d % bn_v n) * r % bn_v n;
-    (==) { M.lemma_mont_id1 (bn_v n) r d (bn_v a) }
+    == { M.lemma_mont_id1 (bn_v n) r d (bn_v a) }
     bn_v a % bn_v n;
     };
 

--- a/code/bignum/Hacl.Spec.Bignum.Montgomery.fst
+++ b/code/bignum/Hacl.Spec.Bignum.Montgomery.fst
@@ -175,15 +175,15 @@ let bn_mont_reduction_f_eval_lemma_aux pbits er0 rj nLen n qj j c0 c1 c2 =
   let p = pow2 (pbits * (nLen + j)) in
   calc (==) {
     er0 + n * qj * pow2 (pbits * j) - c1 * p + p * (c0 + c1 + rj - c2 * pow2 pbits);
-    (==) { Math.Lemmas.distributivity_add_right p c1 (c0 + rj - c2 * pow2 pbits) }
+    == { Math.Lemmas.distributivity_add_right p c1 (c0 + rj - c2 * pow2 pbits) }
     er0 + n * qj * pow2 (pbits * j) - c1 * p + p * c1 + p * (c0 + rj - c2 * pow2 pbits);
-    (==) { }
+    == { }
     er0 + n * qj * pow2 (pbits * j) + p * (c0 + rj - c2 * pow2 pbits);
-    (==) { Math.Lemmas.distributivity_add_right p rj (c0 - c2 * pow2 pbits) }
+    == { Math.Lemmas.distributivity_add_right p rj (c0 - c2 * pow2 pbits) }
     er0 + n * qj * pow2 (pbits * j) + p * rj + p * (c0 - c2 * pow2 pbits);
-    (==) { Math.Lemmas.distributivity_sub_right p c0 (c2 * pow2 pbits); Math.Lemmas.paren_mul_right p c2 (pow2 pbits) }
+    == { Math.Lemmas.distributivity_sub_right p c0 (c2 * pow2 pbits); Math.Lemmas.paren_mul_right p c2 (pow2 pbits) }
     er0 + n * qj * pow2 (pbits * j) + p * rj + p * c0 - p * c2 * pow2 pbits;
-    (==) { Math.Lemmas.pow2_plus (pbits * (nLen + j)) pbits; Math.Lemmas.paren_mul_right c2 p (pow2 pbits) }
+    == { Math.Lemmas.pow2_plus (pbits * (nLen + j)) pbits; Math.Lemmas.paren_mul_right c2 p (pow2 pbits) }
     er0 + n * qj * pow2 (pbits * j) + p * rj + p * c0 - c2 * pow2 (pbits * (nLen + j + 1));
     }
 
@@ -222,13 +222,13 @@ let bn_mont_reduction_f_eval_lemma #t #nLen n mu j (c0, res0) =
 
   calc (==) {
     eval_ resLen res1 (nLen + j) + p * v res.[nLen + j];
-    (==) { }
+    == { }
     eval_ resLen res0 (nLen + j) + bn_v n * v qj * pow2 (pbits * j) - v c1 * p + p * (v c0 + v c1 + v res1.[nLen + j] - v c2 * pow2 pbits);
-    (==) { bn_mont_reduction_f_eval_lemma_aux pbits (eval_ resLen res0 (nLen + j)) (v res1.[nLen + j]) nLen (bn_v n) (v qj) j (v c0) (v c1) (v c2) }
+    == { bn_mont_reduction_f_eval_lemma_aux pbits (eval_ resLen res0 (nLen + j)) (v res1.[nLen + j]) nLen (bn_v n) (v qj) j (v c0) (v c1) (v c2) }
     eval_ resLen res0 (nLen + j) + p * v res1.[nLen + j] + bn_v n * v qj * pow2 (pbits * j) + p * v c0 - pow2 (pbits * (nLen + j + 1)) * v c2;
-    (==) { Seq.lemma_index_slice res1 (nLen + j) resLen 0 }
+    == { Seq.lemma_index_slice res1 (nLen + j) resLen 0 }
     eval_ resLen res0 (nLen + j) + p * v res0.[nLen + j] + bn_v n * v qj * pow2 (pbits * j) + p * v c0 - pow2 (pbits * (nLen + j + 1)) * v c2;
-    (==) { bn_eval_unfold_i res0 (nLen + j + 1) }
+    == { bn_eval_unfold_i res0 (nLen + j + 1) }
     eval_ resLen res0 (nLen + j + 1) + bn_v n * v qj * pow2 (pbits * j) + p * v c0 - pow2 (pbits * (nLen + j + 1)) * v c2;
   };
 
@@ -293,13 +293,13 @@ let bn_mont_reduction_loop_step_lemma #t #nLen n mu j c1 res1 resM1 =
 
   calc (==) {
     (v c1 * pow2 (pbits * (nLen + j)) + bn_v res1) / pow2 (pbits * j) % pow2 pbits;
-    (==) { Math.Lemmas.pow2_plus (pbits * nLen) (pbits * j) }
+    == { Math.Lemmas.pow2_plus (pbits * nLen) (pbits * j) }
     (v c1 * pow2 (pbits * nLen) * pow2 (pbits * j) + bn_v res1) / pow2 (pbits * j) % pow2 pbits;
-    (==) { Math.Lemmas.division_addition_lemma (bn_v res1) (pow2 (pbits * j)) (v c1 * pow2 (pbits * nLen)) }
+    == { Math.Lemmas.division_addition_lemma (bn_v res1) (pow2 (pbits * j)) (v c1 * pow2 (pbits * nLen)) }
     (v c1 * pow2 (pbits * nLen) + bn_v res1 / pow2 (pbits * j)) % pow2 pbits;
-    (==) { Math.Lemmas.pow2_plus (pbits * (nLen - 1)) pbits }
+    == { Math.Lemmas.pow2_plus (pbits * (nLen - 1)) pbits }
     (v c1 * pow2 (pbits * (nLen - 1)) * pow2 pbits + bn_v res1 / pow2 (pbits * j)) % pow2 pbits;
-    (==) { Math.Lemmas.modulo_addition_lemma (bn_v res1 / pow2 (pbits * j)) (pow2 pbits) (v c1 * pow2 (pbits * (nLen - 1))) }
+    == { Math.Lemmas.modulo_addition_lemma (bn_v res1 / pow2 (pbits * j)) (pow2 pbits) (v c1 * pow2 (pbits * (nLen - 1))) }
     (bn_v res1 / pow2 (pbits * j)) % pow2 pbits;
     }
 
@@ -363,11 +363,11 @@ let bn_mont_reduction_loop_div_r_lemma #t #nLen n mu res0 =
 
   calc (==) { // resM / r =
     (v c0 * pow2 (pbits * resLen) + bn_v res1) / r;
-    (==) { Math.Lemmas.pow2_plus (pbits * nLen) (pbits * nLen) }
+    == { Math.Lemmas.pow2_plus (pbits * nLen) (pbits * nLen) }
     (v c0 * r * r + bn_v res1) / r;
-    (==) { Math.Lemmas.division_addition_lemma (bn_v res1) (r) (v c0 * r) }
+    == { Math.Lemmas.division_addition_lemma (bn_v res1) (r) (v c0 * r) }
     v c0 * r + bn_v res1 / r;
-    (==) { }
+    == { }
     v c0 * r + bn_v res2;
     };
   assert (resM / r == v c0 * r + bn_v res2)

--- a/code/bignum/Hacl.Spec.Bignum.Multiplication.fst
+++ b/code/bignum/Hacl.Spec.Bignum.Multiplication.fst
@@ -135,23 +135,23 @@ let bn_mul1_lemma_loop_step #t #aLen a l i (c1, res1) =
 
   calc (==) {
     v c * b2 + bn_v #t #i res;
-    (==) { bn_eval_snoc #t #(i - 1) res1 e }
+    == { bn_eval_snoc #t #(i - 1) res1 e }
     v c * b2 + bn_v #t #(i - 1) res1 + v e * b1;
-    (==) { }
+    == { }
     v c * b2 + eval_ aLen a (i - 1) * v l -(v e + v c * pow2 pbits - v a.[i - 1] * v l) * b1 + v e * b1;
-    (==) { Math.Lemmas.distributivity_add_left (v e) (v c * pow2 pbits - v a.[i - 1] * v l) b1 }
+    == { Math.Lemmas.distributivity_add_left (v e) (v c * pow2 pbits - v a.[i - 1] * v l) b1 }
     v c * b2 + eval_ aLen a (i - 1) * v l - (v c * pow2 pbits - v a.[i - 1] * v l) * b1;
-    (==) { Math.Lemmas.distributivity_sub_left (v c * pow2 pbits) (v a.[i - 1] * v l) b1 }
+    == { Math.Lemmas.distributivity_sub_left (v c * pow2 pbits) (v a.[i - 1] * v l) b1 }
     v c * b2 + eval_ aLen a (i - 1) * v l - v c * pow2 pbits * b1 + v a.[i - 1] * v l * b1;
-    (==) { Math.Lemmas.paren_mul_right (v c) (pow2 pbits) b1; Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
+    == { Math.Lemmas.paren_mul_right (v c) (pow2 pbits) b1; Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
     eval_ aLen a (i - 1) * v l + v a.[i - 1] * v l * b1;
-    (==) { Math.Lemmas.paren_mul_right (v a.[i - 1]) (v l) b1 }
+    == { Math.Lemmas.paren_mul_right (v a.[i - 1]) (v l) b1 }
     eval_ aLen a (i - 1) * v l + v a.[i - 1] * (b1 * v l);
-    (==) { Math.Lemmas.paren_mul_right (v a.[i - 1]) b1 (v l) }
+    == { Math.Lemmas.paren_mul_right (v a.[i - 1]) b1 (v l) }
     eval_ aLen a (i - 1) * v l + v a.[i - 1] * b1 * v l;
-    (==) { Math.Lemmas.distributivity_add_left (eval_ aLen a (i - 1)) (v a.[i - 1] * b1) (v l) }
+    == { Math.Lemmas.distributivity_add_left (eval_ aLen a (i - 1)) (v a.[i - 1] * b1) (v l) }
     (eval_ aLen a (i - 1) + v a.[i - 1] * b1) * v l;
-    (==) { bn_eval_unfold_i a i }
+    == { bn_eval_unfold_i a i }
     eval_ aLen a i * v l;
   };
   assert (v c * b2 + bn_v #t #i res == eval_ aLen a i * v l)
@@ -230,29 +230,29 @@ let bn_mul1_add_in_place_lemma_loop_step #t #aLen a l acc i (c1, res1) =
 
   calc (==) {
     v c * b2 + bn_v #t #i res;
-    (==) { bn_eval_snoc #t #(i - 1) res1 e }
+    == { bn_eval_snoc #t #(i - 1) res1 e }
     v c * b2 + bn_v #t #(i - 1) res1 + v e * b1;
-    (==) { }
+    == { }
     v c * b2 + eval_ aLen acc (i - 1) + eval_ aLen a (i - 1) * v l -
       (v e + v c * pow2 pbits - v a.[i - 1] * v l - v acc.[i - 1]) * b1 + v e * b1;
-    (==) { Math.Lemmas.distributivity_add_left (v e) (v c * pow2 pbits - v a.[i - 1] * v l - v acc.[i - 1]) b1 }
+    == { Math.Lemmas.distributivity_add_left (v e) (v c * pow2 pbits - v a.[i - 1] * v l - v acc.[i - 1]) b1 }
     v c * b2 + eval_ aLen acc (i - 1) + eval_ aLen a (i - 1) * v l - (v c * pow2 pbits - v a.[i - 1] * v l - v acc.[i - 1]) * b1;
-    (==) { Math.Lemmas.distributivity_sub_left (v c * pow2 pbits) (v a.[i - 1] * v l + v acc.[i - 1]) b1 }
+    == { Math.Lemmas.distributivity_sub_left (v c * pow2 pbits) (v a.[i - 1] * v l + v acc.[i - 1]) b1 }
     v c * b2 + eval_ aLen acc (i - 1) + eval_ aLen a (i - 1) * v l - (v c * pow2 pbits) * b1 +
       (v a.[i - 1] * v l + v acc.[i - 1]) * b1;
-    (==) { Math.Lemmas.paren_mul_right (v c) (pow2 pbits) b1; Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
+    == { Math.Lemmas.paren_mul_right (v c) (pow2 pbits) b1; Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
     eval_ aLen acc (i - 1) + eval_ aLen a (i - 1) * v l + (v a.[i - 1] * v l + v acc.[i - 1]) * b1;
-    (==) { Math.Lemmas.distributivity_add_left (v a.[i - 1] * v l) (v acc.[i - 1]) b1 }
+    == { Math.Lemmas.distributivity_add_left (v a.[i - 1] * v l) (v acc.[i - 1]) b1 }
     eval_ aLen acc (i - 1) + eval_ aLen a (i - 1) * v l + v a.[i - 1] * v l * b1 + v acc.[i - 1] * b1;
-    (==) { bn_eval_unfold_i acc i }
+    == { bn_eval_unfold_i acc i }
     eval_ aLen acc i + eval_ aLen a (i - 1) * v l + v a.[i - 1] * v l * b1;
-    (==) { Math.Lemmas.paren_mul_right (v a.[i - 1]) (v l) b1 }
+    == { Math.Lemmas.paren_mul_right (v a.[i - 1]) (v l) b1 }
     eval_ aLen acc i + eval_ aLen a (i - 1) * v l + v a.[i - 1] * (b1 * v l);
-    (==) { Math.Lemmas.paren_mul_right (v a.[i - 1]) b1 (v l) }
+    == { Math.Lemmas.paren_mul_right (v a.[i - 1]) b1 (v l) }
     eval_ aLen acc i + eval_ aLen a (i - 1) * v l + v a.[i - 1] * b1 * v l;
-    (==) { Math.Lemmas.distributivity_add_left (eval_ aLen a (i - 1)) (v a.[i - 1] * b1) (v l) }
+    == { Math.Lemmas.distributivity_add_left (eval_ aLen a (i - 1)) (v a.[i - 1] * b1) (v l) }
     eval_ aLen acc i + (eval_ aLen a (i - 1) + v a.[i - 1] * b1) * v l;
-    (==) { bn_eval_unfold_i a i }
+    == { bn_eval_unfold_i a i }
     eval_ aLen acc i + eval_ aLen a i * v l;
   };
   assert (v c * b2 + bn_v #t #i res == eval_ aLen acc i + eval_ aLen a i * v l)
@@ -338,17 +338,17 @@ let bn_mul1_lshift_add_lemma #t #aLen #resLen a b_j j acc =
 
   calc (==) {
     v c * pow2 (pbits * (aLen + j)) + eval_ resLen res (aLen + j);
-    (==) { Math.Lemmas.pow2_plus (pbits * aLen) (pbits * j) }
+    == { Math.Lemmas.pow2_plus (pbits * aLen) (pbits * j) }
     v c * (pow2 (pbits * aLen) * pow2 (pbits * j)) + eval_ resLen res (aLen + j);
-    (==) { Math.Lemmas.paren_mul_right (v c) (pow2 (pbits * aLen)) (pow2 (pbits * j)) }
+    == { Math.Lemmas.paren_mul_right (v c) (pow2 (pbits * aLen)) (pow2 (pbits * j)) }
     v c * pow2 (pbits * aLen) * pow2 (pbits * j) + eval_ resLen res (aLen + j);
-    (==) { }
+    == { }
     (bn_v res1 + bn_v a * v b_j - bn_v res2) * pow2 (pbits * j) + eval_ resLen res (aLen + j);
-    (==) { }
+    == { }
     (bn_v res1 + bn_v a * v b_j - bn_v res2) * pow2 (pbits * j) + eval_ resLen acc (j + aLen) - pow2 (pbits * j) * bn_v res1 + pow2 (pbits * j) * bn_v res2;
-    (==) { Math.Lemmas.distributivity_add_right (pow2 (pbits * j)) (bn_v res1) (bn_v a * v b_j - bn_v res2) }
+    == { Math.Lemmas.distributivity_add_right (pow2 (pbits * j)) (bn_v res1) (bn_v a * v b_j - bn_v res2) }
     pow2 (pbits * j) * (bn_v a * v b_j - bn_v res2) + eval_ resLen acc (j + aLen) + pow2 (pbits * j) * bn_v res2;
-    (==) { Math.Lemmas.distributivity_sub_right (pow2 (pbits * j)) (bn_v a * v b_j) (bn_v res2) }
+    == { Math.Lemmas.distributivity_sub_right (pow2 (pbits * j)) (bn_v a * v b_j) (bn_v res2) }
     pow2 (pbits * j) * (bn_v a * v b_j) + eval_ resLen acc (j + aLen);
   };
   assert (v c * pow2 (pbits * (aLen + j)) + eval_ resLen res (aLen + j) ==
@@ -399,17 +399,17 @@ let bn_mul_loop_lemma_step #t #aLen #bLen a b i resi1 =
 
   calc (==) {
     eval_ (aLen + bLen) resi (aLen + i);
-    (==) { bn_eval_unfold_i resi (aLen + i) }
+    == { bn_eval_unfold_i resi (aLen + i) }
     eval_ (aLen + bLen) resi (aLen + i - 1) + v resi.[aLen + i - 1] * pow2 (pbits * (aLen + i - 1));
-    (==) { }
+    == { }
     eval_ (aLen + bLen) resi1 (aLen + i - 1) + bn_v a * v b.[i - 1] * (pow2 (pbits * (i - 1)));
-    (==) { }
+    == { }
     bn_v a * eval_ bLen b (i - 1) + bn_v a * v b.[i - 1] * (pow2 (pbits * (i - 1)));
-    (==) { Math.Lemmas.paren_mul_right (bn_v a) (v b.[i - 1]) (pow2 (pbits * (i - 1))) }
+    == { Math.Lemmas.paren_mul_right (bn_v a) (v b.[i - 1]) (pow2 (pbits * (i - 1))) }
     bn_v a * eval_ bLen b (i - 1) + bn_v a * (v b.[i - 1] * (pow2 (pbits * (i - 1))));
-    (==) { Math.Lemmas.distributivity_add_right (bn_v a) (eval_ bLen b (i - 1)) (v b.[i - 1] * (pow2 (pbits * (i - 1)))) }
+    == { Math.Lemmas.distributivity_add_right (bn_v a) (eval_ bLen b (i - 1)) (v b.[i - 1] * (pow2 (pbits * (i - 1)))) }
     bn_v a * (eval_ bLen b (i - 1) + v b.[i - 1] * (pow2 (pbits * (i - 1))));
-    (==) { bn_eval_unfold_i b i }
+    == { bn_eval_unfold_i b i }
     bn_v a * eval_ bLen b i;
   };
   assert (eval_ (aLen + bLen) resi (aLen + i) == bn_v a * eval_ bLen b i)

--- a/code/bignum/Hacl.Spec.Bignum.Squaring.fst
+++ b/code/bignum/Hacl.Spec.Bignum.Squaring.fst
@@ -207,13 +207,13 @@ let bn_sqr_diag_loop_step #t #aLen a i =
 
   calc (==) {
     v acc1.[i + i - 2] * pow2 (pbits * (i + i - 2)) + v acc1.[i + i - 1] * pow2 (pbits * (i + i - 1));
-    (==) { Math.Lemmas.pow2_plus (pbits * (i + i - 2)) pbits }
+    == { Math.Lemmas.pow2_plus (pbits * (i + i - 2)) pbits }
     v acc1.[i + i - 2] * pow2 (pbits * (i + i - 2)) + v acc1.[i + i - 1] * (pow2 (pbits * (i + i - 2)) * pow2 pbits);
-    (==) { Math.Lemmas.paren_mul_right (v acc1.[i + i - 1]) (pow2 pbits) (pow2 (pbits * (i + i - 2))) }
+    == { Math.Lemmas.paren_mul_right (v acc1.[i + i - 1]) (pow2 pbits) (pow2 (pbits * (i + i - 2))) }
     v acc1.[i + i - 2] * pow2 (pbits * (i + i - 2)) + (v acc1.[i + i - 1] * pow2 pbits) * pow2 (pbits * (i + i - 2));
-    (==) { Math.Lemmas.distributivity_add_left (v acc1.[i + i - 2]) (v acc1.[i + i - 1] * pow2 pbits) (pow2 (pbits * (i + i - 2))) }
+    == { Math.Lemmas.distributivity_add_left (v acc1.[i + i - 2]) (v acc1.[i + i - 1] * pow2 pbits) (pow2 (pbits * (i + i - 2))) }
     (v acc1.[i + i - 2] + v acc1.[i + i - 1] * pow2 pbits) * pow2 (pbits * (i + i - 2));
-    (==) { bn_sqr_diag_lemma a i }
+    == { bn_sqr_diag_lemma a i }
     v a.[i - 1] * v a.[i - 1] * pow2 (pbits * (i + i - 2));
   };
 
@@ -312,17 +312,17 @@ let bn_eval_square #t #aLen a i =
 
   calc (==) {
     eval_ aLen a i * eval_ aLen a i;
-    (==) { bn_eval_unfold_i a i }
+    == { bn_eval_unfold_i a i }
     (e1 + v a.[i - 1] * p1) * (e1 + v a.[i - 1] * p1);
-    (==) { square_of_sum e1 (v a.[i - 1] * p1) }
+    == { square_of_sum e1 (v a.[i - 1] * p1) }
     e1 * e1 + 2 * e1 * (v a.[i - 1] * p1) + (v a.[i - 1] * p1) * (v a.[i - 1] * p1);
-    (==) { Math.Lemmas.paren_mul_right (v a.[i - 1]) p1 (v a.[i - 1] * p1); Math.Lemmas.paren_mul_right p1 p1 (v a.[i - 1]) }
+    == { Math.Lemmas.paren_mul_right (v a.[i - 1]) p1 (v a.[i - 1] * p1); Math.Lemmas.paren_mul_right p1 p1 (v a.[i - 1]) }
     e1 * e1 + 2 * e1 * (v a.[i - 1] * p1) + v a.[i - 1] * (p1 * p1 * v a.[i - 1]);
-    (==) { Math.Lemmas.pow2_plus (bits t * (i - 1)) (bits t * (i - 1)) }
+    == { Math.Lemmas.pow2_plus (bits t * (i - 1)) (bits t * (i - 1)) }
     e1 * e1 + 2 * e1 * (v a.[i - 1] * p1) + v a.[i - 1] * (p2 * v a.[i - 1]);
-    (==) { Math.Lemmas.paren_mul_right (v a.[i - 1]) (v a.[i - 1]) p2 }
+    == { Math.Lemmas.paren_mul_right (v a.[i - 1]) (v a.[i - 1]) p2 }
     e1 * e1 + 2 * e1 * (v a.[i - 1] * p1) + v a.[i - 1] * v a.[i - 1] * p2;
-    (==) { Math.Lemmas.paren_mul_right (2 * e1) (v a.[i - 1]) p1 }
+    == { Math.Lemmas.paren_mul_right (2 * e1) (v a.[i - 1]) p1 }
     e1 * e1 + 2 * e1 * v a.[i - 1] * p1 + v a.[i - 1] * v a.[i - 1] * p2;
     }
 
@@ -367,20 +367,20 @@ let rec bn_sqr_loop_lemma #t #aLen a i =
 
     calc (==) {
       2 * eval_ resLen acc (i + i) + eval_ resLen tmp (i + i);
-      (==) { bn_sqr_diag_loop_step a i }
+      == { bn_sqr_diag_loop_step a i }
       2 * eval_ resLen acc (i + i) + eval_ resLen tmp1 (i + i - 2) + v a.[i - 1] * v a.[i - 1] * p2;
-      (==) { bn_eval_unfold_i acc (i + i) }
+      == { bn_eval_unfold_i acc (i + i) }
       2 * (eval_ resLen acc (i + i - 1) + v acc.[i + i - 1] * p1) +
       eval_ (aLen + aLen) tmp1 (i + i - 2) + v a.[i - 1] * v a.[i - 1] * p2;
-      (==) { Classical.forall_intro (bn_sqr_f_lemma a (i - 1) acc1) }
+      == { Classical.forall_intro (bn_sqr_f_lemma a (i - 1) acc1) }
       2 * (eval_ resLen acc1 (i + i - 2) + eval_ aLen a (i - 1) * v a.[i - 1] * p3) +
       eval_ (aLen + aLen) tmp1 (i + i - 2) + v a.[i - 1] * v a.[i - 1] * p2;
-      (==) { Math.Lemmas.distributivity_add_right 2 (eval_ resLen acc1 (i + i - 2)) (eval_ aLen a (i - 1) * v a.[i - 1] * p3) }
+      == { Math.Lemmas.distributivity_add_right 2 (eval_ resLen acc1 (i + i - 2)) (eval_ aLen a (i - 1) * v a.[i - 1] * p3) }
       2 * eval_ resLen acc1 (i + i - 2) + 2 * eval_ aLen a (i - 1) * v a.[i - 1] * p3 +
       eval_ (aLen + aLen) tmp1 (i + i - 2) + v a.[i - 1] * v a.[i - 1] * p2;
-      (==) { bn_sqr_loop_lemma a (i - 1) }
+      == { bn_sqr_loop_lemma a (i - 1) }
       eval_ aLen a (i - 1) * eval_ aLen a (i - 1) + 2 * eval_ aLen a (i - 1) * v a.[i - 1] * p3 + v a.[i - 1] * v a.[i - 1] * p2;
-      (==) { bn_eval_square a i }
+      == { bn_eval_square a i }
       eval_ aLen a i * eval_ aLen a i;
     }; () end
 #pop-options

--- a/code/bignum/Hacl.Spec.Exponentiation.Lemmas.fst
+++ b/code/bignum/Hacl.Spec.Exponentiation.Lemmas.fst
@@ -23,13 +23,13 @@ val lemma_mont_one: n:pos -> r:pos -> d:int{r * d % n = 1} -> a:nat_mod n ->
 let lemma_mont_one n r d a =
   calc (==) {
     a * (1 * r % n) * d % n;
-    (==) { M.lemma_mod_mul_distr3 a r d n }
+    == { M.lemma_mod_mul_distr3 a r d n }
     a * r * d % n;
-    (==) { Math.Lemmas.paren_mul_right a r d; Math.Lemmas.lemma_mod_mul_distr_r a (r * d) n }
+    == { Math.Lemmas.paren_mul_right a r d; Math.Lemmas.lemma_mod_mul_distr_r a (r * d) n }
     a * (r * d % n) % n;
-    (==) { assert (r * d % n = 1) }
+    == { assert (r * d % n = 1) }
     a % n;
-    (==) { Math.Lemmas.small_mod a n }
+    == { Math.Lemmas.small_mod a n }
     a;
     }
 
@@ -38,19 +38,19 @@ val lemma_mont_mul_assoc: n:pos -> d:int -> a:nat_mod n -> b:nat_mod n -> c:nat_
 let lemma_mont_mul_assoc n d a b c =
   calc (==) {
     mont_mul n d (mont_mul n d a b) c;
-    (==) { }
+    == { }
     (a * b * d % n) * c * d % n;
-    (==) { Math.Lemmas.paren_mul_right (a * b * d % n) c d }
+    == { Math.Lemmas.paren_mul_right (a * b * d % n) c d }
     (a * b * d % n) * (c * d) % n;
-    (==) { M.lemma_mod_mul_distr3 1 (a * b * d) (c * d) n }
+    == { M.lemma_mod_mul_distr3 1 (a * b * d) (c * d) n }
     a * b * d * (c * d) % n;
-    (==) { Math.Lemmas.paren_mul_right (a * b * d) c d }
+    == { Math.Lemmas.paren_mul_right (a * b * d) c d }
     a * b * d * c * d % n;
-    (==) { Math.Lemmas.paren_mul_right a b d; Math.Lemmas.paren_mul_right a (b * d) c }
+    == { Math.Lemmas.paren_mul_right a b d; Math.Lemmas.paren_mul_right a (b * d) c }
     a * (b * d * c) * d % n;
-    (==) { Math.Lemmas.paren_mul_right b d c; Math.Lemmas.paren_mul_right b c d }
+    == { Math.Lemmas.paren_mul_right b d c; Math.Lemmas.paren_mul_right b c d }
     a * (b * c * d) * d % n;
-    (==) { M.lemma_mod_mul_distr3 a (b * c * d) d n }
+    == { M.lemma_mod_mul_distr3 a (b * c * d) d n }
     mont_mul n d a (mont_mul n d b c);
     }
 
@@ -76,29 +76,29 @@ let rec pow_nat_mont_is_pow n r d aM b =
   if b = 0 then begin
     calc (==) {
       pow (aM * d % n) b * r % n;
-      (==) { lemma_pow0 (aM * d % n) }
+      == { lemma_pow0 (aM * d % n) }
       1 * r % n;
-      (==) { LE.lemma_pow0 k aM }
+      == { LE.lemma_pow0 k aM }
       LE.pow k aM b;
       }; () end
   else begin
     calc (==) {
       pow (aM * d % n) b * r % n;
-      (==) { lemma_pow_unfold (aM * d % n) b }
+      == { lemma_pow_unfold (aM * d % n) b }
       (aM * d % n) * pow (aM * d % n) (b - 1) * r % n;
-      (==) {
+      == {
         Math.Lemmas.paren_mul_right (aM * d % n) (pow (aM * d % n) (b - 1)) r;
         Math.Lemmas.lemma_mod_mul_distr_r (aM * d % n) (pow (aM * d % n) (b - 1) * r) n }
       (aM * d % n) * (pow (aM * d % n) (b - 1) * r % n) % n;
-      (==) { pow_nat_mont_is_pow n r d aM (b - 1) }
+      == { pow_nat_mont_is_pow n r d aM (b - 1) }
       (aM * d % n) * LE.pow k aM (b - 1) % n;
-      (==) { Math.Lemmas.lemma_mod_mul_distr_l (aM * d) (LE.pow k aM (b - 1)) n }
+      == { Math.Lemmas.lemma_mod_mul_distr_l (aM * d) (LE.pow k aM (b - 1)) n }
       aM * d * LE.pow k aM (b - 1) % n;
-      (==) {
+      == {
         Math.Lemmas.paren_mul_right aM d (LE.pow k aM (b - 1));
         Math.Lemmas.paren_mul_right aM (LE.pow k aM (b - 1)) d }
       aM * LE.pow k aM (b - 1) * d % n;
-      (==) { LE.lemma_pow_unfold k aM b }
+      == { LE.lemma_pow_unfold k aM b }
       LE.pow k aM b;
       }; () end
 
@@ -122,15 +122,15 @@ let mod_exp_mont_lemma n r d a b =
 
   calc (==) { // acc
     LE.pow k aM b * d % n;
-    (==) { pow_nat_mont_is_pow n r d aM b }
+    == { pow_nat_mont_is_pow n r d aM b }
     (pow (aM * d % n) b * r % n) * d % n;
-    (==) { M.lemma_mont_id n r d (pow (aM * d % n) b) }
+    == { M.lemma_mont_id n r d (pow (aM * d % n) b) }
     pow (aM * d % n) b % n;
-    (==) { }
+    == { }
     pow (a * r % n * d % n) b % n;
-    (==) { M.lemma_mont_id n r d a }
+    == { M.lemma_mont_id n r d a }
     pow (a % n) b % n;
-    (==) { Math.Lemmas.small_mod a n }
+    == { Math.Lemmas.small_mod a n }
     pow a b % n;
     };
   assert (mod_exp_mont n r d a b == pow a b % n);
@@ -326,15 +326,15 @@ let from_mont_exp_lemma pbits rLen n mu aM b =
   //assert (c == cM * d % n);
   calc (==) {
     cM * d % n;
-    (==) { pow_nat_mont_ll_is_pow_nat_mont pbits rLen n mu aM b }
+    == { pow_nat_mont_ll_is_pow_nat_mont pbits rLen n mu aM b }
     LE.pow k2 aM b * d % n;
-    (==) { pow_nat_mont_is_pow n r d aM b }
+    == { pow_nat_mont_is_pow n r d aM b }
     pow (aM * d % n) b * r % n * d % n;
-    (==) { M.lemma_mont_id n r d (pow (aM * d % n) b) }
+    == { M.lemma_mont_id n r d (pow (aM * d % n) b) }
     pow (aM * d % n) b % n;
-    (==) { }
+    == { }
     pow a b % n;
-    (==) { Lib.NatMod.lemma_pow_mod #n a b }
+    == { Lib.NatMod.lemma_pow_mod #n a b }
     pow_mod #n a b;
     };
   assert (a < n /\ c == pow_mod #n a b)
@@ -360,14 +360,14 @@ let pow_nat_mont_ll_mod_base pbits rLen n mu a b =
 
   calc (==) {
     LE.pow k2 a b;
-    (==) { pow_nat_mont_ll_is_pow_nat_mont pbits rLen n mu a b }
+    == { pow_nat_mont_ll_is_pow_nat_mont pbits rLen n mu a b }
     LE.pow k1 a b;
-    (==) { pow_nat_mont_is_pow n r d a b }
+    == { pow_nat_mont_is_pow n r d a b }
     pow (a * d % n) b * r % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l a d n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l a d n }
     pow (a % n * d % n) b * r % n;
-    (==) { pow_nat_mont_is_pow n r d (a % n) b }
+    == { pow_nat_mont_is_pow n r d (a % n) b }
     LE.pow k1 (a % n) b;
-    (==) { pow_nat_mont_ll_is_pow_nat_mont pbits rLen n mu (a % n) b }
+    == { pow_nat_mont_ll_is_pow_nat_mont pbits rLen n mu (a % n) b }
     LE.pow k2 (a % n) b;
     }

--- a/code/bignum/Hacl.Spec.Karatsuba.Lemmas.fst
+++ b/code/bignum/Hacl.Spec.Karatsuba.Lemmas.fst
@@ -28,11 +28,11 @@ let lemma_double_p pbits aLen =
   let p = pow2 (aLen / 2 * pbits) in
   calc (==) {
     p * p;
-    (==) { Math.Lemmas.pow2_plus (aLen / 2 * pbits) (aLen / 2 * pbits) }
+    == { Math.Lemmas.pow2_plus (aLen / 2 * pbits) (aLen / 2 * pbits) }
     pow2 (aLen / 2 * pbits + aLen / 2 * pbits);
-    (==) { Math.Lemmas.distributivity_add_left (aLen / 2) (aLen / 2) pbits }
+    == { Math.Lemmas.distributivity_add_left (aLen / 2) (aLen / 2) pbits }
     pow2 ((aLen / 2 * 2) * pbits);
-    (==) { Math.Lemmas.lemma_div_exact aLen 2 }
+    == { Math.Lemmas.lemma_div_exact aLen 2 }
     pow2 (aLen * pbits);
     }
 
@@ -61,52 +61,52 @@ let lemma_middle_karatsuba a0 a1 b0 b1 =
   | (Positive, Positive) ->
     calc (==) { //t45
      t01 - t23;
-     (==) { }
+     == { }
      a0 * b0 + a1 * b1 - (a0 - a1) * (b0 - b1);
-     (==) { Math.Lemmas.distributivity_sub_right (a0 - a1) b0 b1 }
+     == { Math.Lemmas.distributivity_sub_right (a0 - a1) b0 b1 }
      a0 * b0 + a1 * b1 - ((a0 - a1) * b0 - (a0 - a1) * b1);
-     (==) { Math.Lemmas.distributivity_sub_left a0 a1 b0; Math.Lemmas.distributivity_sub_left a0 a1 b1 }
+     == { Math.Lemmas.distributivity_sub_left a0 a1 b0; Math.Lemmas.distributivity_sub_left a0 a1 b1 }
      a0 * b0 + a1 * b1 - (a0 * b0 - a1 * b0 - (a0 * b1 - a1 * b1));
-     (==) { }
+     == { }
      a1 * b0 + a0 * b1;
      }
 
   | (Negative, Negative) ->
     calc (==) { //t45
      t01 - t23;
-     (==) { }
+     == { }
      a0 * b0 + a1 * b1 - (a1 - a0) * (b1 - b0);
-     (==) { Math.Lemmas.distributivity_sub_right (a1 - a0) b1 b0 }
+     == { Math.Lemmas.distributivity_sub_right (a1 - a0) b1 b0 }
      a0 * b0 + a1 * b1 - ((a1 - a0) * b1 - (a1 - a0) * b0);
-     (==) { Math.Lemmas.distributivity_sub_left a1 a0 b1; Math.Lemmas.distributivity_sub_left a1 a0 b0 }
+     == { Math.Lemmas.distributivity_sub_left a1 a0 b1; Math.Lemmas.distributivity_sub_left a1 a0 b0 }
      a0 * b0 + a1 * b1 - (a1 * b1 - a0 * b1 - (a1 * b0 - a0 * b0));
-     (==) { }
+     == { }
      a1 * b0 + a0 * b1;
      }
 
   | (Positive, Negative) ->
     calc (==) { //t45
      t01 + t23;
-     (==) { }
+     == { }
      a0 * b0 + a1 * b1 + (a0 - a1) * (b1 - b0);
-     (==) { Math.Lemmas.distributivity_sub_right (a0 - a1) b1 b0 }
+     == { Math.Lemmas.distributivity_sub_right (a0 - a1) b1 b0 }
      a0 * b0 + a1 * b1 + ((a0 - a1) * b1 - (a0 - a1) * b0);
-     (==) { Math.Lemmas.distributivity_sub_left a0 a1 b1; Math.Lemmas.distributivity_sub_left a0 a1 b0 }
+     == { Math.Lemmas.distributivity_sub_left a0 a1 b1; Math.Lemmas.distributivity_sub_left a0 a1 b0 }
      a0 * b0 + a1 * b1 + (a0 * b1 - a1 * b1 - (a0 * b0 - a1 * b0));
-     (==) { }
+     == { }
      a1 * b0 + a0 * b1;
      }
 
   | (Negative, Positive) ->
     calc (==) { //t45
      t01 + t23;
-     (==) { }
+     == { }
      a0 * b0 + a1 * b1 + (a1 - a0) * (b0 - b1);
-     (==) { Math.Lemmas.distributivity_sub_right (a1 - a0) b0 b1 }
+     == { Math.Lemmas.distributivity_sub_right (a1 - a0) b0 b1 }
      a0 * b0 + a1 * b1 + ((a1 - a0) * b0 - (a1 - a0) * b1);
-     (==) { Math.Lemmas.distributivity_sub_left a1 a0 b0; Math.Lemmas.distributivity_sub_left a1 a0 b1 }
+     == { Math.Lemmas.distributivity_sub_left a1 a0 b0; Math.Lemmas.distributivity_sub_left a1 a0 b1 }
      a0 * b0 + a1 * b1 + (a1 * b0 - a0 * b0 - (a1 * b1 - a0 * b1));
-     (==) { }
+     == { }
      a1 * b0 + a0 * b1;
      }
 
@@ -127,25 +127,25 @@ let lemma_karatsuba pbits aLen a0 a1 b0 b1 =
 
   calc (==) {
     a * b;
-    (==) { }
+    == { }
     (a1 * p + a0) * (b1 * p + b0);
-    (==) { Math.Lemmas.distributivity_add_left (a1 * p) a0 (b1 * p + b0) }
+    == { Math.Lemmas.distributivity_add_left (a1 * p) a0 (b1 * p + b0) }
     a1 * p * (b1 * p + b0) + a0 * (b1 * p + b0);
-    (==) { Math.Lemmas.distributivity_add_right (a1 * p) (b1 * p) b0; Math.Lemmas.distributivity_add_right a0 (b1 * p) b0 }
+    == { Math.Lemmas.distributivity_add_right (a1 * p) (b1 * p) b0; Math.Lemmas.distributivity_add_right a0 (b1 * p) b0 }
     a1 * p * (b1 * p) + a1 * p * b0 + a0 * (b1 * p) + a0 * b0;
-    (==) { Math.Lemmas.paren_mul_right a0 b1 p }
+    == { Math.Lemmas.paren_mul_right a0 b1 p }
     a1 * p * (b1 * p) + a1 * p * b0 + a0 * b1 * p + a0 * b0;
-    (==) {
+    == {
       Math.Lemmas.paren_mul_right a1 p (b1 * p); Math.Lemmas.swap_mul b1 p;
       Math.Lemmas.paren_mul_right p p b1; Math.Lemmas.swap_mul b1 (p * p) }
     a1 * (b1 * (p * p)) + a1 * p * b0 + a0 * b1 * p + a0 * b0;
-    (==) { Math.Lemmas.paren_mul_right a1 b1 (p * p) }
+    == { Math.Lemmas.paren_mul_right a1 b1 (p * p) }
     a1 * b1 * (p * p) + a1 * p * b0 + a0 * b1 * p + a0 * b0;
-    (==) { lemma_double_p pbits aLen }
+    == { lemma_double_p pbits aLen }
     a1 * b1 * pow2 (pbits * aLen) + a1 * p * b0 + a0 * b1 * p + a0 * b0;
-    (==) { Math.Lemmas.paren_mul_right a1 p b0; Math.Lemmas.swap_mul b0 p; Math.Lemmas.paren_mul_right a1 b0 p }
+    == { Math.Lemmas.paren_mul_right a1 p b0; Math.Lemmas.swap_mul b0 p; Math.Lemmas.paren_mul_right a1 b0 p }
     a1 * b1 * pow2 (pbits * aLen) + a1 * b0 * p + a0 * b1 * p + a0 * b0;
-    (==) { Math.Lemmas.distributivity_add_left (a1 * b0) (a0 * b1) p }
+    == { Math.Lemmas.distributivity_add_left (a1 * b0) (a0 * b1) p }
     a1 * b1 * pow2 (pbits * aLen) + (a1 * b0 + a0 * b1) * p + a0 * b0;
    }
 #pop-options

--- a/code/bignum/Hacl.Spec.Montgomery.Lemmas.fst
+++ b/code/bignum/Hacl.Spec.Montgomery.Lemmas.fst
@@ -39,13 +39,13 @@ let eea_pow2_odd_k_lemma a n k1 =
   let k = if n * k1 % pow2 a < pow2 (a - 1) then k1 else k1 + pow2 (a - 1) in
   calc (==) {
     n * k1;
-    (==) { Math.Lemmas.euclidean_division_definition (n * k1) (pow2 (a - 1)) }
+    == { Math.Lemmas.euclidean_division_definition (n * k1) (pow2 (a - 1)) }
     1 + d * pow2 (a - 1);
-    (==) { Math.Lemmas.euclidean_division_definition d 2 }
+    == { Math.Lemmas.euclidean_division_definition d 2 }
     1 + (d / 2 * 2 + d % 2) * pow2 (a - 1);
-    (==) { Math.Lemmas.distributivity_add_left (d / 2 * 2) (d % 2) (pow2 (a - 1)) }
+    == { Math.Lemmas.distributivity_add_left (d / 2 * 2) (d % 2) (pow2 (a - 1)) }
     1 + d / 2 * 2 * pow2 (a - 1) + d % 2 * pow2 (a - 1);
-    (==) { Math.Lemmas.pow2_plus 1 (a - 1) }
+    == { Math.Lemmas.pow2_plus 1 (a - 1) }
     1 + d / 2 * pow2 a + d % 2 * pow2 (a - 1);
   };
 
@@ -55,11 +55,11 @@ let eea_pow2_odd_k_lemma a n k1 =
     assert (d % 2 = 0);
     calc (==) {
       n * k % pow2 a;
-      (==) { }
+      == { }
       (1 + d / 2 * pow2 a) % pow2 a;
-      (==) { Math.Lemmas.modulo_addition_lemma 1 (pow2 a) (d / 2) }
+      == { Math.Lemmas.modulo_addition_lemma 1 (pow2 a) (d / 2) }
       1 % pow2 a;
-      (==) { Math.Lemmas.pow2_le_compat a 1; Math.Lemmas.small_mod 1 (pow2 a) }
+      == { Math.Lemmas.pow2_le_compat a 1; Math.Lemmas.small_mod 1 (pow2 a) }
       1;
     };
     assert (n * k % pow2 a = 1);
@@ -71,23 +71,23 @@ let eea_pow2_odd_k_lemma a n k1 =
     //assert (n * k == 1 + d / 2 * pow2 a + pow2 (a - 1) + n * pow2 (a - 1));
     calc (==) {
       n * k % pow2 a;
-      (==) { Math.Lemmas.distributivity_add_right n k1 (pow2 (a - 1)) }
+      == { Math.Lemmas.distributivity_add_right n k1 (pow2 (a - 1)) }
       (n * k1 + n * pow2 (a - 1)) % pow2 a;
-      (==) { }
+      == { }
       (1 + pow2 (a - 1) + n * pow2 (a - 1) + d / 2 * pow2 a) % pow2 a;
-      (==) { Math.Lemmas.modulo_addition_lemma (1 + pow2 (a - 1) + n * pow2 (a - 1)) (pow2 a) (d / 2) }
+      == { Math.Lemmas.modulo_addition_lemma (1 + pow2 (a - 1) + n * pow2 (a - 1)) (pow2 a) (d / 2) }
       (1 + pow2 (a - 1) + n * pow2 (a - 1)) % pow2 a;
-      (==) { Math.Lemmas.distributivity_add_left 1 n (pow2 (a - 1)) }
+      == { Math.Lemmas.distributivity_add_left 1 n (pow2 (a - 1)) }
       (1 + (1 + n) * pow2 (a - 1)) % pow2 a;
-      (==) { Math.Lemmas.lemma_div_exact (1 + n) 2 }
+      == { Math.Lemmas.lemma_div_exact (1 + n) 2 }
       (1 + (1 + n) / 2 * 2 * pow2 (a - 1)) % pow2 a;
-      (==) { Math.Lemmas.paren_mul_right ((1 + n) / 2) 2 (pow2 (a - 1)) }
+      == { Math.Lemmas.paren_mul_right ((1 + n) / 2) 2 (pow2 (a - 1)) }
       (1 + (1 + n) / 2 * (2 * pow2 (a - 1))) % pow2 a;
-      (==) { Math.Lemmas.pow2_plus 1 (a - 1)}
+      == { Math.Lemmas.pow2_plus 1 (a - 1)}
       (1 + (1 + n) / 2 * pow2 a) % pow2 a;
-      (==) { Math.Lemmas.modulo_addition_lemma 1 (pow2 a) ((1 + n) / 2) }
+      == { Math.Lemmas.modulo_addition_lemma 1 (pow2 a) ((1 + n) / 2) }
       1 % pow2 a;
-      (==) { Math.Lemmas.pow2_le_compat a 1; Math.Lemmas.small_mod 1 (pow2 a) }
+      == { Math.Lemmas.pow2_le_compat a 1; Math.Lemmas.small_mod 1 (pow2 a) }
       1;
     };
     assert (n * k % pow2 a == 1);
@@ -152,11 +152,11 @@ let mont_preconditions_d pbits rLen n =
   let d, k = eea_pow2_odd (pbits * rLen) n in
   calc (==) {
     pow2 (pbits * rLen) * d % n;
-    (==) { }
+    == { }
     (1 + k * n) % n;
-    (==) { Math.Lemmas.modulo_addition_lemma 1 n k }
+    == { Math.Lemmas.modulo_addition_lemma 1 n k }
     1 % n;
-    (==) { Math.Lemmas.small_mod 1 n }
+    == { Math.Lemmas.small_mod 1 n }
     1;
   };
   assert (pow2 (pbits * rLen) * d % n == 1)
@@ -169,13 +169,13 @@ val mont_preconditions_n0: pbits:pos -> n:pos{n > 1} -> mu:nat -> Lemma
 let mont_preconditions_n0 pbits n mu =
   calc (==) {
     (1 + n * mu) % pow2 pbits;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r 1 (n * mu) (pow2 pbits) }
+    == { Math.Lemmas.lemma_mod_plus_distr_r 1 (n * mu) (pow2 pbits) }
     (1 + n * mu % pow2 pbits) % pow2 pbits;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l n mu (pow2 pbits) }
+    == { Math.Lemmas.lemma_mod_mul_distr_l n mu (pow2 pbits) }
     (1 + n % pow2 pbits * mu % pow2 pbits) % pow2 pbits;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r 1 (n % pow2 pbits * mu) (pow2 pbits) }
+    == { Math.Lemmas.lemma_mod_plus_distr_r 1 (n % pow2 pbits * mu) (pow2 pbits) }
     (1 + n % pow2 pbits * mu) % pow2 pbits;
-    (==) { assert ((1 + (n % pow2 pbits) * mu) % pow2 pbits == 0) }
+    == { assert ((1 + (n % pow2 pbits) * mu) % pow2 pbits == 0) }
     0;
   };
   assert ((1 + n * mu) % pow2 pbits == 0)
@@ -252,23 +252,23 @@ let mont_reduction_lemma_step_bound_aux pbits n q_i i c res0 =
 
   calc (<=) {
     res0 + n * q_i * b1;
-    (<=) { Math.Lemmas.lemma_mult_le_right b1 q_i (pow2 pbits - 1) }
+    <= { Math.Lemmas.lemma_mult_le_right b1 q_i (pow2 pbits - 1) }
     res0 + n * (pow2 pbits - 1) * b1;
-    (==) { Math.Lemmas.paren_mul_right n (pow2 pbits - 1) b1 }
+    == { Math.Lemmas.paren_mul_right n (pow2 pbits - 1) b1 }
     res0 + n * ((pow2 pbits - 1) * b1);
-    (==) { Math.Lemmas.distributivity_sub_left (pow2 pbits) 1 b1 }
+    == { Math.Lemmas.distributivity_sub_left (pow2 pbits) 1 b1 }
     res0 + n * (pow2 pbits * b1 - b1);
-    (==) { Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
+    == { Math.Lemmas.pow2_plus pbits (pbits * (i - 1)) }
     res0 + n * (b - b1);
-    (==) { Math.Lemmas.distributivity_sub_right n b b1 }
+    == { Math.Lemmas.distributivity_sub_right n b b1 }
     res0 + n * b - n * b1;
-    (<=) { }
+    <= { }
     c + (b1 - 1) * n + n * b - n * b1;
-    (==) { Math.Lemmas.distributivity_sub_left b1 1 n }
+    == { Math.Lemmas.distributivity_sub_left b1 1 n }
     c + b1 * n - n + n * b - n * b1;
-    (==) { }
+    == { }
     c - n + b * n;
-    (==) { Math.Lemmas.distributivity_sub_left b 1 n }
+    == { Math.Lemmas.distributivity_sub_left b 1 n }
     c + (b - 1) * n;
   }
 
@@ -296,21 +296,21 @@ let mont_reduction_lemma_step_mod_pbits pbits n mu c_i =
   let q_i = mu * c_i % r in
   calc (==) {
     (c_i + n * q_i) % r;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r c_i (n * q_i) r }
+    == { Math.Lemmas.lemma_mod_plus_distr_r c_i (n * q_i) r }
     (c_i + n * q_i % r) % r;
-    (==) { }
+    == { }
     (c_i + n * (mu * c_i % r) % r) % r;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r n (mu * c_i) r }
+    == { Math.Lemmas.lemma_mod_mul_distr_r n (mu * c_i) r }
     (c_i + n * (mu * c_i) % r) % r;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r c_i (n * (mu * c_i)) r }
+    == { Math.Lemmas.lemma_mod_plus_distr_r c_i (n * (mu * c_i)) r }
     (c_i + n * (mu * c_i)) % r;
-    (==) { Math.Lemmas.paren_mul_right n mu c_i }
+    == { Math.Lemmas.paren_mul_right n mu c_i }
     (c_i + n * mu * c_i) % r;
-    (==) { Math.Lemmas.distributivity_add_left 1 (n * mu) c_i }
+    == { Math.Lemmas.distributivity_add_left 1 (n * mu) c_i }
     ((1 + n * mu) * c_i) % r;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (1 + n * mu) c_i r }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (1 + n * mu) c_i r }
     ((1 + n * mu) % r * c_i) % r;
-    (==) { assert ((1 + n * mu) % r = 0) }
+    == { assert ((1 + n * mu) % r = 0) }
     0;
   }
 
@@ -326,11 +326,11 @@ let mont_reduction_lemma_step_modr_aux pbits n q_i i res0 =
 
   calc (==) {
     (res0 / b1 * b1 + n * q_i * b1) % pow2 (pbits * i);
-    (==) { Math.Lemmas.distributivity_add_left (res0 / b1) (n * q_i) b1 }
+    == { Math.Lemmas.distributivity_add_left (res0 / b1) (n * q_i) b1 }
     (res0 / b1 + n * q_i) * b1 % pow2 (pbits * i);
-    (==) { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (res0 / b1 + n * q_i) (pbits * i) (pbits * (i - 1)) }
+    == { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (res0 / b1 + n * q_i) (pbits * i) (pbits * (i - 1)) }
     (res0 / b1 + n * q_i) % pow2 pbits * b1;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l (res0 / b1) (n * q_i) (pow2 pbits) }
+    == { Math.Lemmas.lemma_mod_plus_distr_l (res0 / b1) (n * q_i) (pow2 pbits) }
     (res0 / b1 % pow2 pbits + n * q_i) % pow2 pbits * b1;
     }
 
@@ -412,9 +412,9 @@ let mont_reduction_loop_div_r_fits_lemma pbits rLen n mu c =
 
   calc (==) {
     (c + (r - 1) * n) / r;
-    (==) { Math.Lemmas.distributivity_sub_left r 1 n }
+    == { Math.Lemmas.distributivity_sub_left r 1 n }
     (c - n + r * n) / r;
-    (==) { Math.Lemmas.division_addition_lemma (c - n) r n }
+    == { Math.Lemmas.division_addition_lemma (c - n) r n }
     (c - n) / r + n;
     };
   assert (res / r <= (c - n) / r + n)
@@ -433,19 +433,19 @@ let mont_reduction_loop_div_r_eval_lemma pbits rLen n d mu c =
   assert (res % n == c % n /\ res % r == 0 /\ res <= c + (r - 1) * n);
   calc (==) {
     res / r % n;
-    (==) { assert (r * d % n == 1) }
+    == { assert (r * d % n == 1) }
     res / r * (r * d % n) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (res / r) (r * d) n }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (res / r) (r * d) n }
     res / r * (r * d) % n;
-    (==) { Math.Lemmas.paren_mul_right (res / r) r d }
+    == { Math.Lemmas.paren_mul_right (res / r) r d }
     res / r * r * d % n;
-    (==) { Math.Lemmas.div_exact_r res r }
+    == { Math.Lemmas.div_exact_r res r }
     res * d % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l res d n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l res d n }
     res % n * d % n;
-    (==) { assert (res % n == c % n) }
+    == { assert (res % n == c % n) }
     c % n * d % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l c d n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l c d n }
     c * d % n;
   };
   assert (res / r % n == c * d % n)
@@ -528,13 +528,13 @@ val lemma_mod_mul_distr3: a:int -> b:int -> c:int -> n:pos -> Lemma
 let lemma_mod_mul_distr3 a b c n =
   calc (==) {
     a * (b % n) * c % n;
-    (==) { }
+    == { }
     (b % n) * a * c % n;
-    (==) { Math.Lemmas.paren_mul_right (b % n) a c }
+    == { Math.Lemmas.paren_mul_right (b % n) a c }
     (b % n) * (a * c) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l b (a * c) n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l b (a * c) n }
     b * (a * c) % n;
-    (==) { Math.Lemmas.paren_mul_right b a c }
+    == { Math.Lemmas.paren_mul_right b a c }
     a * b * c % n;
   }
 
@@ -560,20 +560,20 @@ let to_mont_eval_lemma pbits rLen n mu a =
   let c = a * r2 in
   calc (==) {
     c * d % n;
-    (==) { }
+    == { }
     a * r2 * d % n;
-    (==) { Math.Lemmas.paren_mul_right 2 pbits rLen;
+    == { Math.Lemmas.paren_mul_right 2 pbits rLen;
            Math.Lemmas.pow2_plus (pbits * rLen) (pbits * rLen) }
     a * (r * r % n) * d % n;
-    (==) { lemma_mod_mul_distr3 a (r * r) d n }
+    == { lemma_mod_mul_distr3 a (r * r) d n }
     a * (r * r) * d % n;
-    (==) { Math.Lemmas.paren_mul_right a r r }
+    == { Math.Lemmas.paren_mul_right a r r }
     a * r * r * d % n;
-    (==) { Math.Lemmas.paren_mul_right (a * r) r d }
+    == { Math.Lemmas.paren_mul_right (a * r) r d }
     a * r * (r * d) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (a * r) (r * d) n }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (a * r) (r * d) n }
     a * r * (r * d % n) % n;
-    (==) { assert (r * d % n == 1) }
+    == { assert (r * d % n == 1) }
     a * r % n;
     };
   assert (c * d % n == a * r % n)
@@ -626,11 +626,11 @@ val lemma_mont_id: n:pos -> r:pos -> d:int{r * d % n == 1} -> a:nat ->
 let lemma_mont_id n r d a =
   calc (==) {
     a * r % n * d % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (a * r) d n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (a * r) d n }
     a * r * d % n;
-    (==) { Math.Lemmas.paren_mul_right a r d; Math.Lemmas.lemma_mod_mul_distr_r a (r * d) n }
+    == { Math.Lemmas.paren_mul_right a r d; Math.Lemmas.lemma_mod_mul_distr_r a (r * d) n }
     a * (r * d % n) % n;
-    (==) { assert (r * d % n == 1) }
+    == { assert (r * d % n == 1) }
     a % n;
   }
 
@@ -641,13 +641,13 @@ val lemma_mont_id1: n:pos -> r:pos -> d:int{r * d % n = 1} -> a:nat ->
 let lemma_mont_id1 n r d a =
   calc (==) {
     ((a * d % n) * r) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (a * d) r n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (a * d) r n }
     ((a * d) * r) % n;
-    (==) { Math.Lemmas.paren_mul_right a d r }
+    == { Math.Lemmas.paren_mul_right a d r }
     (a * (d * r)) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r a (d * r) n }
+    == { Math.Lemmas.lemma_mod_mul_distr_r a (d * r) n }
     (a * (d * r % n)) % n;
-    (==) { assert (r * d % n = 1) }
+    == { assert (r * d % n = 1) }
     a % n;
   };
   assert (a * d % n * r % n == a % n)
@@ -662,11 +662,11 @@ let lemma_mont_mul_one n r d a =
 
   calc (==) {
     r1 * r0 * d % n;
-    (==) { Math.Lemmas.paren_mul_right r1 r0 d; Math.Lemmas.lemma_mod_mul_distr_r r1 (r0 * d) n }
+    == { Math.Lemmas.paren_mul_right r1 r0 d; Math.Lemmas.lemma_mod_mul_distr_r r1 (r0 * d) n }
     r1 * (r0 * d % n) % n;
-    (==) { lemma_mont_id n r d 1 }
+    == { lemma_mont_id n r d 1 }
     r1 * (1 % n) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r r1 1 n }
+    == { Math.Lemmas.lemma_mod_mul_distr_r r1 1 n }
     r1 % n;
     }
 
@@ -696,13 +696,13 @@ let from_mont_add_lemma pbits rLen n mu aM bM =
 
   calc (==) { //c
     cM * d % n;
-    (==) { }
+    == { }
     (aM + bM) % n * d % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (aM + bM) d n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (aM + bM) d n }
     (aM + bM) * d % n;
-    (==) { Math.Lemmas.distributivity_add_left aM bM d }
+    == { Math.Lemmas.distributivity_add_left aM bM d }
     (aM * d + bM * d) % n;
-    (==) { Math.Lemmas.modulo_distributivity (aM * d) (bM * d) n }
+    == { Math.Lemmas.modulo_distributivity (aM * d) (bM * d) n }
     (aM * d % n + bM * d % n) % n;
     };
 
@@ -735,15 +735,15 @@ let from_mont_sub_lemma pbits rLen n mu aM bM =
 
   calc (==) { //c
     cM * d % n;
-    (==) { }
+    == { }
     (aM - bM) % n * d % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (aM - bM) d n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (aM - bM) d n }
     (aM - bM) * d % n;
-    (==) { Math.Lemmas.distributivity_sub_left aM bM d }
+    == { Math.Lemmas.distributivity_sub_left aM bM d }
     (aM * d - bM * d) % n;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l (aM * d) (- bM * d) n }
+    == { Math.Lemmas.lemma_mod_plus_distr_l (aM * d) (- bM * d) n }
     (aM * d % n - bM * d) % n;
-    (==) { Math.Lemmas.lemma_mod_sub_distr (aM * d % n) (bM * d) n }
+    == { Math.Lemmas.lemma_mod_sub_distr (aM * d % n) (bM * d) n }
     (aM * d % n - bM * d % n) % n;
     };
 
@@ -778,20 +778,20 @@ let from_mont_mul_lemma pbits rLen n mu aM bM =
 
   calc (==) { //c
     cM * d % n;
-    (==) { }
+    == { }
     (aM * bM * d % n) * d % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (aM * bM * d) d n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (aM * bM * d) d n }
     aM * bM * d * d % n;
-    (==) { Math.Lemmas.paren_mul_right aM bM d }
+    == { Math.Lemmas.paren_mul_right aM bM d }
     aM * (bM * d) * d % n;
-    (==) {
+    == {
       Math.Lemmas.paren_mul_right aM (bM * d) d;
       Math.Lemmas.swap_mul (bM * d) d;
       Math.Lemmas.paren_mul_right aM d (bM * d) }
     aM * d * (bM * d) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (aM * d) (bM * d) n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (aM * d) (bM * d) n }
     (aM * d % n) * (bM * d) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (aM * d % n) (bM * d) n }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (aM * d % n) (bM * d) n }
     (aM * d % n) * (bM * d % n) % n;
     };
 

--- a/code/bignum/Hacl.Spec.PrecompBaseTable.fst
+++ b/code/bignum/Hacl.Spec.PrecompBaseTable.fst
@@ -137,15 +137,15 @@ let precomp_base_table_step_g_i #t #a_t #len #ctx_len k g n g_i_acc1 =
   assert (k.concr_ops.SE.to.SE.refl g_i1 == pow_base k g n);
   calc (==) {
     refl g_i;
-    (==) { }
+    == { }
     refl (k.concr_ops.SE.mul g_i1 g);
-    (==) { }
+    == { }
     k.concr_ops.SE.to.SE.comm_monoid.LE.mul (refl g_i1) (refl g);
-    (==) { }
+    == { }
     k.concr_ops.SE.to.SE.comm_monoid.LE.mul (pow_base k g n) (refl g);
-    (==) { k.concr_ops.SE.to.SE.comm_monoid.LE.lemma_mul_comm (pow_base k g n) (refl g) }
+    == { k.concr_ops.SE.to.SE.comm_monoid.LE.lemma_mul_comm (pow_base k g n) (refl g) }
     k.concr_ops.SE.to.SE.comm_monoid.LE.mul (refl g) (pow_base k g n);
-    (==) { LE.lemma_pow_unfold k.concr_ops.SE.to.SE.comm_monoid (refl g) (n + 1) }
+    == { LE.lemma_pow_unfold k.concr_ops.SE.to.SE.comm_monoid (refl g) (n + 1) }
     pow_base k g (n + 1);
   };
   assert (refl g_i == pow_base k g (n + 1))

--- a/code/bignum/Hacl.Spec.PrecompBaseTable256.fst
+++ b/code/bignum/Hacl.Spec.PrecompBaseTable256.fst
@@ -14,11 +14,11 @@ module BD = Hacl.Spec.Bignum.Definitions
 let lemma_mod_pow2_sub x a b =
   calc (==) {
     x / pow2 a % pow2 b * pow2 a;
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 x a (a + b) }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 x a (a + b) }
     x % pow2 (a + b) / pow2 a * pow2 a;
-    (==) { Math.Lemmas.euclidean_division_definition (x % pow2 (a + b)) (pow2 a) }
+    == { Math.Lemmas.euclidean_division_definition (x % pow2 (a + b)) (pow2 a) }
     x % pow2 (a + b) - x % pow2 (a + b) % pow2 a;
-    (==) { Math.Lemmas.pow2_modulo_modulo_lemma_1 x a (a + b) }
+    == { Math.Lemmas.pow2_modulo_modulo_lemma_1 x a (a + b) }
     x % pow2 (a + b) - x % pow2 a;
   }
 
@@ -34,13 +34,13 @@ let lemma_decompose_nat256_as_four_u64 x =
   assert (x3 == x3');
   calc (==) {
     x0 + x1 * pow2 64 + x2 * pow2 128 + x3 * pow2 192;
-    (==) { }
+    == { }
     x0 + x1 * pow2 64 + (x / pow2 128 % pow2 64) * pow2 128 + x / pow2 192 * pow2 192;
-    (==) { lemma_mod_pow2_sub x 128 64 }
+    == { lemma_mod_pow2_sub x 128 64 }
     x0 + x1 * pow2 64 + x % pow2 192 - x % pow2 128 + x / pow2 192 * pow2 192;
-    (==) { Math.Lemmas.euclidean_division_definition x (pow2 192) }
+    == { Math.Lemmas.euclidean_division_definition x (pow2 192) }
     x0 + x1 * pow2 64 - x % pow2 128 + x;
-    (==) { lemma_mod_pow2_sub x 64 64 }
+    == { lemma_mod_pow2_sub x 64 64 }
     x;
   }
 
@@ -54,39 +54,39 @@ let lemma_point_mul_base_precomp4 #t k a b =
 
   calc (==) {
     LE.exp_four_fw k a 64 b0 a_pow2_64 b1 a_pow2_128 b2 a_pow2_192 b3 4;
-    (==) { LE.exp_four_fw_lemma k a 64 b0 a_pow2_64 b1 a_pow2_128 b2 a_pow2_192 b3 4 }
+    == { LE.exp_four_fw_lemma k a 64 b0 a_pow2_64 b1 a_pow2_128 b2 a_pow2_192 b3 4 }
     k.LE.mul
       (k.LE.mul
         (k.LE.mul (LE.pow k a b0) (LE.pow k (LE.pow k a (pow2 64)) b1))
         (LE.pow k a_pow2_128 b2))
       (LE.pow k a_pow2_192 b3);
-    (==) { LE.lemma_pow_mul k a (pow2 64) b1 }
+    == { LE.lemma_pow_mul k a (pow2 64) b1 }
     k.LE.mul
       (k.LE.mul
         (k.LE.mul (LE.pow k a b0) (LE.pow k a (b1 * pow2 64)))
         (LE.pow k a_pow2_128 b2))
       (LE.pow k a_pow2_192 b3);
-    (==) { LE.lemma_pow_add k a b0 (b1 * pow2 64) }
+    == { LE.lemma_pow_add k a b0 (b1 * pow2 64) }
     k.LE.mul
       (k.LE.mul
         (LE.pow k a (b0 + b1 * pow2 64))
         (LE.pow k (LE.pow k a (pow2 128)) b2))
       (LE.pow k a_pow2_192 b3);
-    (==) { LE.lemma_pow_mul k a (pow2 128) b2 }
+    == { LE.lemma_pow_mul k a (pow2 128) b2 }
     k.LE.mul
       (k.LE.mul (LE.pow k a (b0 + b1 * pow2 64)) (LE.pow k a (b2 * pow2 128)))
       (LE.pow k a_pow2_192 b3);
-    (==) { LE.lemma_pow_add k a (b0 + b1 * pow2 64) (b2 * pow2 128) }
+    == { LE.lemma_pow_add k a (b0 + b1 * pow2 64) (b2 * pow2 128) }
     k.LE.mul
       (LE.pow k a (b0 + b1 * pow2 64 + b2 * pow2 128))
       (LE.pow k (LE.pow k a (pow2 192)) b3);
-    (==) { LE.lemma_pow_mul k a (pow2 192) b3 }
+    == { LE.lemma_pow_mul k a (pow2 192) b3 }
     k.LE.mul
       (LE.pow k a (b0 + b1 * pow2 64 + b2 * pow2 128))
       (LE.pow k a (b3 * pow2 192));
-    (==) { LE.lemma_pow_add k a (b0 + b1 * pow2 64 + b2 * pow2 128) (b3 * pow2 192) }
+    == { LE.lemma_pow_add k a (b0 + b1 * pow2 64 + b2 * pow2 128) (b3 * pow2 192) }
     LE.pow k a (b0 + b1 * pow2 64 + b2 * pow2 128 + b3 * pow2 192);
-    (==) { lemma_decompose_nat256_as_four_u64 b }
+    == { lemma_decompose_nat256_as_four_u64 b }
     LE.pow k a b;
   }
 
@@ -112,15 +112,15 @@ let a_pow2_128_lemma #t k a =
   let refl = k.SE.to.SE.refl in
   calc (==) {
     refl (a_pow2_128 k a);
-    (==) { }
+    == { }
     refl (SE.exp_pow2 k (a_pow2_64 k a) 64);
-    (==) { a_pow2_64_lemma k (a_pow2_64 k a) }
+    == { a_pow2_64_lemma k (a_pow2_64 k a) }
     LE.pow cm (refl (a_pow2_64 k a)) (pow2 64);
-    (==) { a_pow2_64_lemma k a }
+    == { a_pow2_64_lemma k a }
     LE.pow cm (LE.pow cm (refl a) (pow2 64)) (pow2 64);
-    (==) { LE.lemma_pow_mul cm (refl a) (pow2 64) (pow2 64) }
+    == { LE.lemma_pow_mul cm (refl a) (pow2 64) (pow2 64) }
     LE.pow cm (refl a) (pow2 64 * pow2 64);
-    (==) { Math.Lemmas.pow2_plus 64 64 }
+    == { Math.Lemmas.pow2_plus 64 64 }
     LE.pow cm (refl a) (pow2 128);
   }
 
@@ -130,15 +130,15 @@ let a_pow2_192_lemma #t k a =
   let refl = k.SE.to.SE.refl in
   calc (==) {
     refl (a_pow2_192 k a);
-    (==) { }
+    == { }
     refl (SE.exp_pow2 k (a_pow2_128 k a) 64);
-    (==) { a_pow2_64_lemma k (a_pow2_128 k a) }
+    == { a_pow2_64_lemma k (a_pow2_128 k a) }
     LE.pow cm (refl (a_pow2_128 k a)) (pow2 64);
-    (==) { a_pow2_128_lemma k a }
+    == { a_pow2_128_lemma k a }
     LE.pow cm (LE.pow cm (refl a) (pow2 128)) (pow2 64);
-    (==) { LE.lemma_pow_mul cm (refl a) (pow2 128) (pow2 64) }
+    == { LE.lemma_pow_mul cm (refl a) (pow2 128) (pow2 64) }
     LE.pow cm (refl a) (pow2 128 * pow2 64);
-    (==) { Math.Lemmas.pow2_plus 128 64 }
+    == { Math.Lemmas.pow2_plus 128 64 }
     LE.pow cm (refl a) (pow2 192);
   }
 

--- a/code/chacha20/Hacl.Spec.Chacha20.Equiv.fst
+++ b/code/chacha20/Hacl.Spec.Chacha20.Equiv.fst
@@ -345,13 +345,13 @@ let lemma_i_div_w4 w i =
   let bs = w * 4 in
   calc (==) {
     i / bs * bs + i % bs / 4 * 4;
-    (==) { Math.Lemmas.euclidean_division_definition (i % bs) 4 }
+    == { Math.Lemmas.euclidean_division_definition (i % bs) 4 }
     i / bs * bs + i % bs - i % bs % 4;
-    (==) { Math.Lemmas.euclidean_division_definition i bs }
+    == { Math.Lemmas.euclidean_division_definition i bs }
     i - i % bs % 4;
-    (==) { Math.Lemmas.modulo_modulo_lemma i 4 w }
+    == { Math.Lemmas.modulo_modulo_lemma i 4 w }
     i - i % 4;
-    (==) { Math.Lemmas.euclidean_division_definition i 4 }
+    == { Math.Lemmas.euclidean_division_definition i 4 }
     i / 4 * 4;
     }
 
@@ -360,13 +360,13 @@ val lemma_i_div_blocksize: w:pos -> i:nat{i < w * blocksize} ->
 let lemma_i_div_blocksize w i =
   calc (==) {
     i / blocksize * blocksize + i % blocksize / 4 * 4;
-    (==) { Math.Lemmas.euclidean_division_definition (i % blocksize) 4 }
+    == { Math.Lemmas.euclidean_division_definition (i % blocksize) 4 }
     i / blocksize * blocksize + i % blocksize - i % blocksize % 4;
-    (==) { Math.Lemmas.modulo_modulo_lemma i 4 16 }
+    == { Math.Lemmas.modulo_modulo_lemma i 4 16 }
     i / blocksize * blocksize + i % blocksize - i % 4;
-    (==) { Math.Lemmas.euclidean_division_definition i blocksize }
+    == { Math.Lemmas.euclidean_division_definition i blocksize }
     i - i % 4;
-    (==) { Math.Lemmas.euclidean_division_definition i 4 }
+    == { Math.Lemmas.euclidean_division_definition i 4 }
     i / 4 * 4;
   }
 
@@ -391,17 +391,17 @@ let xor_block_vec_lemma_i #w k b i =
 
   calc (==) {
     Seq.index (xor_block k b) i;
-    (==) { index_map_blocks_multi (w * 4) 16 16 b (xor_block_f #w k) i }
+    == { index_map_blocks_multi (w * 4) 16 16 b (xor_block_f #w k) i }
     Seq.index (uints_to_bytes_le ob) (i % bs);
-    (==) { index_uints_to_bytes_le ob (i % bs) }
+    == { index_uints_to_bytes_le ob (i % bs) }
     Seq.index (uint_to_bytes_le ob.[i % bs / 4]) (i % bs % 4);
-    (==) { Math.Lemmas.modulo_modulo_lemma i 4 w }
+    == { Math.Lemmas.modulo_modulo_lemma i 4 w }
     Seq.index (uint_to_bytes_le ob.[i % bs / 4]) (i % 4);
-    (==) { (* def of xor *) }
+    == { (* def of xor *) }
     Seq.index (uint_to_bytes_le ((uints_from_bytes_le #U32 #SEC #w b_j).[i % bs / 4] ^. kb_j.[i % bs / 4])) (i % 4);
-    (==) { index_uints_from_bytes_le #U32 #SEC #w b_j (i % bs / 4) }
+    == { index_uints_from_bytes_le #U32 #SEC #w b_j (i % bs / 4) }
     Seq.index (uint_to_bytes_le ((uint_from_bytes_le b_i) ^. kb_j.[i % bs / 4])) (i % 4);
-    (==) { lemma_i_div_w4 w i; Seq.slice_slice b (j * bs) (j * bs + bs) (i % bs / 4 * 4) (i % bs / 4 * 4 + 4) }
+    == { lemma_i_div_w4 w i; Seq.slice_slice b (j * bs) (j * bs + bs) (i % bs / 4 * 4) (i % bs / 4 * 4 + 4) }
     Seq.index (uint_to_bytes_le ((uint_from_bytes_le block) ^. kb_j.[i % bs / 4])) (i % 4);
     }
 
@@ -416,11 +416,11 @@ let xor_block_scalar_lemma_i k b i =
 
   calc (==) {
     Seq.index (uints_to_bytes_le ob) i;
-    (==) { index_uints_to_bytes_le ob i }
+    == { index_uints_to_bytes_le ob i }
     Seq.index (uint_to_bytes_le ob.[i / 4]) (i % 4);
-    (==) { (* def of xor *) }
+    == { (* def of xor *) }
     Seq.index (uint_to_bytes_le (ib.[i / 4] ^. k.[i / 4])) (i % 4);
-    (==) { index_uints_from_bytes_le #U32 #SEC #16 b (i / 4) }
+    == { index_uints_from_bytes_le #U32 #SEC #16 b (i / 4) }
     Seq.index (uint_to_bytes_le ((uint_from_bytes_le b_i) ^. k.[i / 4])) (i % 4);
     }
 
@@ -435,13 +435,13 @@ let transpose_lemma_i #w k i =
   let ki = (transpose_state k).[i / blocksize] in
   calc (==) {
     Seq.index (vec_v (Seq.index (transpose k) j)) (i % bs / 4);
-    (==) { Math.Lemmas.modulo_division_lemma i 4 w }
+    == { Math.Lemmas.modulo_division_lemma i 4 w }
     Seq.index (vec_v (Seq.index (transpose k) j)) (i / 4 % w);
-    (==) { Math.Lemmas.division_multiplication_lemma i 4 w }
+    == { Math.Lemmas.division_multiplication_lemma i 4 w }
     Seq.index (vec_v (Seq.index (transpose k) (i / 4 / w))) (i / 4 % w);
-    (==) { Lemmas.transpose_lemma_index #w k (i / 4); Math.Lemmas.division_multiplication_lemma i 4 16 }
+    == { Lemmas.transpose_lemma_index #w k (i / 4); Math.Lemmas.division_multiplication_lemma i 4 16 }
     Seq.index ki (i / 4 % 16);
-    (==) { Math.Lemmas.modulo_division_lemma i 4 16 }
+    == { Math.Lemmas.modulo_division_lemma i 4 16 }
     Seq.index ki (i % blocksize / 4);
     }
 
@@ -461,17 +461,17 @@ let xor_block_lemma_i #w k b i =
 
   calc (==) {
     Seq.index (xor_block (transpose k) b) i;
-    (==) { xor_block_vec_lemma_i #w (transpose k) b i }
+    == { xor_block_vec_lemma_i #w (transpose k) b i }
     Seq.index (uint_to_bytes_le ((uint_from_bytes_le block) ^. (Seq.index (vec_v (transpose k).[j]) (i % bs / 4)))) (i % 4);
-    (==) { transpose_lemma_i #w k i }
+    == { transpose_lemma_i #w k i }
     Seq.index (uint_to_bytes_le ((uint_from_bytes_le block) ^. (Seq.index ki (i % blocksize / 4)))) (i % 4);
     };
 
   calc (==) {
     Seq.index (Scalar.xor_block ki b_i) (i % blocksize);
-    (==) { xor_block_scalar_lemma_i ki b_i (i % blocksize); Math.Lemmas.modulo_modulo_lemma i 4 16 }
+    == { xor_block_scalar_lemma_i ki b_i (i % blocksize); Math.Lemmas.modulo_modulo_lemma i 4 16 }
     Seq.index (uint_to_bytes_le ((uint_from_bytes_le #U32 #SEC (sub b_i (i % blocksize / 4 * 4) 4)) ^. ki.[i % blocksize / 4])) (i % 4);
-    (==) { lemma_i_div_blocksize w i; Seq.Properties.slice_slice b (i / blocksize * blocksize)
+    == { lemma_i_div_blocksize w i; Seq.Properties.slice_slice b (i / blocksize * blocksize)
             (i / blocksize * blocksize + blocksize) (i % blocksize / 4 * 4) (i % blocksize / 4 * 4 + 4) }
     Seq.index (uint_to_bytes_le ((uint_from_bytes_le #U32 #SEC block) ^. (Seq.index ki (i % blocksize / 4)))) (i % 4);
     }
@@ -631,9 +631,9 @@ let update_sub_get_block_lemma_k #a w blocksize zero len b_v j k =
 
   calc (<=) {
     (j / blocksize + 1) * blocksize;
-    (<=) { div_mul_lt blocksize j (len / blocksize) }
+    <= { div_mul_lt blocksize j (len / blocksize) }
     len / blocksize * blocksize;
-    (<=) { Math.Lemmas.multiply_fractions len blocksize }
+    <= { Math.Lemmas.multiply_fractions len blocksize }
     len;
   };
 
@@ -641,11 +641,11 @@ let update_sub_get_block_lemma_k #a w blocksize zero len b_v j k =
   
   calc (==) {
     Seq.index b_p k;
-    (==) { }
+    == { }
     Seq.index (Seq.slice plain (j / blocksize * blocksize) (j / blocksize * blocksize + blocksize)) k;
-    (==) { Seq.lemma_index_slice plain (j / blocksize * blocksize) (j / blocksize * blocksize + blocksize) k }
+    == { Seq.lemma_index_slice plain (j / blocksize * blocksize) (j / blocksize * blocksize + blocksize) k }
     Seq.index plain (j / blocksize * blocksize + k);
-    (==) { Seq.lemma_index_app1 b_v zeros (j / blocksize * blocksize + k) }
+    == { Seq.lemma_index_app1 b_v zeros (j / blocksize * blocksize + k) }
     Seq.index b_v (j / blocksize * blocksize + k);
     };
 
@@ -711,11 +711,11 @@ let update_sub_get_last_lemma_plain_k #a w blocksize zero len b_v j k =
   if k < len % blocksize then begin
     calc (==) {
       Seq.index plain k;
-      (==) { Seq.lemma_index_app1 block_l zeros k }
+      == { Seq.lemma_index_app1 block_l zeros k }
       Seq.index block_l k;
-      (==) { Seq.lemma_index_slice b_v (len - len % blocksize) len k }
+      == { Seq.lemma_index_slice b_v (len - len % blocksize) len k }
       Seq.index b_v (len - len % blocksize + k);
-      (==) { Math.Lemmas.euclidean_division_definition len blocksize }
+      == { Math.Lemmas.euclidean_division_definition len blocksize }
       Seq.index b_v (len / blocksize * blocksize + k);
       } end
   else ()
@@ -761,11 +761,11 @@ let update_sub_get_last_lemma_plain_v_k #a w blocksize zero len b_v j k =
 
   calc (==) {
     //Seq.index b k;
-    //(==) { }
+    //== { }
     Seq.index (Seq.slice plain_v (j / blocksize * blocksize) (j / blocksize * blocksize + blocksize)) k;
-    (==) { Seq.lemma_index_slice plain_v (j / blocksize * blocksize) (j / blocksize * blocksize + blocksize) k }
+    == { Seq.lemma_index_slice plain_v (j / blocksize * blocksize) (j / blocksize * blocksize + blocksize) k }
     Seq.index plain_v (j / blocksize * blocksize + k);
-    (==) {  }
+    == {  }
     Seq.index plain_v (len / blocksize * blocksize + k);
     }
 
@@ -845,9 +845,9 @@ let chacha20_map_blocks_vec_equiv_pre_k0 #w k n c0 hi_fv rem b_v j =
 
   calc (==) {
     Seq.index (g_v hi_fv rem b_v) j;
-    (==) { encrypt_block_lemma_bs_i #w k n c0 hi_fv plain_v j; div_mul_lt blocksize j w }
+    == { encrypt_block_lemma_bs_i #w k n c0 hi_fv plain_v j; div_mul_lt blocksize j w }
     Seq.index (f (w * hi_fv + j / blocksize) b) (j % blocksize);
-    (==) { update_sub_get_block_lemma w blocksize (u8 0) rem b_v j }
+    == { update_sub_get_block_lemma w blocksize (u8 0) rem b_v j }
     Seq.index (f (w * hi_fv + j / blocksize) b1) (j % blocksize);
     }
 
@@ -890,11 +890,11 @@ let chacha20_map_blocks_vec_equiv_pre_k1 #w k n c0 hi_fv rem b_v j =
 
   calc (==) {
     Seq.index (g_v hi_fv rem b_v) j;
-    (==) { encrypt_block_lemma_bs_i #w k n c0 hi_fv plain_v j; div_mul_lt blocksize j w }
+    == { encrypt_block_lemma_bs_i #w k n c0 hi_fv plain_v j; div_mul_lt blocksize j w }
     Seq.index (f (w * hi_fv + j / blocksize) b) (j % blocksize);
-    (==) { update_sub_get_last_lemma w blocksize (u8 0) rem b_v j; mod_div_lt blocksize j rem }
+    == { update_sub_get_last_lemma w blocksize (u8 0) rem b_v j; mod_div_lt blocksize j rem }
     Seq.index (f (w * hi_fv + j / blocksize) plain) (j % blocksize);
-    (==) { }
+    == { }
     Seq.index (g (w * hi_fv + j / blocksize) (rem % blocksize) b1) (j % blocksize);
     }
 

--- a/code/curve25519/Hacl.Spec.Curve25519.Field64.Core.fst
+++ b/code/curve25519/Hacl.Spec.Curve25519.Field64.Core.fst
@@ -113,17 +113,17 @@ let carry_pass_lemma f cin =
   SD.bn_upd_eval r b1 0;
   calc (==) {
     SD.bn_v out % P.prime;
-    (==) { assert_norm (pow2 0 = 1) }
+    == { assert_norm (pow2 0 = 1) }
     (SD.bn_v r - v r.[0] + v b1) % P.prime;
-    (==) { lemma_add1_carry f cin }
+    == { lemma_add1_carry f cin }
     (SD.bn_v r - v r.[0] + (v r.[0] + v c * 38)) % P.prime;
-    (==) { }
+    == { }
     (SD.bn_v r + v c * 38) % P.prime;
-    (==) { Lemmas.lemma_mul_pow256_add (SD.bn_v r) (v c) }
+    == { Lemmas.lemma_mul_pow256_add (SD.bn_v r) (v c) }
     (SD.bn_v r + v c * pow2 256) % P.prime;
-    (==) { }
+    == { }
     (SD.bn_v f + v cin * 38) % P.prime;
-    (==) { Lemmas.lemma_mul_pow256_add (SD.bn_v f) (v cin) }
+    == { Lemmas.lemma_mul_pow256_add (SD.bn_v f) (v cin) }
     (SD.bn_v f + v cin * pow2 256) % P.prime;
     }
 
@@ -145,15 +145,15 @@ let carry_wide f =
   let out = carry_pass r0 c in
   calc (==) {
     SD.bn_v out % P.prime;
-    (==) { carry_pass_lemma r0 c }
+    == { carry_pass_lemma r0 c }
     (SD.bn_v r0 + v c * pow2 256) % P.prime;
-    (==) { }
+    == { }
     (SD.bn_v (sub f 0 4) + SD.bn_v (sub f 4 4) * 38) % P.prime;
-    (==) { Lemmas.lemma_mul_pow256_add (SD.bn_v (sub f 0 4)) (SD.bn_v (sub f 4 4)) }
+    == { Lemmas.lemma_mul_pow256_add (SD.bn_v (sub f 0 4)) (SD.bn_v (sub f 4 4)) }
     (SD.bn_v (sub f 0 4) + SD.bn_v (sub f 4 4) * pow2 256) % P.prime;
-    (==) { SD.bn_concat_lemma (sub f 0 4) (sub f 4 4) }
+    == { SD.bn_concat_lemma (sub f 0 4) (sub f 4 4) }
     SD.bn_v (concat (sub f 0 4) (sub f 4 4)) % P.prime;
-    (==) { eq_intro f (concat (sub f 0 4) (sub f 4 4)) }
+    == { eq_intro f (concat (sub f 0 4) (sub f 4 4)) }
     SD.bn_v f % P.prime;
   };
   out
@@ -236,13 +236,13 @@ let fsub4 f1 f2 =
   SD.bn_upd_eval r1 b1 0;
   calc (==) {
     SD.bn_v out % P.prime;
-    (==) { assert_norm (pow2 0 = 1) }
+    == { assert_norm (pow2 0 = 1) }
     (SD.bn_v r1 - v r1.[0] + v b1) % P.prime;
-    (==) { lemma_sub1_carry r0 c0 }
+    == { lemma_sub1_carry r0 c0 }
     (SD.bn_v r1 - v r1.[0] + (v r1.[0] - v c1 * 38)) % P.prime;
-    (==) { }
+    == { }
     (SD.bn_v f1 - SD.bn_v f2 + v c0 * pow2 256 - v c0 * 38 + v c1 * pow2 256 - v c1 * 38) % P.prime;
-    (==) { Lemmas.lemma_fsub4 (SD.bn_v f1) (SD.bn_v f2) (v c0) (v c1) }
+    == { Lemmas.lemma_fsub4 (SD.bn_v f1) (SD.bn_v f2) (v c0) (v c1) }
     (SD.bn_v f1 % P.prime - SD.bn_v f2 % P.prime) % P.prime;
     };
   out
@@ -291,11 +291,11 @@ let fmul14 f1 f2 =
   let out = carry_pass r0 c0 in
   calc (==) {
     SD.bn_v out % P.prime;
-    (==) { carry_pass_lemma r0 c0 }
+    == { carry_pass_lemma r0 c0 }
     (SD.bn_v r0 + v c0 * pow2 256) % P.prime;
-    (==) { }
+    == { }
     (SD.bn_v f1 * v f2) % P.prime;
-    (==) {Math.Lemmas.lemma_mod_mul_distr_l (SD.bn_v f1) (v f2) P.prime }
+    == {Math.Lemmas.lemma_mod_mul_distr_l (SD.bn_v f1) (v f2) P.prime }
     (SD.bn_v f1 % P.prime * v f2) % P.prime;
     };
   out

--- a/code/curve25519/Hacl.Spec.Curve25519.Field64.Lemmas.fst
+++ b/code/curve25519/Hacl.Spec.Curve25519.Field64.Lemmas.fst
@@ -18,15 +18,15 @@ val lemma_prime: unit -> Lemma (pow2 256 % prime == 38)
 let lemma_prime () =
   calc (==) {
     pow2 256 % prime;
-    (==) { Math.Lemmas.pow2_plus 255 1 }
+    == { Math.Lemmas.pow2_plus 255 1 }
     2 * pow2 255 % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r 2 (pow2 255) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r 2 (pow2 255) prime }
     2 * (pow2 255 % prime) % prime;
-    (==) { Math.Lemmas.sub_div_mod_1 (pow2 255) prime }
+    == { Math.Lemmas.sub_div_mod_1 (pow2 255) prime }
     2 * (19 % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r 2 19 prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r 2 19 prime }
     38 % prime;
-    (==) { Math.Lemmas.small_mod 38 prime }
+    == { Math.Lemmas.small_mod 38 prime }
     38;
     }
 
@@ -42,13 +42,13 @@ val lemma_mul_pow256_add: fn:int -> c:int ->
 let lemma_mul_pow256_add fn c =
   calc (==) {
     (fn + c * pow2 256) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r fn (c * pow2 256) prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_r fn (c * pow2 256) prime }
     (fn + c * pow2 256 % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r c (pow2 256) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r c (pow2 256) prime }
     (fn + c * (pow2 256 % prime) % prime) % prime;
-    (==) { lemma_prime () }
+    == { lemma_prime () }
     (fn + c * 38 % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r fn (c * 38) prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_r fn (c * 38) prime }
     (fn + c * 38) % prime;
     }
 
@@ -58,13 +58,13 @@ val lemma_mul_pow255_add: fn:int -> c:int ->
 let lemma_mul_pow255_add fn c =
   calc (==) {
     (fn + c * pow2 255) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r fn (c * pow2 255) prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_r fn (c * pow2 255) prime }
     (fn + c * pow2 255 % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r c (pow2 255) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r c (pow2 255) prime }
     (fn + c * (pow2 255 % prime) % prime) % prime;
-    (==) { lemma_prime19 () }
+    == { lemma_prime19 () }
     (fn + c * 19 % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r fn (c * 19) prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_r fn (c * 19) prime }
     (fn + c * 19) % prime;
     }
 
@@ -75,17 +75,17 @@ val lemma_fsub4: fn1:nat -> fn2:nat -> c0:nat -> c1:nat ->
 let lemma_fsub4 fn1 fn2 c0 c1 =
   calc (==) {
     (fn1 - fn2 + c0 * pow2 256 - c0 * 38 + c1 * pow2 256 - c1 * 38) % prime;
-    (==) { lemma_mul_pow256_add (fn1 - fn2 + c0 * pow2 256 - c0 * 38 + c1 * pow2 256) (- c1) }
+    == { lemma_mul_pow256_add (fn1 - fn2 + c0 * pow2 256 - c0 * 38 + c1 * pow2 256) (- c1) }
     (fn1 - fn2 + c0 * pow2 256 - c0 * 38 + c1 * pow2 256 - c1 * pow2 256) % prime;
-    (==) { }
+    == { }
     (fn1 - fn2 + c0 * pow2 256 - c0 * 38) % prime;
-    (==) { lemma_mul_pow256_add (fn1 - fn2 + c0 * pow2 256) (- c0) }
+    == { lemma_mul_pow256_add (fn1 - fn2 + c0 * pow2 256) (- c0) }
     (fn1 - fn2 + c0 * pow2 256 - c0 * pow2 256) % prime;
-    (==) { }
+    == { }
     (fn1 - fn2) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l fn1 (- fn2) prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_l fn1 (- fn2) prime }
     (fn1 % prime - fn2) % prime;
-    (==) { Math.Lemmas.lemma_mod_sub_distr (fn1 % prime) fn2 prime }
+    == { Math.Lemmas.lemma_mod_sub_distr (fn1 % prime) fn2 prime }
     (fn1 % prime - fn2 % prime) % prime;
     }
 
@@ -257,13 +257,13 @@ let lemma_felem64_mod255 a =
 
   calc (==) { //SD.bn_v a == SD.bn_v r + v a.[3] * pow2 192 - v a3' * pow2 192
     SD.bn_v r + v a.[3] * pow2 192 - v a3' * pow2 192;
-    (==) { }
+    == { }
     SD.bn_v r + v a.[3] * pow2 192 - v a.[3] % pow2 63 * pow2 192;
-    (==) { Math.Lemmas.distributivity_sub_left (v a.[3]) (v a.[3] % pow2 63) (pow2 192) }
+    == { Math.Lemmas.distributivity_sub_left (v a.[3]) (v a.[3] % pow2 63) (pow2 192) }
     SD.bn_v r + (v a.[3] - v a.[3] % pow2 63) * pow2 192;
-    (==) { Math.Lemmas.euclidean_division_definition (v a.[3]) (pow2 63) }
+    == { Math.Lemmas.euclidean_division_definition (v a.[3]) (pow2 63) }
     SD.bn_v r + v a.[3] / pow2 63 * pow2 63 * pow2 192;
-    (==) { Math.Lemmas.paren_mul_right (v a.[3] / pow2 63) (pow2 63) (pow2 192); Math.Lemmas.pow2_plus 63 192 }
+    == { Math.Lemmas.paren_mul_right (v a.[3] / pow2 63) (pow2 63) (pow2 192); Math.Lemmas.pow2_plus 63 192 }
     SD.bn_v r + v a.[3] / pow2 63 * pow2 255;
   };
 

--- a/code/curve25519/Hacl.Spec.Curve25519.Field64.fst
+++ b/code/curve25519/Hacl.Spec.Curve25519.Field64.fst
@@ -43,11 +43,11 @@ let lemma_carry_pass_store0 f =
   assert (SD.bn_v r0 == SD.bn_v f - v f.[3] * pow2 (3 * 64) + v f3' * pow2 (3 * 64));
   calc (==) {
     SD.bn_v f - v f.[3] * pow2 (3 * 64) + v f3' * pow2 (3 * 64);
-    (==) { }
+    == { }
     SD.bn_v f - (v top_bit * pow2 63 + v f3') * pow2 (3 * 64) + v f3' * pow2 (3 * 64);
-    (==) { Math.Lemmas.distributivity_add_left (v top_bit * pow2 63) (v f3') (pow2 (3 * 64)) }
+    == { Math.Lemmas.distributivity_add_left (v top_bit * pow2 63) (v f3') (pow2 (3 * 64)) }
     SD.bn_v f - (v top_bit * pow2 63) * pow2 (3 * 64);
-    (==) { Math.Lemmas.paren_mul_right (v top_bit) (pow2 63) (pow2 (3 * 64)); Math.Lemmas.pow2_plus 63 (3 * 64) }
+    == { Math.Lemmas.paren_mul_right (v top_bit) (pow2 63) (pow2 (3 * 64)); Math.Lemmas.pow2_plus 63 (3 * 64) }
     SD.bn_v f - v top_bit * pow2 255;
     };
 
@@ -59,11 +59,11 @@ let lemma_carry_pass_store0 f =
 
   calc (==) { //SD.bn_v r1 % prime ==
     (SD.bn_v r0 + 19 * v top_bit) % prime;
-    (==) { }
+    == { }
     (SD.bn_v f - v top_bit * pow2 255 + 19 * v top_bit) % prime;
-    (==) { Lemmas.lemma_mul_pow255_add (SD.bn_v f - v top_bit * pow2 255) (v top_bit) }
+    == { Lemmas.lemma_mul_pow255_add (SD.bn_v f - v top_bit * pow2 255) (v top_bit) }
     (SD.bn_v f - v top_bit * pow2 255 + v top_bit * pow2 255) % prime;
-    (==) { }
+    == { }
     SD.bn_v f % prime;
     }
 

--- a/code/curve25519/Hacl.Spec.Curve25519.Finv.fst
+++ b/code/curve25519/Hacl.Spec.Curve25519.Finv.fst
@@ -60,9 +60,9 @@ let fsquare_times inp n =
       let res = fsqr out in
       calc (==) {
         fmul out out;
-        (==) { lemma_pow_add inp (pow2 (i + 1)) (pow2 (i + 1)) }
+        == { lemma_pow_add inp (pow2 (i + 1)) (pow2 (i + 1)) }
         pow inp (pow2 (i + 1) + pow2 (i + 1));
-        (==) { Math.Lemmas.pow2_double_sum (i + 1) }
+        == { Math.Lemmas.pow2_double_sum (i + 1) }
         pow inp (pow2 (i + 2));
       };
       res) out in

--- a/code/ecdsap256/Hacl.Impl.P256.Bignum.fst
+++ b/code/ecdsap256/Hacl.Impl.P256.Bignum.fst
@@ -23,14 +23,14 @@ let bn_v_is_as_nat a =
 
   calc (==) {
     bn_v a;
-  (==) { bn_eval1 (slice a 0 1); bn_eval_split_i #U64 a 1 }
+  == { bn_eval1 (slice a 0 1); bn_eval_split_i #U64 a 1 }
     v a.[0] + pow2 64 * bn_v (slice a 1 4);
-  (==) { bn_eval_split_i #U64 (slice a 1 4) 1; bn_eval1 (slice a 1 2) }
+  == { bn_eval_split_i #U64 (slice a 1 4) 1; bn_eval1 (slice a 1 2) }
     v a.[0] + pow2 64 * v a.[1] + pow2 64 * pow2 64 * bn_v (slice a 2 4);
-  (==) { bn_eval_split_i #U64 (slice a 2 4) 1; bn_eval1 (slice a 2 3) }
+  == { bn_eval_split_i #U64 (slice a 2 4) 1; bn_eval1 (slice a 2 3) }
     v a.[0] + pow2 64 * v a.[1] + pow2 64 * pow2 64 * v a.[2]
     + pow2 64 * pow2 64 * pow2 64 * bn_v (slice a 3 4);
-  (==) { bn_eval1 (slice a 3 4) }
+  == { bn_eval1 (slice a 3 4) }
     v a.[0] + pow2 64 * v a.[1] + pow2 64 * pow2 64 * v a.[2]
     + pow2 64 * pow2 64 * pow2 64 * v a.[3];
   }

--- a/code/ecdsap256/Hacl.Impl.P256.Field.fst
+++ b/code/ecdsap256/Hacl.Impl.P256.Field.fst
@@ -189,11 +189,11 @@ let to_mont res a =
   assert (SM.fmont_R_inv * SM.fmont_R % S.prime = 1);
   calc (==) {
     (as_nat h0 a * (SM.fmont_R * SM.fmont_R % S.prime) * SM.fmont_R_inv) % S.prime;
-    (==) { Math.Lemmas.swap_mul (as_nat h0 a) (SM.fmont_R * SM.fmont_R % S.prime) }
+    == { Math.Lemmas.swap_mul (as_nat h0 a) (SM.fmont_R * SM.fmont_R % S.prime) }
     ((SM.fmont_R * SM.fmont_R % S.prime) * as_nat h0 a * SM.fmont_R_inv) % S.prime;
-    (==) { SM.mont_cancel_lemma_gen S.prime SM.fmont_R SM.fmont_R_inv SM.fmont_R (as_nat h0 a) }
+    == { SM.mont_cancel_lemma_gen S.prime SM.fmont_R SM.fmont_R_inv SM.fmont_R (as_nat h0 a) }
     SM.fmont_R * as_nat h0 a % S.prime;
-    (==) { Math.Lemmas.swap_mul SM.fmont_R (as_nat h0 a) }
+    == { Math.Lemmas.swap_mul SM.fmont_R (as_nat h0 a) }
     as_nat h0 a * SM.fmont_R % S.prime;
     };
   pop_frame ()

--- a/code/ecdsap256/Hacl.Spec.P256.Finv.fst
+++ b/code/ecdsap256/Hacl.Spec.P256.Finv.fst
@@ -93,11 +93,11 @@ val lemma_pow_mod_mul: f:S.felem -> a:nat -> b:nat ->
 let lemma_pow_mod_mul f a b =
   calc (==) {
     S.fmul (M.pow f a % S.prime) (M.pow f b % S.prime);
-    (==) {
+    == {
       Math.Lemmas.lemma_mod_mul_distr_l (M.pow f a) (M.pow f b % S.prime) S.prime;
       Math.Lemmas.lemma_mod_mul_distr_r (M.pow f a) (M.pow f b) S.prime }
     M.pow f a * M.pow f b % S.prime;
-    (==) { M.lemma_pow_add f a b }
+    == { M.lemma_pow_add f a b }
     M.pow f (a + b) % S.prime;
   }
 
@@ -107,9 +107,9 @@ val lemma_pow_pow_mod: f:S.felem -> a:nat -> b:nat ->
 let lemma_pow_pow_mod f a b =
   calc (==) {
     M.pow (M.pow f a % S.prime) b % S.prime;
-    (==) { M.lemma_pow_mod_base (M.pow f a) b S.prime }
+    == { M.lemma_pow_mod_base (M.pow f a) b S.prime }
     M.pow (M.pow f a) b % S.prime;
-    (==) { M.lemma_pow_mul f a b }
+    == { M.lemma_pow_mul f a b }
     M.pow f (a * b) % S.prime;
     }
 
@@ -119,9 +119,9 @@ val lemma_pow_pow_mod_mul: f:S.felem -> a:nat -> b:nat -> c:nat ->
 let lemma_pow_pow_mod_mul f a b c =
   calc (==) {
     S.fmul (M.pow (M.pow f a % S.prime) b % S.prime) (M.pow f c % S.prime);
-    (==) { lemma_pow_pow_mod f a b }
+    == { lemma_pow_pow_mod f a b }
     S.fmul (M.pow f (a * b) % S.prime) (M.pow f c % S.prime);
-    (==) { lemma_pow_mod_mul f (a * b) c }
+    == { lemma_pow_mod_mul f (a * b) c }
     M.pow f (a * b + c) % S.prime;
   }
 

--- a/code/ecdsap256/Hacl.Spec.P256.Montgomery.fst
+++ b/code/ecdsap256/Hacl.Spec.P256.Montgomery.fst
@@ -25,11 +25,11 @@ val lemma_mod_mul_assoc (n:pos) (a b c:nat) : Lemma ((a * b % n) * c % n == (a *
 let lemma_mod_mul_assoc m a b c =
   calc (==) {
     (a * b % m) * c % m;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (a * b) c m }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (a * b) c m }
     (a * b) * c % m;
-    (==) { Math.Lemmas.paren_mul_right a b c }
+    == { Math.Lemmas.paren_mul_right a b c }
     a * (b * c) % m;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r a (b * c) m }
+    == { Math.Lemmas.lemma_mod_mul_distr_r a (b * c) m }
     a * (b * c % m) % m;
   }
 
@@ -58,22 +58,22 @@ val mont_mul_lemma_gen (n:pos) (mont_R_inv a b: nat) :
 let mont_mul_lemma_gen n mont_R_inv a b =
   calc (==) {
     ((a * mont_R_inv % n) * (b * mont_R_inv % n)) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l
+    == { Math.Lemmas.lemma_mod_mul_distr_l
       (a * mont_R_inv) (b * mont_R_inv % n) n }
     (a * mont_R_inv * (b * mont_R_inv % n)) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (a * mont_R_inv) (b * mont_R_inv) n }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (a * mont_R_inv) (b * mont_R_inv) n }
     (a * mont_R_inv * (b * mont_R_inv)) % n;
-    (==) { Math.Lemmas.paren_mul_right a mont_R_inv (b * mont_R_inv) }
+    == { Math.Lemmas.paren_mul_right a mont_R_inv (b * mont_R_inv) }
     (a * (mont_R_inv * (b * mont_R_inv))) % n;
-    (==) { Math.Lemmas.paren_mul_right mont_R_inv b mont_R_inv }
+    == { Math.Lemmas.paren_mul_right mont_R_inv b mont_R_inv }
     (a * (mont_R_inv * b * mont_R_inv)) % n;
-    (==) { Math.Lemmas.swap_mul mont_R_inv b }
+    == { Math.Lemmas.swap_mul mont_R_inv b }
     (a * (b * mont_R_inv * mont_R_inv)) % n;
-    (==) { Math.Lemmas.paren_mul_right a (b * mont_R_inv) mont_R_inv }
+    == { Math.Lemmas.paren_mul_right a (b * mont_R_inv) mont_R_inv }
     (a * (b * mont_R_inv) * mont_R_inv) % n;
-    (==) { Math.Lemmas.paren_mul_right a b mont_R_inv }
+    == { Math.Lemmas.paren_mul_right a b mont_R_inv }
     (a * b * mont_R_inv * mont_R_inv) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (a * b * mont_R_inv) mont_R_inv n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (a * b * mont_R_inv) mont_R_inv n }
     ((a * b * mont_R_inv) % n) * mont_R_inv % n;
   }
 
@@ -84,11 +84,11 @@ val mont_add_lemma_gen (n:pos) (mont_R_inv a b: nat) :
 let mont_add_lemma_gen n mont_R_inv a b =
   calc (==) {
     (a * mont_R_inv % n + b * mont_R_inv % n) % n;
-    (==) { Math.Lemmas.modulo_distributivity (a * mont_R_inv) (b * mont_R_inv) n }
+    == { Math.Lemmas.modulo_distributivity (a * mont_R_inv) (b * mont_R_inv) n }
     (a * mont_R_inv + b * mont_R_inv) % n;
-    (==) { Math.Lemmas.distributivity_add_left a b mont_R_inv }
+    == { Math.Lemmas.distributivity_add_left a b mont_R_inv }
     (a + b) * mont_R_inv % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (a + b) mont_R_inv n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (a + b) mont_R_inv n }
     (a + b) % n * mont_R_inv % n;
   }
 
@@ -99,13 +99,13 @@ val mont_sub_lemma_gen (n:pos) (mont_R_inv a b: nat) :
 let mont_sub_lemma_gen n mont_R_inv a b =
   calc (==) {
     (a * mont_R_inv % n - b * mont_R_inv % n) % n;
-    (==) { Math.Lemmas.lemma_mod_sub_distr (a * mont_R_inv % n) (b * mont_R_inv) n }
+    == { Math.Lemmas.lemma_mod_sub_distr (a * mont_R_inv % n) (b * mont_R_inv) n }
     (a * mont_R_inv % n - b * mont_R_inv) % n;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l (a * mont_R_inv) (- b * mont_R_inv) n }
+    == { Math.Lemmas.lemma_mod_plus_distr_l (a * mont_R_inv) (- b * mont_R_inv) n }
     (a * mont_R_inv - b * mont_R_inv) % n;
-    (==) { Math.Lemmas.distributivity_sub_left a b mont_R_inv }
+    == { Math.Lemmas.distributivity_sub_left a b mont_R_inv }
     (a - b) * mont_R_inv % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (a - b) mont_R_inv n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (a - b) mont_R_inv n }
     (a - b) % n * mont_R_inv % n;
   }
 
@@ -139,20 +139,20 @@ let lemma_mont_inv_gen n mont_R mont_R_inv k =
 let mont_cancel_lemma_gen n mont_R mont_R_inv a b =
   calc (==) {
     (a * mont_R % n * b * mont_R_inv) % n;
-    (==) { Math.Lemmas.paren_mul_right (a * mont_R % n) b mont_R_inv }
+    == { Math.Lemmas.paren_mul_right (a * mont_R % n) b mont_R_inv }
     (a * mont_R % n * (b * mont_R_inv)) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (a * mont_R) (b * mont_R_inv) n }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (a * mont_R) (b * mont_R_inv) n }
     (a * mont_R * (b * mont_R_inv)) % n;
-    (==) { Math.Lemmas.paren_mul_right a mont_R (b * mont_R_inv);
+    == { Math.Lemmas.paren_mul_right a mont_R (b * mont_R_inv);
            Math.Lemmas.swap_mul mont_R (b * mont_R_inv) }
     (a * (b * mont_R_inv * mont_R)) % n;
-    (==) { Math.Lemmas.paren_mul_right b mont_R_inv mont_R }
+    == { Math.Lemmas.paren_mul_right b mont_R_inv mont_R }
     (a * (b * (mont_R_inv * mont_R))) % n;
-    (==) { Math.Lemmas.paren_mul_right a b (mont_R_inv * mont_R) }
+    == { Math.Lemmas.paren_mul_right a b (mont_R_inv * mont_R) }
     (a * b * (mont_R_inv * mont_R)) % n;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (a * b) (mont_R_inv * mont_R) n }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (a * b) (mont_R_inv * mont_R) n }
     (a * b * (mont_R_inv * mont_R % n)) % n;
-    (==) { assert (mont_R_inv * mont_R % n = 1) }
+    == { assert (mont_R_inv * mont_R % n = 1) }
     (a * b) % n;
   }
 
@@ -195,9 +195,9 @@ let bn_mont_reduction_lemma x n =
   assert (BD.bn_v res == BD.bn_v x * d % S.prime);
   calc (==) {
     BD.bn_v x * d % S.prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (BD.bn_v x) d S.prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (BD.bn_v x) d S.prime }
     BD.bn_v x * (d % S.prime) % S.prime;
-    (==) { }
+    == { }
     BD.bn_v x * fmont_R_inv % S.prime;
   }
 
@@ -272,9 +272,9 @@ let bn_qmont_reduction_lemma x n =
   assert (BD.bn_v res == BD.bn_v x * d % S.order);
   calc (==) {
     (BD.bn_v x) * d % S.order;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (BD.bn_v x) d S.order }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (BD.bn_v x) d S.order }
     (BD.bn_v x) * (d % S.order) % S.order;
-    (==) { }
+    == { }
     (BD.bn_v x) * qmont_R_inv % S.order;
   }
 
@@ -324,13 +324,13 @@ val qmont_cancel_lemma2: a:S.qelem -> b:S.qelem ->
 let qmont_cancel_lemma2 a b =
   calc (==) {
     to_qmont a * from_qmont b % S.order;
-    (==) { }
+    == { }
     (a * qmont_R % S.order * (b * qmont_R_inv % S.order)) % S.order;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (a * qmont_R % S.order) (b * qmont_R_inv) S.order }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (a * qmont_R % S.order) (b * qmont_R_inv) S.order }
     (a * qmont_R % S.order * (b * qmont_R_inv)) % S.order;
-    (==) { Math.Lemmas.paren_mul_right (a * qmont_R % S.order) b qmont_R_inv }
+    == { Math.Lemmas.paren_mul_right (a * qmont_R % S.order) b qmont_R_inv }
     (a * qmont_R % S.order * b * qmont_R_inv) % S.order;
-    (==) { qmont_cancel_lemma1 a b }
+    == { qmont_cancel_lemma1 a b }
     a * b % S.order;
   }
 
@@ -340,13 +340,13 @@ let qmont_inv_mul_lemma s sinv b =
   let b_mont = from_qmont b in
   calc (==) {
     (sinv * b_mont * qmont_R_inv) % S.order;
-    (==) { lemma_from_to_qmont_id sinv }
+    == { lemma_from_to_qmont_id sinv }
     (S.qinv s_mont * qmont_R % S.order * b_mont * qmont_R_inv) % S.order;
-    (==) { qmont_cancel_lemma1 (S.qinv s_mont) b_mont }
+    == { qmont_cancel_lemma1 (S.qinv s_mont) b_mont }
     S.qinv s_mont * b_mont % S.order;
-    (==) { qmont_inv_lemma s }
+    == { qmont_inv_lemma s }
     (S.qinv s * qmont_R % S.order * (b * qmont_R_inv % S.order)) % S.order;
-    (==) { qmont_cancel_lemma2 (S.qinv s) b }
+    == { qmont_cancel_lemma2 (S.qinv s) b }
     S.qinv s * b % S.order;
   }
 
@@ -355,22 +355,22 @@ let lemma_ecdsa_sign_s k kinv r d_a m =
   let s = (from_qmont m + from_qmont (r * d_a)) % S.order in
   calc (==) { // s =
     (m * qmont_R_inv % S.order + (r * d_a * qmont_R_inv) % S.order) % S.order;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (r * d_a) qmont_R_inv S.order }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (r * d_a) qmont_R_inv S.order }
     (m * qmont_R_inv % S.order + (S.qmul r d_a * qmont_R_inv) % S.order) % S.order;
-    (==) { qmont_add_lemma m (S.qmul r d_a) }
+    == { qmont_add_lemma m (S.qmul r d_a) }
     (S.qadd m (S.qmul r d_a)) * qmont_R_inv % S.order;
-    (==) { }
+    == { }
     from_qmont (S.qadd m (S.qmul r d_a));
     };
 
   calc (==) {
     (kinv * s * qmont_R_inv) % S.order;
-    (==) { lemma_abc_is_acb kinv s qmont_R_inv }
+    == { lemma_abc_is_acb kinv s qmont_R_inv }
     (kinv * qmont_R_inv * s) % S.order;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (kinv * qmont_R_inv) s S.order }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (kinv * qmont_R_inv) s S.order }
     ((kinv * qmont_R_inv % S.order) * s) % S.order;
-    (==) { }
+    == { }
     to_qmont (S.qinv k) * s % S.order;
-    (==) { qmont_cancel_lemma2 (S.qinv k) (S.qadd m (S.qmul r d_a)) }
+    == { qmont_cancel_lemma2 (S.qinv k) (S.qadd m (S.qmul r d_a)) }
     (S.qinv k * (S.qadd m (S.qmul r d_a))) % S.order;
   }

--- a/code/ecdsap256/Hacl.Spec.P256.Qinv.fst
+++ b/code/ecdsap256/Hacl.Spec.P256.Qinv.fst
@@ -145,11 +145,11 @@ val lemma_pow_mod_mul: f:S.qelem -> a:nat -> b:nat ->
 let lemma_pow_mod_mul f a b =
   calc (==) {
     S.qmul (M.pow f a % S.order) (M.pow f b % S.order);
-    (==) {
+    == {
       Math.Lemmas.lemma_mod_mul_distr_l (M.pow f a) (M.pow f b % S.order) S.order;
       Math.Lemmas.lemma_mod_mul_distr_r (M.pow f a) (M.pow f b) S.order }
     M.pow f a * M.pow f b % S.order;
-    (==) { M.lemma_pow_add f a b }
+    == { M.lemma_pow_add f a b }
     M.pow f (a + b) % S.order;
   }
 
@@ -159,9 +159,9 @@ val lemma_pow_pow_mod: f:S.qelem -> a:nat -> b:nat ->
 let lemma_pow_pow_mod f a b =
   calc (==) {
     M.pow (M.pow f a % S.order) b % S.order;
-    (==) { M.lemma_pow_mod_base (M.pow f a) b S.order }
+    == { M.lemma_pow_mod_base (M.pow f a) b S.order }
     M.pow (M.pow f a) b % S.order;
-    (==) { M.lemma_pow_mul f a b }
+    == { M.lemma_pow_mul f a b }
     M.pow f (a * b) % S.order;
     }
 
@@ -171,9 +171,9 @@ val lemma_pow_pow_mod_mul: f:S.qelem -> a:nat -> b:nat -> c:nat ->
 let lemma_pow_pow_mod_mul f a b c =
   calc (==) {
     S.qmul (M.pow (M.pow f a % S.order) b % S.order) (M.pow f c % S.order);
-    (==) { lemma_pow_pow_mod f a b }
+    == { lemma_pow_pow_mod f a b }
     S.qmul (M.pow f (a * b) % S.order) (M.pow f c % S.order);
-    (==) { lemma_pow_mod_mul f (a * b) c }
+    == { lemma_pow_mod_mul f (a * b) c }
     M.pow f (a * b + c) % S.order;
   }
 

--- a/code/ed25519/Hacl.Bignum25519.fst
+++ b/code/ed25519/Hacl.Bignum25519.fst
@@ -143,22 +143,22 @@ let times_2 out a =
 
   calc (==) {
     (2 * (F51.fevalh h0 a)) % SC.prime;
-    (==) { calc (==) {
+    == { calc (==) {
            F51.fevalh h0 a;
-           (==) { }
+           == { }
            S51.as_nat5 (a0, a1, a2, a3, a4) % SC.prime;
            }
          }
     (2 * (S51.as_nat5 (a0, a1, a2, a3, a4) % SC.prime)) % SC.prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_mul_distr_r 2 (S51.as_nat5 (a0, a1, a2, a3, a4)) SC.prime }
+    == { FStar.Math.Lemmas.lemma_mod_mul_distr_r 2 (S51.as_nat5 (a0, a1, a2, a3, a4)) SC.prime }
     (2 * S51.as_nat5 (a0, a1, a2, a3, a4)) % SC.prime;
-    (==) { calc (==) {
+    == { calc (==) {
            2 * S51.as_nat5 (a0, a1, a2, a3, a4);
-           (==) { SL51.lemma_smul_felem5 (u64 2) (a0, a1, a2, a3, a4) }
+           == { SL51.lemma_smul_felem5 (u64 2) (a0, a1, a2, a3, a4) }
            2 * v a0 + 2 * v a1 * S51.pow51 + 2 * v a2 * S51.pow51 * S51.pow51 +
            2 * v a3 * S51.pow51 * S51.pow51 * S51.pow51 +
            2 * v a4 * S51.pow51 * S51.pow51 * S51.pow51 * S51.pow51;
-           (==) {
+           == {
              assert_norm (2 * S51.pow51 < pow2 64);
              assert_norm (4 * S51.pow51 < pow2 64);
              FStar.Math.Lemmas.small_mod (2 * v a0) (pow2 64);
@@ -171,7 +171,7 @@ let times_2 out a =
            }
          }
     S51.as_nat5 (u64 2 *. a0, u64 2 *. a1, u64 2 *. a2, u64 2 *. a3, u64 2 *. a4) % SC.prime;
-    (==) { }
+    == { }
     F51.fevalh h1 out;
   }
 

--- a/code/ed25519/Hacl.Ed25519.PrecompTable.fst
+++ b/code/ed25519/Hacl.Ed25519.PrecompTable.fst
@@ -39,25 +39,25 @@ let lemma_is_on_curve x y =
   let open Spec.Ed25519 in
   calc (==) {
     y *% y -% x *% x;
-    (==) { }
+    == { }
     ((y * y) % prime - (x * x) % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l (y * y) (- (x * x) % prime) prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_l (y * y) (- (x * x) % prime) prime }
     (y * y - (x * x) % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_sub_distr (y * y) (x * x) prime }
+    == { Math.Lemmas.lemma_mod_sub_distr (y * y) (x * x) prime }
     (y * y - x * x) % prime;
     };
 
   calc (==) {
     1 +% S.d *% (x *% x) *% (y *% y);
-    (==) { }
+    == { }
     (1 + (S.d * (x * x % prime) % prime) * (y * y % prime) % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r S.d (x * x) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r S.d (x * x) prime }
     (1 + (S.d * (x * x) % prime) * (y * y % prime) % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (S.d * (x * x)) (y * y % prime) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (S.d * (x * x)) (y * y % prime) prime }
     (1 + (S.d * (x * x)) * (y * y % prime) % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (S.d * (x * x)) (y * y) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (S.d * (x * x)) (y * y) prime }
     (1 + (S.d * (x * x)) * (y * y) % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r 1 ((S.d * (x * x)) * (y * y)) prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_r 1 ((S.d * (x * x)) * (y * y)) prime }
     (1 + (S.d * (x * x)) * (y * y)) % prime;
     }
 

--- a/code/ed25519/Hacl.Impl.Ed25519.PointCompress.fst
+++ b/code/ed25519/Hacl.Impl.Ed25519.PointCompress.fst
@@ -38,28 +38,28 @@ let lemma_fits_in_prime_last_byte (b:lbytes 32) : Lemma
   (ensures v (Seq.index b 31) < pow2 7)
   = calc (==) {
       nat_from_bytes_le b <: nat;
-     (==) { nat_from_intseq_le_slice_lemma b 31 }
+     == { nat_from_intseq_le_slice_lemma b 31 }
      nat_from_intseq_le (Seq.slice b 0 31) +
        pow2 (31 * 8) * nat_from_intseq_le (Seq.slice b 31 32);
-     (==) { nat_from_intseq_le_lemma0 (Seq.slice b 31 32) }
+     == { nat_from_intseq_le_lemma0 (Seq.slice b 31 32) }
      nat_from_intseq_le (Seq.slice b 0 31) + pow2 (31*8) * v (Seq.index b 31);
     };
     assert (nat_from_intseq_le (Seq.slice b 0 31) < pow2 (31 * 8));
     calc (<) {
       pow2 (31*8) * v (Seq.index b 31);
-      (<) { }
+      < { }
       Spec.Curve25519.prime - nat_from_intseq_le (Seq.slice b 0 31);
-      (<=) { }
+      <= { }
       Spec.Curve25519.prime;
-      (<) { }
+      < { }
       pow2 255;
     };
     FStar.Math.Lemmas.lemma_div_lt_nat (pow2 (31*8) * v (Seq.index b 31)) 255 (31*8);
     calc (==) {
       (pow2 (31 *8) * v (Seq.index b 31))/ (pow2 (31*8));
-      (==) { FStar.Math.Lemmas.swap_mul (pow2 (31*8)) (v (Seq.index b 31)) }
+      == { FStar.Math.Lemmas.swap_mul (pow2 (31*8)) (v (Seq.index b 31)) }
       (v (Seq.index b 31) * pow2 (31 *8)) / (pow2 (31*8));
-      (==) { FStar.Math.Lemmas.cancel_mul_div (v (Seq.index b 31)) (pow2 (31*8)) }
+      == { FStar.Math.Lemmas.cancel_mul_div (v (Seq.index b 31)) (pow2 (31*8)) }
       v (Seq.index b 31);
     };
     assert_norm (255 - 31 * 8 == 7)
@@ -85,21 +85,21 @@ let add_sign out x =
   (**) let h1 = ST.get() in
   (**) calc (==) {
   (**)   nat_from_intseq_le (as_seq h1 out) <: nat;
-  (**)   (==) { nat_from_intseq_le_slice_lemma (as_seq h1 out) 31 }
+  (**)   == { nat_from_intseq_le_slice_lemma (as_seq h1 out) 31 }
   (**)   nat_from_intseq_le (Seq.slice (as_seq h1 out) 0 31) +
   (**)     pow2 (31 * 8) * nat_from_intseq_le (Seq.slice (as_seq h1 out) 31 32);
-  (**)   (==) {
+  (**)   == {
   (**)     calc (==) {
   (**)       pow2 (31 * 8) * nat_from_intseq_le (Seq.slice (as_seq h1 out) 31 32);
-  (**)       (==) { calc (==) {
+  (**)       == { calc (==) {
   (**)                nat_from_intseq_le (Seq.slice (as_seq h1 out) 31 32) <: nat;
-  (**)                (==) { nat_from_intseq_le_lemma0 (Seq.slice (as_seq h1 out) 31 32) }
+  (**)                == { nat_from_intseq_le_lemma0 (Seq.slice (as_seq h1 out) 31 32) }
   (**)                v (o31 +. (xbyte <<. 7ul));
-  (**)                (==) { calc (==) {
+  (**)                == { calc (==) {
   (**)                         v (o31 +. (xbyte <<. 7ul)) <: nat;
-  (**)                         (==) { }
+  (**)                         == { }
   (**)                         (v o31 + v (xbyte <<. 7ul)) % pow2 8;
-  (**)                         (==) { FStar.Math.Lemmas.lemma_mult_le_left (pow2 7) (v x) 1;
+  (**)                         == { FStar.Math.Lemmas.lemma_mult_le_left (pow2 7) (v x) 1;
   (**)                                assert (pow2 7 * (v x) <= pow2 7);
   (**)                                assert_norm (pow2 7 < pow2 8);
   (**)                                lemma_fits_in_prime_last_byte (as_seq h0 out);
@@ -112,11 +112,11 @@ let add_sign out x =
   (**)                nat_from_intseq_le (Seq.slice (as_seq h0 out) 31 32) + pow2 7 * (v x);
   (**)            } }
   (**)       pow2 (31 * 8) * (nat_from_intseq_le (Seq.slice (as_seq h0 out) 31 32) + pow2 7 * (v x));
-  (**)       (==) { FStar.Math.Lemmas.distributivity_add_right (pow2 (31 * 8))
+  (**)       == { FStar.Math.Lemmas.distributivity_add_right (pow2 (31 * 8))
   (**)              (nat_from_intseq_le (Seq.slice (as_seq h0 out) 31 32)) (pow2 7 * (v x)) }
   (**)       pow2 (31 * 8) * nat_from_intseq_le (Seq.slice (as_seq h0 out) 31 32) +
   (**)       pow2 (31 * 8) * pow2 7 * (v x);
-  (**)       (==) { assert_norm (pow2 (31*8) * pow2 7 == pow2 255) }
+  (**)       == { assert_norm (pow2 (31*8) * pow2 7 == pow2 255) }
   (**)       pow2 (31 * 8) * nat_from_intseq_le (Seq.slice (as_seq h0 out) 31 32) +
   (**)       pow2 255 * (v x);
   (**)     }
@@ -124,7 +124,7 @@ let add_sign out x =
   (**)   nat_from_intseq_le (Seq.slice (as_seq h1 out) 0 31) +
   (**)   pow2 (31 * 8) * nat_from_intseq_le (Seq.slice (as_seq h0 out) 31 32) +
   (**)   pow2 255 * (v x);
-  (**)   (==) { nat_from_intseq_le_slice_lemma (as_seq h0 out) 31 }
+  (**)   == { nat_from_intseq_le_slice_lemma (as_seq h0 out) 31 }
   (**)   nat_from_bytes_le (as_seq h0 out) + pow2 255 * (v x);
   (**) }
 

--- a/code/ed25519/Hacl.Impl.Ed25519.PointEqual.fst
+++ b/code/ed25519/Hacl.Impl.Ed25519.PointEqual.fst
@@ -85,7 +85,7 @@ let lemma_equality1 a b c d e a' b' c' d' e' =
 
     calc (==) {
       (a + pow2 51 * b + pow2 102 * c + pow2 153 * d + pow2 204 * e) % (pow2 204);
-      (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r
+      == { FStar.Math.Lemmas.lemma_mod_plus_distr_r
          (a + pow2 51 * b + pow2 102 * c + pow2 153 * d)
          (pow2 204 * e)
          (pow2 204);
@@ -95,7 +95,7 @@ let lemma_equality1 a b c d e a' b' c' d' e' =
     };
     calc (==) {
       (a' + pow2 51 * b' + pow2 102 * c' + pow2 153 * d' + pow2 204 * e') % (pow2 204);
-      (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r
+      == { FStar.Math.Lemmas.lemma_mod_plus_distr_r
          (a' + pow2 51 * b' + pow2 102 * c' + pow2 153 * d')
          (pow2 204 * e')
          (pow2 204);
@@ -109,7 +109,7 @@ let lemma_equality1 a b c d e a' b' c' d' e' =
 
     calc (==) {
       (a + pow2 51 * b + pow2 102 * c + pow2 153 * d) % (pow2 153);
-      (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r
+      == { FStar.Math.Lemmas.lemma_mod_plus_distr_r
          (a + pow2 51 * b + pow2 102 * c)
          (pow2 153 * d)
          (pow2 153);
@@ -119,7 +119,7 @@ let lemma_equality1 a b c d e a' b' c' d' e' =
     };
     calc (==) {
       (a' + pow2 51 * b' + pow2 102 * c' + pow2 153 * d') % (pow2 153);
-      (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r
+      == { FStar.Math.Lemmas.lemma_mod_plus_distr_r
          (a' + pow2 51 * b' + pow2 102 * c')
          (pow2 153 * d')
          (pow2 153);
@@ -134,7 +134,7 @@ let lemma_equality1 a b c d e a' b' c' d' e' =
 
     calc (==) {
       (a + pow2 51 * b + pow2 102 * c) % (pow2 102);
-      (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r
+      == { FStar.Math.Lemmas.lemma_mod_plus_distr_r
          (a + pow2 51 * b)
          (pow2 102 * c)
          (pow2 102);
@@ -144,7 +144,7 @@ let lemma_equality1 a b c d e a' b' c' d' e' =
     };
     calc (==) {
       (a' + pow2 51 * b' + pow2 102 * c') % (pow2 102);
-      (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r
+      == { FStar.Math.Lemmas.lemma_mod_plus_distr_r
          (a' + pow2 51 * b')
          (pow2 102 * c')
          (pow2 102);

--- a/code/ed25519/Hacl.Impl.Load56.fst
+++ b/code/ed25519/Hacl.Impl.Load56.fst
@@ -34,18 +34,18 @@ let hload56_le b off =
   assert_norm (0x100000000000000 == pow2 56 );
   calc (==) {
     v z' <: nat;
-    (==) { }
+    == { }
     v (z &. u64 0xffffffffffffff);
-    (==) { logand_spec z (u64 0xffffffffffffff) }
+    == { logand_spec z (u64 0xffffffffffffff) }
     v z `logand_v` 0xffffffffffffff;
-    (==) { assert_norm(pow2 56 - 1 == 0xffffffffffffff); UInt.logand_mask (UInt.to_uint_t 64 (v z)) 56 }
+    == { assert_norm(pow2 56 - 1 == 0xffffffffffffff); UInt.logand_mask (UInt.to_uint_t 64 (v z)) 56 }
     (v z % pow2 56);
-    (==) { lemma_reveal_uint_to_bytes_le #U64 #SEC (as_seq h0 b8) }
+    == { lemma_reveal_uint_to_bytes_le #U64 #SEC (as_seq h0 b8) }
     nat_from_bytes_le (as_seq h0 b8) % pow2 56;
-    (==) { nat_from_intseq_le_slice_lemma (as_seq h0 b8) 7 }
+    == { nat_from_intseq_le_slice_lemma (as_seq h0 b8) 7 }
     (nat_from_bytes_le (Seq.slice (as_seq h0 b8) 0 7) +
       pow2 (7 * 8) * nat_from_bytes_le (Seq.slice (as_seq h0 b8) 7 8)) % pow2 56;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r
       (nat_from_bytes_le (Seq.slice (as_seq h0 b8) 0 7))
       (pow2 (7 * 8) * nat_from_bytes_le (Seq.slice (as_seq h0 b8) 7 8))
       (pow2 56);
@@ -165,18 +165,18 @@ let hload56_le' b off =
   assert_norm (0x100000000000000 == pow2 56 );
   calc (==) {
     v z' <: nat;
-    (==) { }
+    == { }
     v (z &. u64 0xffffffffffffff);
-    (==) { logand_spec z (u64 0xffffffffffffff) }
+    == { logand_spec z (u64 0xffffffffffffff) }
     v z `logand_v` 0xffffffffffffff;
-    (==) { assert_norm(pow2 56 - 1 == 0xffffffffffffff); UInt.logand_mask (UInt.to_uint_t 64 (v z)) 56 }
+    == { assert_norm(pow2 56 - 1 == 0xffffffffffffff); UInt.logand_mask (UInt.to_uint_t 64 (v z)) 56 }
     (v z % pow2 56);
-    (==) { lemma_reveal_uint_to_bytes_le #U64 #SEC (as_seq h0 b8) }
+    == { lemma_reveal_uint_to_bytes_le #U64 #SEC (as_seq h0 b8) }
     nat_from_bytes_le (as_seq h0 b8) % pow2 56;
-    (==) { nat_from_intseq_le_slice_lemma (as_seq h0 b8) 7 }
+    == { nat_from_intseq_le_slice_lemma (as_seq h0 b8) 7 }
     (nat_from_bytes_le (Seq.slice (as_seq h0 b8) 0 7) +
       pow2 (7 * 8) * nat_from_bytes_le (Seq.slice (as_seq h0 b8) 7 8)) % pow2 56;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r
       (nat_from_bytes_le (Seq.slice (as_seq h0 b8) 0 7))
       (pow2 (7 * 8) * nat_from_bytes_le (Seq.slice (as_seq h0 b8) 7 8))
       (pow2 56);

--- a/code/ed25519/Hacl.Impl.Store56.fst
+++ b/code/ed25519/Hacl.Impl.Store56.fst
@@ -32,14 +32,14 @@ let hstore56_le out off x =
   let h1 = ST.get() in
   calc (==) {
     v x <: nat;
-    (==) { Math.Lemmas.small_mod (v x) (pow2 56) }
+    == { Math.Lemmas.small_mod (v x) (pow2 56) }
     (v x) % pow2 56 <: nat;
-    (==) { assert (Seq.equal (as_seq h1 b8) (Seq.slice (as_seq h1 out) (v off) (v off + 8))) }
+    == { assert (Seq.equal (as_seq h1 b8) (Seq.slice (as_seq h1 out) (v off) (v off + 8))) }
     (nat_from_bytes_le (as_seq h1 b8)) % pow2 56;
-    (==) { nat_from_intseq_le_slice_lemma (as_seq h1 b8) 7 }
+    == { nat_from_intseq_le_slice_lemma (as_seq h1 b8) 7 }
     (nat_from_bytes_le (Seq.slice (as_seq h1 b8) 0 7) +
     pow2 56 * nat_from_bytes_le (Seq.slice (as_seq h1 b8) 7 8)) % pow2 56;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r
+    == { Math.Lemmas.lemma_mod_plus_distr_r
       (nat_from_bytes_le (Seq.slice (as_seq h1 b8) 0 7))
       (pow2 56 * nat_from_bytes_le (Seq.slice (as_seq h1 b8) 7 8))
       (pow2 56);
@@ -50,7 +50,7 @@ let hstore56_le out off x =
         (nat_from_bytes_le (Seq.slice (as_seq h1 b8) 7 8))
         (pow2 56) }
      nat_from_bytes_le (Seq.slice (as_seq h1 b8) 0 7) % pow2 56;
-     (==) {
+     == {
        Math.Lemmas.small_mod (nat_from_bytes_le (Seq.slice (as_seq h1 b8) 0 7)) (pow2 56);
      assert (Seq.equal (Seq.slice (as_seq h1 b8) 0 7) (Seq.slice (as_seq h1 out) (v off) (v off + 7))) }
      nat_from_bytes_le (Seq.slice (as_seq h1 out) (v off) (v off + 7));

--- a/code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst
+++ b/code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst
@@ -110,16 +110,16 @@ let lemma_div224 x =
   assert_norm (pow2 280 * pow2 224 == pow2 504);
   calc (==) {
     wide_as_nat5 x / pow2 224;
-    (==) { }
+    == { }
     (v x0 + v x1 * pow2 56 + v x2 * pow2 112 + v x3 * pow2 168 +
     (v x4 + v x5 * pow2 56 + v x6 * pow2 112 + v x7 * pow2 168 + v x8 * pow2 224 + v x9 * pow2 280) * pow2 224) / pow2 224;
-    (==) {
+    == {
       FStar.Math.Lemmas.lemma_div_plus
         (v x0 + v x1 * pow2 56 + v x2 * pow2 112 + v x3 * pow2 168)
         (v x4 + v x5 * pow2 56 + v x6 * pow2 112 + v x7 * pow2 168 + v x8 * pow2 224 + v x9 * pow2 280) (pow2 224) }
     (v x0 + v x1 * pow2 56 + v x2 * pow2 112 + v x3 * pow2 168) / pow2 224 +
     v x4 + v x5 * pow2 56 + v x6 * pow2 112 + v x7 * pow2 168 + v x8 * pow2 224 + v x9 * pow2 280;
-    (==) { FStar.Math.Lemmas.small_division_lemma_1 (v x0 + v x1 * pow2 56 + v x2 * pow2 112 + v x3 * pow2 168) (pow2 224) }
+    == { FStar.Math.Lemmas.small_division_lemma_1 (v x0 + v x1 * pow2 56 + v x2 * pow2 112 + v x3 * pow2 168) (pow2 224) }
       v x4 + v x5 * pow2 56 + v x6 * pow2 112 + v x7 * pow2 168 + v x8 * pow2 224 + v x9 * pow2 280;
     }
 #pop-options
@@ -149,12 +149,12 @@ let lemma_div248_aux x =
 
   calc (==) {
     wide_as_nat5 x / pow2 248;
-  (==) { FStar.Math.Lemmas.division_multiplication_lemma (wide_as_nat5 x) (pow2 224) (pow2 24) }
+  == { FStar.Math.Lemmas.division_multiplication_lemma (wide_as_nat5 x) (pow2 224) (pow2 24) }
     (wide_as_nat5 x / pow2 224) / pow2 24;
-  (==) { lemma_div224 x }
+  == { lemma_div224 x }
     (v x4 + v x5 * pow2 56 + v x6 * pow2 112 + v x7 * pow2 168 + v x8 * pow2 224 + v x9 * pow2 280) / pow2 24;
-  (==) { _ by (Tactics.mapply (`feq #int #int (fun x -> x / pow2 24)); int_semiring ()) }    (v x4 + (v x5 * pow2 32 + v x6 * pow2 88 + v x7 * pow2 144 + v x8 * pow2 200 + v x9 * pow2 256) * pow2 24) / pow2 24;
-  (==) { FStar.Math.Lemmas.lemma_div_plus (v x4) (v x5 * pow2 32 + v x6 * pow2 88 + v x7 * pow2 144 + v x8 * pow2 200 + v x9 * pow2 256) (pow2 24) }
+  == { _ by (Tactics.mapply (`feq #int #int (fun x -> x / pow2 24)); int_semiring ()) }    (v x4 + (v x5 * pow2 32 + v x6 * pow2 88 + v x7 * pow2 144 + v x8 * pow2 200 + v x9 * pow2 256) * pow2 24) / pow2 24;
+  == { FStar.Math.Lemmas.lemma_div_plus (v x4) (v x5 * pow2 32 + v x6 * pow2 88 + v x7 * pow2 144 + v x8 * pow2 200 + v x9 * pow2 256) (pow2 24) }
     v x4 / pow2 24 + v x5 * pow2 32 + v x6 * pow2 88 + v x7 * pow2 144 + v x8 * pow2 200 + v x9 * pow2 256;
   }
 #pop-options
@@ -169,9 +169,9 @@ val lemma_div248_x6: x6:uint64 ->
 let lemma_div248_x6 x6 =
   calc (==) {
     pow2 32 * (v x6 % pow2 24) * pow2 56 + v x6 / pow2 24 * pow2 112;
-    (==) { _ by (Tactics.norm [delta_only [`%pow2]; primops]; int_semiring ()) }
+    == { _ by (Tactics.norm [delta_only [`%pow2]; primops]; int_semiring ()) }
     ((v x6 / pow2 24) * pow2 24 + v x6 % pow2 24) * pow2 88;
-    (==) { FStar.Math.Lemmas.euclidean_division_definition (v x6) (pow2 24) }
+    == { FStar.Math.Lemmas.euclidean_division_definition (v x6) (pow2 24) }
     v x6 * pow2 88;
   }
 
@@ -181,9 +181,9 @@ val lemma_div248_x7: x7:uint64 ->
 let lemma_div248_x7 x7 =
   calc (==) {
     pow2 32 * (v x7 % pow2 24) * pow2 112 + v x7 / pow2 24 * pow2 168;
-    (==) { _ by (Tactics.norm [delta_only [`%pow2]; primops]; int_semiring ()) }
+    == { _ by (Tactics.norm [delta_only [`%pow2]; primops]; int_semiring ()) }
     ((v x7 / pow2 24) * pow2 24 + v x7 % pow2 24) * pow2 144;
-    (==) { FStar.Math.Lemmas.euclidean_division_definition (v x7) (pow2 24) }
+    == { FStar.Math.Lemmas.euclidean_division_definition (v x7) (pow2 24) }
     v x7 * pow2 144;
   }
 
@@ -193,9 +193,9 @@ val lemma_div248_x8: x8:uint64 ->
 let lemma_div248_x8 x8 =
   calc (==) {
     pow2 32 * (v x8 % pow2 24) * pow2 168 + v x8 / pow2 24 * pow2 224;
-    (==) { _ by (Tactics.norm [delta_only [`%pow2]; primops]; int_semiring ()) }
+    == { _ by (Tactics.norm [delta_only [`%pow2]; primops]; int_semiring ()) }
     ((v x8 / pow2 24) * pow2 24 + v x8 % pow2 24) * pow2 200;
-    (==) { FStar.Math.Lemmas.euclidean_division_definition (v x8) (pow2 24) }
+    == { FStar.Math.Lemmas.euclidean_division_definition (v x8) (pow2 24) }
     v x8 * pow2 200;
   }
 
@@ -205,9 +205,9 @@ val lemma_div248_x9: x9:uint64{v x9 < pow2 24} ->
 let lemma_div248_x9 x9 =
   calc (==) {
     pow2 32 * (v x9 % pow2 24) * pow2 224;
-    (==) { Math.Lemmas.small_mod (v x9) (pow2 24) }
+    == { Math.Lemmas.small_mod (v x9) (pow2 24) }
     pow2 32 * v x9 * pow2 224;
-    (==) { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
+    == { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
     v x9 * pow2 256;
   }
 
@@ -257,23 +257,23 @@ let lemma_div248 x =
     let z3 = v x7 / pow2 24 + pow2 32 * (v x8 % pow2 24) in
     let z4 = v x8 / pow2 24 + pow2 32 * (v x9 % pow2 24) in
     z0 + z1 * pow2 56 + z2 * pow2 112 + z3 * pow2 168 + z4 * pow2 224);
-  (==) { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
+  == { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
     v x4 / pow2 24 + pow2 32 * (v x5 % pow2 24) +
     v x5 / pow2 24 * pow2 56 + pow2 32 * (v x6 % pow2 24) * pow2 56 +
     v x6 / pow2 24 * pow2 112 + pow2 32 * (v x7 % pow2 24) * pow2 112 +
     v x7 / pow2 24 * pow2 168 + pow2 32 * (v x8 % pow2 24) * pow2 168 +
     v x8 / pow2 24 * pow2 224 + pow2 32 * (v x9 % pow2 24) * pow2 224;
-  (==) { lemma_div248_x5 x5; lemma_div248_x6 x6 }
+  == { lemma_div248_x5 x5; lemma_div248_x6 x6 }
     v x4 / pow2 24 + v x5 * pow2 32 + v x6 * pow2 88 +
     pow2 32 * (v x7 % pow2 24) * pow2 112 +
     v x7 / pow2 24 * pow2 168 + pow2 32 * (v x8 % pow2 24) * pow2 168 +
     v x8 / pow2 24 * pow2 224 + pow2 32 * (v x9 % pow2 24) * pow2 224;
-  (==) { lemma_div248_x7 x7; lemma_div248_x8 x8 }
+  == { lemma_div248_x7 x7; lemma_div248_x8 x8 }
     v x4 / pow2 24 + v x5 * pow2 32 + v x6 * pow2 88 + v x7 * pow2 144 + v x8 * pow2 200 +
     pow2 32 * (v x9 % pow2 24) * pow2 224;
-  (==) { lemma_div248_x9 x9 }
+  == { lemma_div248_x9 x9 }
     v x4 / pow2 24 + v x5 * pow2 32 + v x6 * pow2 88 + v x7 * pow2 144 + v x8 * pow2 200 + v x9 * pow2 256;
-  (==) { lemma_div248_aux x }
+  == { lemma_div248_aux x }
     wide_as_nat5 x / pow2 248;
   }
 #pop-options
@@ -345,13 +345,13 @@ let lemma_div264_aux x =
 
   calc (==) {
     wide_as_nat5 x / pow2 264;
-  (==) { FStar.Math.Lemmas.division_multiplication_lemma (wide_as_nat5 x) (pow2 224) (pow2 40) }
+  == { FStar.Math.Lemmas.division_multiplication_lemma (wide_as_nat5 x) (pow2 224) (pow2 40) }
     (wide_as_nat5 x / pow2 224) / pow2 40;
-  (==) { lemma_div224 x }
+  == { lemma_div224 x }
     (v x4 + v x5 * pow2 56 + v x6 * pow2 112 + v x7 * pow2 168 + v x8 * pow2 224 + v x9 * pow2 280) / pow2 40;
-  (==) { _ by (Tactics.mapply (`feq #int #int (fun x -> x / pow2 40)); int_semiring ()) }
+  == { _ by (Tactics.mapply (`feq #int #int (fun x -> x / pow2 40)); int_semiring ()) }
     (v x4 + (v x5 * pow2 16 + v x6 * pow2 72 + v x7 * pow2 128 + v x8 * pow2 184 + v x9 * pow2 240) * pow2 40) / pow2 40;
-  (==) { FStar.Math.Lemmas.lemma_div_plus (v x4) (v x5 * pow2 16 + v x6 * pow2 72 + v x7 * pow2 128 + v x8 * pow2 184 + v x9 * pow2 240) (pow2 40) }
+  == { FStar.Math.Lemmas.lemma_div_plus (v x4) (v x5 * pow2 16 + v x6 * pow2 72 + v x7 * pow2 128 + v x8 * pow2 184 + v x9 * pow2 240) (pow2 40) }
     v x4 / pow2 40 + v x5 * pow2 16 + v x6 * pow2 72 + v x7 * pow2 128 + v x8 * pow2 184 + v x9 * pow2 240;
   }
 
@@ -362,9 +362,9 @@ let lemma_div264_x5 x5 =
   assert_norm (0 < pow2 24);
   calc (==) {
     pow2 16 * (v x5 % pow2 40) + v x5 / pow2 40 * pow2 56;
-    (==) { _ by (Tactics.norm [delta_only [`%pow2]; primops]; int_semiring ()) }
+    == { _ by (Tactics.norm [delta_only [`%pow2]; primops]; int_semiring ()) }
     ((v x5 / pow2 40) * pow2 40 + v x5 % pow2 40) * pow2 16;
-    (==) { FStar.Math.Lemmas.euclidean_division_definition (v x5) (pow2 40) }
+    == { FStar.Math.Lemmas.euclidean_division_definition (v x5) (pow2 40) }
     v x5 * pow2 16;
   }
 
@@ -374,9 +374,9 @@ val lemma_div264_x6: x6:uint64 ->
 let lemma_div264_x6 x6 =
   calc (==) {
     pow2 16 * (v x6 % pow2 40) * pow2 56 + v x6 / pow2 40 * pow2 112;
-    (==) { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
+    == { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
     ((v x6 / pow2 40) * pow2 40 + v x6 % pow2 40) * pow2 72;
-    (==) { Math.Lemmas.euclidean_division_definition (v x6) (pow2 40) }
+    == { Math.Lemmas.euclidean_division_definition (v x6) (pow2 40) }
     v x6 * pow2 72;
   }
 
@@ -386,9 +386,9 @@ val lemma_div264_x7: x7:uint64 ->
 let lemma_div264_x7 x7 =
   calc (==) {
     pow2 16 * (v x7 % pow2 40) * pow2 112 + v x7 / pow2 40 * pow2 168;
-    (==) { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
+    == { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
     ((v x7 / pow2 40) * pow2 40 + v x7 % pow2 40) * pow2 128;
-    (==) { Math.Lemmas.euclidean_division_definition (v x7) (pow2 40) }
+    == { Math.Lemmas.euclidean_division_definition (v x7) (pow2 40) }
     v x7 * pow2 128;
   }
 
@@ -398,9 +398,9 @@ val lemma_div264_x8: x8:uint64 ->
 let lemma_div264_x8 x8 =
   calc (==) {
     pow2 16 * (v x8 % pow2 40) * pow2 168 + v x8 / pow2 40 * pow2 224;
-    (==) { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
+    == { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
     ((v x8 / pow2 40) * pow2 40 + v x8 % pow2 40) * pow2 184;
-    (==) { Math.Lemmas.euclidean_division_definition (v x8) (pow2 40) }
+    == { Math.Lemmas.euclidean_division_definition (v x8) (pow2 40) }
     v x8 * pow2 184;
   }
 
@@ -409,9 +409,9 @@ val lemma_div264_x9: x9:uint64{v x9 < pow2 40} ->
 let lemma_div264_x9 x9 =
   calc (==) {
     pow2 16 * (v x9 % pow2 40) * pow2 224;
-    (==) { Math.Lemmas.small_mod (v x9) (pow2 40) }
+    == { Math.Lemmas.small_mod (v x9) (pow2 40) }
     pow2 16 * v x9 * pow2 224;
-    (==) { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
+    == { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
     v x9 * pow2 240;
   }
 
@@ -443,23 +443,23 @@ let lemma_div264 x =
     let z3 = v x7 / pow2 40 + pow2 16 * (v x8 % pow2 40) in
     let z4 = v x8 / pow2 40 + pow2 16 * (v x9 % pow2 40) in
     z0 + z1 * pow2 56 + z2 * pow2 112 + z3 * pow2 168 + z4 * pow2 224);
-  (==) { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
+  == { _ by (Tactics.norm [delta; primops]; int_semiring ()) }
     v x4 / pow2 40 + pow2 16 * (v x5 % pow2 40) +
     v x5 / pow2 40 * pow2 56 + pow2 16 * (v x6 % pow2 40) * pow2 56 +
     v x6 / pow2 40 * pow2 112 + pow2 16 * (v x7 % pow2 40) * pow2 112 +
     v x7 / pow2 40 * pow2 168 + pow2 16 * (v x8 % pow2 40) * pow2 168 +
     v x8 / pow2 40 * pow2 224 + pow2 16 * (v x9 % pow2 40) * pow2 224;
-  (==) { lemma_div264_x5 x5; lemma_div264_x6 x6 }
+  == { lemma_div264_x5 x5; lemma_div264_x6 x6 }
     v x4 / pow2 40 + v x5 * pow2 16 + v x6 * pow2 72 +
     pow2 16 * (v x7 % pow2 40) * pow2 112 +
     v x7 / pow2 40 * pow2 168 + pow2 16 * (v x8 % pow2 40) * pow2 168 +
     v x8 / pow2 40 * pow2 224 + pow2 16 * (v x9 % pow2 40) * pow2 224;
-  (==) { lemma_div264_x7 x7; lemma_div264_x8 x8 }
+  == { lemma_div264_x7 x7; lemma_div264_x8 x8 }
     v x4 / pow2 40 + v x5 * pow2 16 + v x6 * pow2 72 + v x7 * pow2 128 + v x8 * pow2 184 +
     pow2 16 * (v x9 % pow2 40) * pow2 224;
-  (==) { lemma_div264_x9 x9 }
+  == { lemma_div264_x9 x9 }
     v x4 / pow2 40 + v x5 * pow2 16 + v x6 * pow2 72 + v x7 * pow2 128 + v x8 * pow2 184 + v x9 * pow2 240;
-  (==) { lemma_div264_aux x }
+  == { lemma_div264_aux x }
     wide_as_nat5 x / pow2 264;
   }
 #pop-options
@@ -488,14 +488,14 @@ let lemma_mod_264_aux t =
 
   calc (==) {
     (wide_as_nat5 t) % pow2 264;
-  (==) { }
+  == { }
     (v t0 + v t1 * pow2 56 + v t2 * pow2 112 + v t3 * pow2 168 + v t4 * pow2 224 +
      (v t5 * pow2 16 + v t6 * pow2 72 + v t7 * pow2 128 + v t8 * pow2 184 + v t9 * pow2 240) * pow2 264) % pow2 264;
-  (==) { FStar.Math.Lemmas.lemma_mod_add_distr (v t0 + v t1 * pow2 56 + v t2 * pow2 112 + v t3 * pow2 168 + v t4 * pow2 224)
+  == { FStar.Math.Lemmas.lemma_mod_add_distr (v t0 + v t1 * pow2 56 + v t2 * pow2 112 + v t3 * pow2 168 + v t4 * pow2 224)
     ((v t5 * pow2 16 + v t6 * pow2 72 + v t7 * pow2 128 + v t8 * pow2 184 + v t9 * pow2 240) * pow2 264) (pow2 264)}
     ((v t0 + v t1 * pow2 56 + v t2 * pow2 112 + v t3 * pow2 168 + v t4 * pow2 224) +
      ((v t5 * pow2 16 + v t6 * pow2 72 + v t7 * pow2 128 + v t8 * pow2 184 + v t9 * pow2 240) * pow2 264) % pow2 264) % pow2 264;
-  (==) { FStar.Math.Lemmas.cancel_mul_mod (v t5 * pow2 16 + v t6 * pow2 72 + v t7 * pow2 128 + v t8 * pow2 184 + v t9 * pow2 240) (pow2 264) }
+  == { FStar.Math.Lemmas.cancel_mul_mod (v t5 * pow2 16 + v t6 * pow2 72 + v t7 * pow2 128 + v t8 * pow2 184 + v t9 * pow2 240) (pow2 264) }
     (v t0 + v t1 * pow2 56 + v t2 * pow2 112 + v t3 * pow2 168 + v t4 * pow2 224) % pow2 264;
   }
 #pop-options
@@ -535,13 +535,13 @@ let lemma_mod_264 t =
 
   calc (==) {
     (wide_as_nat5 t) % pow2 264;
-    (==) { lemma_mod_264_aux t }
+    == { lemma_mod_264_aux t }
     (v t0 + v t1 * pow2 56 + v t2 * pow2 112 + v t3 * pow2 168 + v t4 * pow2 224) % pow2 264;
-    (==) { FStar.Math.Lemmas.lemma_mod_add_distr (v t0 + v t1 * pow2 56 + v t2 * pow2 112 + v t3 * pow2 168) (v t4 * pow2 224) (pow2 264) }
+    == { FStar.Math.Lemmas.lemma_mod_add_distr (v t0 + v t1 * pow2 56 + v t2 * pow2 112 + v t3 * pow2 168) (v t4 * pow2 224) (pow2 264) }
     (v t0 + v t1 * pow2 56 + v t2 * pow2 112 + v t3 * pow2 168 + (v t4 * pow2 224) % pow2 264) % pow2 264;
-    (==) { FStar.Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v t4) 264 224 }
+    == { FStar.Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v t4) 264 224 }
     (v t0 + v t1 * pow2 56 + v t2 * pow2 112 + v t3 * pow2 168 + (v t4 % pow2 40) * pow2 224) % pow2 264;
-    (==) { lemma_as_nat_pow264 res; FStar.Math.Lemmas.modulo_lemma (as_nat5 res) (pow2 264) }
+    == { lemma_as_nat_pow264 res; FStar.Math.Lemmas.modulo_lemma (as_nat5 res) (pow2 264) }
     v t0 + v t1 * pow2 56 + v t2 * pow2 112 + v t3 * pow2 168 + (v t4 % pow2 40) * pow2 224;
     }
 
@@ -677,7 +677,7 @@ let lemma_mul_5''' x1 x2 x3 x4 x5 y1 y2 y3 y4 y5 =
   calc (==) {
     ((x1 + pow2 56 * x2 + pow2 112 * x3 + pow2 168 * x4 + pow2 224 * x5)
     * (y1 + pow2 56 * y2 + pow2 112 * y3 + pow2 168 * y4 + pow2 224 * y5)) % pow2 264;
-  (==) { _ by (Tactics.mapply (`feq #int #int (fun x -> x % pow2 264));
+  == { _ by (Tactics.mapply (`feq #int #int (fun x -> x % pow2 264));
               Tactics.norm [zeta; iota; delta; primops];
               int_semiring ()) }
     (x1 * y1
@@ -689,7 +689,7 @@ let lemma_mul_5''' x1 x2 x3 x4 x5 y1 y2 y3 y4 y5 =
        pow2 16 * x3 * y4 + pow2 72 * x3 * y5 +
        pow2 16 * x4 * y3 + pow2 72 * x4 * y4 + pow2 128 * x4 * y5 +
        pow2 16 * x5 * y2 + pow2 72 * x5 * y3 + pow2 128 * x5 * y4 + pow2 184 * x5 * y5) * pow2 264) % pow2 264;
-  (==) { _ by (Tactics.mapply (`eq_eq2); Tactics.mapply (`Math.Lemmas.lemma_mod_plus)) }
+  == { _ by (Tactics.mapply (`eq_eq2); Tactics.mapply (`Math.Lemmas.lemma_mod_plus)) }
     (x1 * y1
     + pow2 56 * (x2 * y1 + x1 * y2)
     + pow2 112 * (x3 * y1 + x2 * y2 + x1 * y3)
@@ -879,23 +879,23 @@ let lemma_barrett_reduce'' (u:nat) (z:nat) (x:nat) (q:nat) : Lemma
   if u >= S.q then (
     calc (==) {
     z;
-    (==) { Math.Lemmas.small_mod z S.q }
+    == { Math.Lemmas.small_mod z S.q }
     (u - S.q) % S.q;
-    (==) { }
+    == { }
     (x - (q * S.q + S.q)) % S.q;
-    (==) { Math.Lemmas.distributivity_add_left q 1 S.q; assert_norm (1 * S.q == S.q) }
+    == { Math.Lemmas.distributivity_add_left q 1 S.q; assert_norm (1 * S.q == S.q) }
     (x - (q + 1) * S.q) % S.q;
-    (==) { Math.Lemmas.lemma_mod_sub x S.q (q+1) }
+    == { Math.Lemmas.lemma_mod_sub x S.q (q+1) }
     x % S.q;
     }
   ) else (
     calc (==) {
     z;
-    (==) { Math.Lemmas.small_mod z S.q }
+    == { Math.Lemmas.small_mod z S.q }
     u % S.q;
-    (==) { }
+    == { }
     (x - (q * S.q)) % S.q;
-    (==) { Math.Lemmas.lemma_mod_sub x S.q q }
+    == { Math.Lemmas.lemma_mod_sub x S.q q }
     x % S.q;
     }
   )
@@ -921,25 +921,25 @@ let lemma_barrett_reduce' x =
   let a' = (x % pow2 264) - (q * l) % pow2 264 in
   calc (<) {
     x - q * l;
-    (<) { lemma_optimized_barrett_reduce x }
+    < { lemma_optimized_barrett_reduce x }
     2 * S.q;
-    (<) { assert_norm (2 * S.q < pow2 264) }
+    < { assert_norm (2 * S.q < pow2 264) }
     pow2 264;
   };
   calc (>=) {
     x - q * l;
-    (>=) { lemma_optimized_barrett_reduce x}
+    >= { lemma_optimized_barrett_reduce x}
     0;
   };
   Math.Lemmas.modulo_lemma (x - q * l) (pow2 264);
   calc (<) {
     x - ((x * m) / pow2 512) * l;
-    (<) { lemma_optimized_barrett_reduce2 x }
+    < { lemma_optimized_barrett_reduce2 x }
     pow2 264;
   };
   calc (>=) {
     x - ((x * m) / pow2 512) * l;
-    (>=) { lemma_optimized_barrett_reduce2 x }
+    >= { lemma_optimized_barrett_reduce2 x }
     0;
   };
   Math.Lemmas.modulo_lemma (x - ((x * m) / pow2 512) * l) (pow2 264);

--- a/code/ed25519/Hacl.Spec.BignumQ.Mul.fst
+++ b/code/ed25519/Hacl.Spec.BignumQ.Mul.fst
@@ -224,11 +224,11 @@ let mul64_wide_5 a b =
     = if v a = 0 || v b = 0 then () else
       calc (<) {
        v a * v b <: int;
-       (<) { Math.Lemmas.lemma_mult_le_left (v a) (v b) (pow2 56) }
+       < { Math.Lemmas.lemma_mult_le_left (v a) (v b) (pow2 56) }
        v a * pow2 56;
-       (<) { Math.Lemmas.lemma_mult_le_right (pow2 56) (v a) (pow2 56) }
+       < { Math.Lemmas.lemma_mult_le_right (pow2 56) (v a) (pow2 56) }
        pow2 56 * pow2 56;
-       (==) { assert_norm (pow2 56 * pow2 56 == pow2 112) }
+       == { assert_norm (pow2 56 * pow2 56 == pow2 112) }
        pow2 112;
       }
   in
@@ -239,11 +239,11 @@ let mul64_wide_5 a b =
       assert_norm (pow2 112 - pow2 57 + 1 >= 0);
       calc (<=) {
        v a * v b <: int;
-       (<=) { Math.Lemmas.lemma_mult_le_left (v a) (v b) (pow2 56 - 1) }
+       <= { Math.Lemmas.lemma_mult_le_left (v a) (v b) (pow2 56 - 1) }
        v a * (pow2 56 - 1);
-       (<=) { Math.Lemmas.lemma_mult_le_right (pow2 56 - 1) (v a) (pow2 56 - 1) }
+       <= { Math.Lemmas.lemma_mult_le_right (pow2 56 - 1) (v a) (pow2 56 - 1) }
        (pow2 56 - 1) * (pow2 56 - 1);
-       (==) { assert_norm ((pow2 56 - 1) * (pow2 56 - 1) == pow2 112 - pow2 57 + 1) }
+       == { assert_norm ((pow2 56 - 1) * (pow2 56 - 1) == pow2 112 - pow2 57 + 1) }
        pow2 112 - pow2 57 + 1;
       }
   in
@@ -412,38 +412,38 @@ let mul_5 (x0, x1, x2, x3, x4) (y0, y1, y2, y3, y4) =
 
       calc (<) {
         v c0;
-        (<) { Math.Lemmas.lemma_div_lt_nat (v z0) 112 56 }
+        < { Math.Lemmas.lemma_div_lt_nat (v z0) 112 56 }
         pow2 56;
       };
       calc (<) {
         v c1;
-        (<) { assert_norm (2*(pow2 112 - pow2 57 + 1) + pow2 56 <= pow2 113);
+        < { assert_norm (2*(pow2 112 - pow2 57 + 1) + pow2 56 <= pow2 113);
           Math.Lemmas.lemma_div_lt_nat (v z1 + v c0) 113 56 }
         pow2 57;
       };
       calc (<) {
         v c2;
-        (<) { assert_norm (3*(pow2 112 - pow2 57 + 1) + pow2 57 <= pow2 114);
+        < { assert_norm (3*(pow2 112 - pow2 57 + 1) + pow2 57 <= pow2 114);
           Math.Lemmas.lemma_div_lt_nat (v z2 + v c1) 114 56 }
         pow2 58;
       };
       calc (<=) {
         v c3;
-        (<=) { assert_norm (4*(pow2 112 - pow2 57 + 1) + pow2 58 <= 31153781151208965410895007785680895);
+        <= { assert_norm (4*(pow2 112 - pow2 57 + 1) + pow2 58 <= 31153781151208965410895007785680895);
            assert_norm (31153781151208965410895007785680895 / pow56 == 432345564227567610);
           Math.Lemmas.lemma_div_le (v z3 + v c2) 31153781151208965410895007785680895 (pow2 56) }
         432345564227567610;
       };
       calc (<=) {
         v c4;
-        (<=) { assert_norm (5*(pow2 112 - pow2 57 + 1) + 432345564227567610 <= 25961484292674137854422105494388735); // (pow2 59 - 2) * pow56
+        <= { assert_norm (5*(pow2 112 - pow2 57 + 1) + 432345564227567610 <= 25961484292674137854422105494388735); // (pow2 59 - 2) * pow56
           assert_norm (25961484292674137854422105494388735 / pow56 == 360287970189639675);
           Math.Lemmas.lemma_div_le (v z4 + v c3) 25961484292674137854422105494388735 (pow2 56) }
         360287970189639675;
       };
       calc (<=) {
         v c5;
-        (<=) { assert_norm (4*(pow2 112 - pow2 57 + 1) + 360287970189639675 <= 20769187434139310297949203203096575);
+        <= { assert_norm (4*(pow2 112 - pow2 57 + 1) + 360287970189639675 <= 20769187434139310297949203203096575);
           Math.Lemmas.lemma_div_le (v z5 + v c4) 20769187434139310297949203203096575 (pow2 56);
           assert_norm (20769187434139310297949203203096575 / pow2 56 == pow2 58 - 4) }
         pow2 58 - 4;
@@ -451,21 +451,21 @@ let mul_5 (x0, x1, x2, x3, x4) (y0, y1, y2, y3, y4) =
 
       calc (<=) {
         v c6;
-        (<=) { assert_norm (3*(pow2 112 - pow2 57 + 1) + pow2 58 - 4 <= 15576890575604482741476300911804415);
+        <= { assert_norm (3*(pow2 112 - pow2 57 + 1) + pow2 58 - 4 <= 15576890575604482741476300911804415);
           Math.Lemmas.lemma_div_le (v z6 + v c5) 15576890575604482741476300911804415 (pow2 56);
           assert_norm (15576890575604482741476300911804415 / pow2 56 == 216172782113783805) }
         216172782113783805;
       };
       calc (<=) {
         v c7;
-        (<=) { assert_norm (2*(pow2 112 - pow2 57 + 1) + 216172782113783805 <= 10384593717069655185003398620512255); // (pow2 57 - 1) * pow2 56 - 1
+        <= { assert_norm (2*(pow2 112 - pow2 57 + 1) + 216172782113783805 <= 10384593717069655185003398620512255); // (pow2 57 - 1) * pow2 56 - 1
           Math.Lemmas.lemma_div_le (v z7 + v c6) 10384593717069655185003398620512255 (pow2 56);
           assert_norm (10384593717069655185003398620512255 / pow2 56 == pow2 57 - 2) }
         pow2 57 - 2;
       };
       calc (<) {
         v c8;
-        (<) { Math.Lemmas.lemma_div_lt_nat (v z8 + v c7) 112 56 }
+        < { Math.Lemmas.lemma_div_lt_nat (v z8 + v c7) 112 56 }
         pow2 56;
       };
       assert_norm (pow2 56 < pow2 64);
@@ -476,10 +476,10 @@ let mul_5 (x0, x1, x2, x3, x4) (y0, y1, y2, y3, y4) =
 
   calc (==) {
     wide_as_nat5 (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9) <: int;
-    (==) { }
+    == { }
     v t0 + v t1 * pow56 + v t2 * pow112 + v t3 * pow168 + v t4 * pow224 +
     v t5 * pow280 + v t6 * pow336 + v t7 * pow392 + v t8 * pow448 + v t9 * pow504;
-    (==) { assert_norm (pow2 61 < pow2 64);
+    == { assert_norm (pow2 61 < pow2 64);
            Math.Lemmas.small_mod (v c8) (pow2 64)
     }
     v z0 - v c0 * pow2 56 +
@@ -492,7 +492,7 @@ let mul_5 (x0, x1, x2, x3, x4) (y0, y1, y2, y3, y4) =
     (v z7 + v c6 - v c7 * pow2 56) * pow392 +
     (v z8 + v c7 - v c8 * pow2 56) * pow448 +
     v c8 * pow504;
-    (==) {
+    == {
       lemma_mult_distr_3 (v z1) (v c0) (v c1) 56;
       lemma_mult_distr_3 (v z2) (v c1) (v c2) 112;
       lemma_mult_distr_3 (v z3) (v c2) (v c3) 168;
@@ -511,44 +511,44 @@ let mul_5 (x0, x1, x2, x3, x4) (y0, y1, y2, y3, y4) =
     v z6 * pow336 +
     v z7 * pow392 +
     v z8 * pow448;
-    (==) { calc (==) {
+    == { calc (==) {
              v z1;
-             (==) { }
+             == { }
              v x0 * v y1 + v x1 * v y0;
            };
            calc (==) {
              v z2;
-             (==) { }
+             == { }
              v x0 * v y2 + v x1 * v y1 + v x2 * v y0;
            };
            calc (==) {
              v z3;
-             (==) { }
+             == { }
              v x0 * v y3 + v x1 * v y2 + v x2 * v y1 + v x3 * v y0;
            };
            calc (==) {
              v z4;
-             (==) { }
+             == { }
              v x0 * v y4 + v x1 * v y3 + v x2 * v y2 + v x3 * v y1 + v x4 * v y0;
            };
            calc (==) {
              v z5;
-             (==) { }
+             == { }
              v x1 * v y4 + v x2 * v y3 + v x3 * v y2 + v x4 * v y1;
            };
            calc (==) {
              v z6;
-             (==) { }
+             == { }
              v x2 * v y4 + v x3 * v y3 + v x4 * v y2;
            };
            calc (==) {
              v z7;
-             (==) { }
+             == { }
              v x3 * v y4 + v x4 * v y3;
            };
            calc (==) {
              v z8;
-             (==) { }
+             == { }
              v x4 * v y4;
            }
          }
@@ -561,7 +561,7 @@ let mul_5 (x0, x1, x2, x3, x4) (y0, y1, y2, y3, y4) =
     (v x2 * v y4 + v x3 * v y3 + v x4 * v y2) * pow336 +
     (v x3 * v y4 + v x4 * v y3) * pow392 +
     (v x4 * v y4) * pow448;
-    (==) { Lemmas.lemma_mul_qelem5 (v x0) (v x1) (v x2) (v x3) (v x4) (v y0) (v y1) (v y2) (v y3) (v y4) }
+    == { Lemmas.lemma_mul_qelem5 (v x0) (v x1) (v x2) (v x3) (v x4) (v y0) (v y1) (v y2) (v y3) (v y4) }
     (v x0 + v x1 * pow2 56 + v x2 * pow2 112 + v x3 * pow2 168 + v x4 * pow2 224) *
     (v y0 + v y1 * pow2 56 + v y2 * pow2 112 + v y3 * pow2 168 + v y4 * pow2 224);
   };
@@ -608,15 +608,15 @@ let low_mul_5 (x0, x1, x2, x3, x4) (y0, y1, y2, y3, y4) =
 
   calc (==) {
     as_nat5 (t0, t1, t2, t3, t4) <: int;
-    (==) { }
+    == { }
     v t0 + v t1 * pow56 + v t2 * pow112 + v t3 * pow168 + v t4 * pow224;
-    (==) { }
+    == { }
     v xy00 - v c0 * pow2 56 +
     (v xy01 + v xy10 + v c0 - v c1 * pow2 56) * pow56 +
     (v xy02 + v xy11 + v xy20 + v c1 - v c2 * pow56) * pow112 +
     (v xy03 + v xy12 + v xy21 + v xy30 + v c2 - v c3 * pow56) * pow168 +
     v t4 * pow224;
-    (==) { logand_mask (to_u64 (add_inner_carry (add5 xy04 xy13 xy22 xy31 xy40) c3)) mask40 40;
+    == { logand_mask (to_u64 (add_inner_carry (add5 xy04 xy13 xy22 xy31 xy40) c3)) mask40 40;
       Math.Lemmas.pow2_modulo_modulo_lemma_1 (v (add_inner_carry (add5 xy04 xy13 xy22 xy31 xy40) c3)) 40 64
     }
     v x0 * v y0 +

--- a/code/ed25519/Hacl.Spec.Ed25519.PrecompTable.fst
+++ b/code/ed25519/Hacl.Spec.Ed25519.PrecompTable.fst
@@ -82,11 +82,11 @@ val lemma_mod_pow2_sub: x:nat -> a:nat -> b:nat ->
 let lemma_mod_pow2_sub x a b =
   calc (==) {
     x / pow2 a % pow2 b * pow2 a;
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 x a (a + b) }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 x a (a + b) }
     x % pow2 (a + b) / pow2 a * pow2 a;
-    (==) { Math.Lemmas.euclidean_division_definition (x % pow2 (a + b)) (pow2 a) }
+    == { Math.Lemmas.euclidean_division_definition (x % pow2 (a + b)) (pow2 a) }
     x % pow2 (a + b) - x % pow2 (a + b) % pow2 a;
-    (==) { Math.Lemmas.pow2_modulo_modulo_lemma_1 x a (a + b) }
+    == { Math.Lemmas.pow2_modulo_modulo_lemma_1 x a (a + b) }
     x % pow2 (a + b) - x % pow2 a;
   }
 
@@ -107,15 +107,15 @@ let felem_to_list_lemma_eval x =
   assert (nat_x == x0 + x1 * pow51 + x2 * pow102 + x3 * pow153 + x4 * pow204);
   calc (==) {
     x0 + x1 * pow51 + x2 * pow102 + x3 * pow153 + x4 * pow204;
-    (==) { }
+    == { }
     x0 + x1 * pow51 + x2 * pow102 + (x / pow153 % pow51) * pow153 + x / pow204 * pow204;
-    (==) { lemma_mod_pow2_sub x 153 51 }
+    == { lemma_mod_pow2_sub x 153 51 }
     x0 + x1 * pow51 + x2 * pow102 + x % pow204 - x % pow153 + x / pow204 * pow204;
-    (==) { Math.Lemmas.euclidean_division_definition x pow204 }
+    == { Math.Lemmas.euclidean_division_definition x pow204 }
     x0 + x1 * pow51 + (x / pow102 % pow51) * pow102 - x % pow153 + x;
-    (==) { lemma_mod_pow2_sub x 102 51 }
+    == { lemma_mod_pow2_sub x 102 51 }
     x0 + (x / pow51 % pow51) * pow51 - x % pow102 + x;
-    (==) { lemma_mod_pow2_sub x 51 51 }
+    == { lemma_mod_pow2_sub x 51 51 }
     x;
   }
 
@@ -152,9 +152,9 @@ let ext_point_to_list_sub p =
 
   calc (==) { // ((a * b) * c) * d == a * (b * (c * d))
     FL.append (FL.append (FL.append px_list py_list) pz_list) pt_list;
-    (==) { FL.append_assoc FL.(px_list @ py_list) pz_list pt_list }
+    == { FL.append_assoc FL.(px_list @ py_list) pz_list pt_list }
     FL.append (FL.append px_list py_list) (FL.append pz_list pt_list);
-    (==) { FL.append_assoc px_list py_list (FL.append pz_list pt_list) }
+    == { FL.append_assoc px_list py_list (FL.append pz_list pt_list) }
     FL.(px_list @ py_list @ pz_list @ pt_list);
   };
 

--- a/code/ffdhe/Hacl.Spec.FFDHE.Lemmas.fst
+++ b/code/ffdhe/Hacl.Spec.FFDHE.Lemmas.fst
@@ -50,15 +50,15 @@ let pow2_lt_len len =
   let b = pow2 (8 * (len - 1)) * (pow2 8 - 1) in
   calc (==) {
     b / a;
-    (==) { Math.Lemmas.pow2_plus (8 * len - 8) 7 }
+    == { Math.Lemmas.pow2_plus (8 * len - 8) 7 }
     b / (pow2 (8 * len - 8) * pow2 7);
-    (==) { Math.Lemmas.division_multiplication_lemma b (pow2 (8 * len - 8)) (pow2 7) }
+    == { Math.Lemmas.division_multiplication_lemma b (pow2 (8 * len - 8)) (pow2 7) }
     b / pow2 (8 * len - 8) / pow2 7;
-    (==) { Math.Lemmas.cancel_mul_div (pow2 8 - 1) (pow2 (8 * len - 8)) }
+    == { Math.Lemmas.cancel_mul_div (pow2 8 - 1) (pow2 (8 * len - 8)) }
     (pow2 8 - 1) / pow2 7;
-    (==) { Math.Lemmas.pow2_plus 7 1 }
+    == { Math.Lemmas.pow2_plus 7 1 }
     (pow2 7 * 2 - 1) / pow2 7;
-    (==) { }
+    == { }
     1;
     };
   //  assert (b / a * a <= b);
@@ -66,15 +66,15 @@ let pow2_lt_len len =
 
   calc (>) {
     pow2 (8 * len - 8) * (pow2 8 - 1) % pow2 (8 * len - 1);
-    (==) { Math.Lemmas.pow2_plus (8 * len - 8) 8 }
+    == { Math.Lemmas.pow2_plus (8 * len - 8) 8 }
     (pow2 (8 * len) - pow2 (8 * len - 8)) % pow2 (8 * len - 1);
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l (pow2 (8 * len)) (- pow2 (8 * len - 8)) (pow2 (8 * len - 1)) }
+    == { Math.Lemmas.lemma_mod_plus_distr_l (pow2 (8 * len)) (- pow2 (8 * len - 8)) (pow2 (8 * len - 1)) }
     (pow2 (8 * len) % pow2 (8 * len - 1) - pow2 (8 * len - 8)) % pow2 (8 * len - 1);
-    (==) { Math.Lemmas.pow2_multiplication_modulo_lemma_1 1 (8 * len - 1) (8 * len) }
+    == { Math.Lemmas.pow2_multiplication_modulo_lemma_1 1 (8 * len - 1) (8 * len) }
     (0 - pow2 (8 * len - 8)) % pow2 (8 * len - 1);
-    //(==) { Math.Lemmas.pow2_lt_compat (8 * len - 1) (8 * len - 8) }
+    //== { Math.Lemmas.pow2_lt_compat (8 * len - 1) (8 * len - 8) }
     //pow2 (8 * len - 1) - pow2 (8 * len - 8);
-    (>) { Math.Lemmas.pow2_lt_compat (8 * len - 1) (8 * len - 8) }
+    > { Math.Lemmas.pow2_lt_compat (8 * len - 1) (8 * len - 8) }
     0;
     };
 

--- a/code/hash/Hacl.Hash.Blake2b_256.fst
+++ b/code/hash/Hacl.Hash.Blake2b_256.fst
@@ -42,13 +42,13 @@ let hash output input input_len = Hacl.Streaming.Blake2b_256.hash_with_key outpu
 let copy_internal_state src dst =
   calc (==) {
     B.length src;
-  (==) {}
+  == {}
     impl_state_length (| Spec.Agile.Hash.Blake2B, Hacl.Impl.Blake2.Core.M256 |);
-  (==) {}
+  == {}
     UInt32.v (4ul *. row_len Spec.Blake2.Definitions.Blake2B Hacl.Impl.Blake2.Core.M256);
-  (==) {}
+  == {}
     UInt32.v (4ul *. 1ul);
-  (==) { Lib.IntTypes.mul_mod_lemma 4ul 1ul; assert_norm (4 < pow2 32) }
+  == { Lib.IntTypes.mul_mod_lemma 4ul 1ul; assert_norm (4 < pow2 32) }
     UInt32.v 4ul;
   };
   B.blit src 0ul dst 0ul 4ul

--- a/code/hash/Hacl.Hash.MD.fst
+++ b/code/hash/Hacl.Hash.MD.fst
@@ -290,15 +290,15 @@ let mk_hash a alloca update_multi update_last finish output input input_len =
   // We need to prove that rest_v0 @| padding is a block. We do this using the calc below
   calc (==) {
     S.(length (rest_v0 @| padding)) % block_length a;
-    (==) { }
+    == { }
     S.(length rest_v0 + S.length padding) % block_length a;
-    (==) { Math.Lemmas.lemma_mod_add_distr (S.length padding) (S.length rest_v0) (block_length a) }
+    == { Math.Lemmas.lemma_mod_add_distr (S.length padding) (S.length rest_v0) (block_length a) }
     S.(length rest_v0 % block_length a + S.length padding) % block_length a;
-    (==) { }
+    == { }
     S.(length input_v0 % block_length a + S.length padding) % block_length a;
-    (==) { Math.Lemmas.lemma_mod_add_distr (S.length padding) (S.length input_v0) (block_length a) }
+    == { Math.Lemmas.lemma_mod_add_distr (S.length padding) (S.length input_v0) (block_length a) }
     S.(length input_v0 + S.length padding) % block_length a;
-    (==) { }
+    == { }
     0;
   };
   (**) assert (as_seq h02 s == Spec.Agile.Hash.(update_multi a

--- a/code/hash/Hacl.Hash.SHA2.fst
+++ b/code/hash/Hacl.Hash.SHA2.fst
@@ -125,29 +125,29 @@ let mk_update_multi a st () blocks n_blocks =
 
   calc (==) {
     as_seq h1 st;
-  (==) { }
+  == { }
     as_seq #(| a, () |) h1 st';
-  (==) { }
+  == { }
     Vec.update_nblocks #a #Vec.M32 length_blocks blocks0_multi st0';
-  (==) { state_spec_v_lemma a (Vec.update_nblocks #a #Vec.M32 length_blocks blocks0_multi st0') }
+  == { state_spec_v_lemma a (Vec.update_nblocks #a #Vec.M32 length_blocks blocks0_multi st0') }
     Lib.Sequence.index (Vec.state_spec_v (Vec.update_nblocks #a #Vec.M32 length_blocks blocks0_multi st0')) 0;
-  (==) { Hacl.Spec.SHA2.Equiv.update_nblocks_lemma_l #a #Vec.M32 length_blocks blocks0_multi st0_raw 0 }
+  == { Hacl.Spec.SHA2.Equiv.update_nblocks_lemma_l #a #Vec.M32 length_blocks blocks0_multi st0_raw 0 }
     Hacl.Spec.SHA2.update_nblocks a length_blocks blocks0_multi.(|0|)
       (Lib.Sequence.index (Vec.state_spec_v #a #Vec.M32 (as_seq h0 st)) 0);
-  (==) { state_spec_v_lemma a (as_seq h0 st) }
+  == { state_spec_v_lemma a (as_seq h0 st) }
     Hacl.Spec.SHA2.update_nblocks a length_blocks blocks0_multi.(|0|) (as_seq h0 st);
-  (==) { }
+  == { }
     Hacl.Spec.SHA2.update_nblocks a length_blocks blocks0 st0;
-  (==) { Hacl.Spec.SHA2.EquivScalar.update_nblocks_is_repeat_blocks_multi a length_blocks blocks0 st0 } (
+  == { Hacl.Spec.SHA2.EquivScalar.update_nblocks_is_repeat_blocks_multi a length_blocks blocks0 st0 } (
     let b = blocks0 in
     let open Lib.Sequence in
     let bl = block_length a in
     repeat_blocks_multi #Lib.IntTypes.uint8 #(words_state a) bl
       (Seq.slice b 0 (Seq.length b - Seq.length b % bl)) (Hacl.Spec.SHA2.update a) st0);
-  (==) { }
+  == { }
     Lib.Sequence.repeat_blocks_multi #Lib.IntTypes.uint8 #(words_state a)
       (block_length a) blocks0 (Hacl.Spec.SHA2.update a) st0;
-  (==) {
+  == {
     FStar.Classical.forall_intro_2 (Hacl.Spec.SHA2.EquivScalar.update_lemma a);
     Lib.Sequence.Lemmas.repeat_blocks_multi_extensionality
       #Lib.IntTypes.uint8 #(words_state a)
@@ -157,12 +157,12 @@ let mk_update_multi a st () blocks n_blocks =
   }
     Lib.Sequence.repeat_blocks_multi #Lib.IntTypes.uint8 #(words_state a)
       (block_length a) blocks0 (Lib.UpdateMulti.Lemmas.repeat_f (block_length a) (Spec.Agile.Hash.update a)) st0;
-  (==) {
+  == {
     Lib.UpdateMulti.Lemmas.update_multi_is_repeat_blocks_multi #(words_state a)
       (block_length a) (Spec.Agile.Hash.update a) st0 blocks0
   }
     Lib.UpdateMulti.mk_update_multi #(words_state a) (block_length a) (Spec.Agile.Hash.update a) st0 blocks0;
-  (==) { }
+  == { }
     Spec.Agile.Hash.update_multi a st0 () blocks0;
   }
   end
@@ -216,53 +216,53 @@ let mk_update_last a st prev_len input input_len =
     let blocks1_raw = Seq.append input0_raw pad_s in
     calc (==) {
       blocks1;
-      (==) { ntup1_lemma #_ #1 input0; assert (Seq.equal blocks1 blocks1_raw) }
+      == { ntup1_lemma #_ #1 input0; assert (Seq.equal blocks1 blocks1_raw) }
       blocks1_raw;
     };
 
     calc (==) {
       vtotlen % block_length a;
-      (==) { }
+      == { }
       (vprev_len + vlen) % block_length a;
-      (==) { Math.Lemmas.lemma_mod_add_distr vlen vprev_len (block_length a) }
+      == { Math.Lemmas.lemma_mod_add_distr vlen vprev_len (block_length a) }
       vlen % block_length a;
     };
 
     calc (==) {
       Seq.length blocks1 % block_length a;
-      (==) { }
+      == { }
       (vlen + Seq.length pad_s) % block_length a;
-      (==) { Math.Lemmas.lemma_mod_add_distr (Seq.length pad_s) vlen (block_length a) }
+      == { Math.Lemmas.lemma_mod_add_distr (Seq.length pad_s) vlen (block_length a) }
       (vlen % block_length a + Seq.length pad_s) % block_length a;
-      (==) { }
+      == { }
       (vtotlen % block_length a + Seq.length pad_s) % block_length a;
-      (==) { Math.Lemmas.lemma_mod_add_distr (Seq.length pad_s) vtotlen (block_length a) }
+      == { Math.Lemmas.lemma_mod_add_distr (Seq.length pad_s) vtotlen (block_length a) }
       (vtotlen + Seq.length pad_s) % block_length a;
-      (==) { }
+      == { }
       0;
     };
 
     calc (==) {
         as_seq h1 st;
-      (==) { }
+      == { }
         Vec.update_last #a #Vec.M32 totlen vlen input0 st0';
-      (==) { state_spec_v_lemma a (Vec.update_last totlen vlen input0 st0') }
+      == { state_spec_v_lemma a (Vec.update_last totlen vlen input0 st0') }
         Lib.Sequence.index (Vec.state_spec_v #a #Vec.M32 (Vec.update_last totlen vlen input0 st0')) 0;
-      (==) { Hacl.Spec.SHA2.Equiv.update_last_lemma_l #a #Vec.M32 totlen vlen input0 st0' 0 }
+      == { Hacl.Spec.SHA2.Equiv.update_last_lemma_l #a #Vec.M32 totlen vlen input0 st0' 0 }
         Hacl.Spec.SHA2.update_last a totlen vlen input0.(|0|)
           (Lib.Sequence.index (Vec.state_spec_v #a #Vec.M32 st0') 0);
-      (==) { state_spec_v_lemma a st0' }
+      == { state_spec_v_lemma a st0' }
         Hacl.Spec.SHA2.update_last a totlen vlen input0.(|0|) st0';
-      (==) { ntup1_lemma #_ #1 input0 }
+      == { ntup1_lemma #_ #1 input0 }
         Hacl.Spec.SHA2.update_last a totlen vlen input0 st0';
-      (==) {
+      == {
         Hacl.Spec.SHA2.EquivScalar.update_last_is_repeat_blocks_multi a vtotlen vlen input0 st0'
       }
         Lib.Sequence.repeat_blocks_multi (block_length a) blocks1 (Hacl.Spec.SHA2.update a) st0';
-      (==) { assert (st0 `Seq.equal` st0');
+      == { assert (st0 `Seq.equal` st0');
              ntup1_lemma #_ #1 input0; assert (blocks1 `Seq.equal` blocks1_raw) }
         Lib.Sequence.repeat_blocks_multi (block_length a) blocks1_raw (Hacl.Spec.SHA2.update a) st0;
-      (==) { Classical.forall_intro_2 (Hacl.Spec.SHA2.EquivScalar.update_lemma a);
+      == { Classical.forall_intro_2 (Hacl.Spec.SHA2.EquivScalar.update_lemma a);
              Lib.Sequence.Lemmas.repeat_blocks_multi_extensionality (block_length a)
                blocks1_raw
                (Hacl.Spec.SHA2.update a)
@@ -271,10 +271,10 @@ let mk_update_last a st prev_len input input_len =
         Lib.Sequence.repeat_blocks_multi (block_length a) blocks1_raw
           (Lib.UpdateMulti.Lemmas.repeat_f (block_length a) (Spec.Agile.Hash.update a))
           st0;
-      (==) {
+      == {
         Lib.UpdateMulti.Lemmas.update_multi_is_repeat_blocks_multi (block_length a) (Spec.Agile.Hash.update a) st0 blocks1_raw }
         Lib.UpdateMulti.mk_update_multi (block_length a) (Spec.Agile.Hash.update a) st0 blocks1_raw;
-      (==) { }
+      == { }
         Spec.Hash.Incremental.update_last a st0 (prev_len_v prev_len) input0_raw;
     }
   end
@@ -309,13 +309,13 @@ let mk_finish a st dst =
 
     calc (==) {
       B.as_seq h1 dst;
-      (==) { ntup1_lemma #_ #1 hash1_m;
+      == { ntup1_lemma #_ #1 hash1_m;
              ntup1_lemma #_ #1 (Hacl.Spec.SHA2.Vec.finish #a #Vec.M32 st0);
              Hacl.Spec.SHA2.Equiv.finish_lemma_l #a #Vec.M32 st0 0 }
      Hacl.Spec.SHA2.finish a (Lib.Sequence.index (Vec.state_spec_v #a #Vec.M32 st0) 0);
-     (==) { state_spec_v_lemma a st0 }
+     == { state_spec_v_lemma a st0 }
      Hacl.Spec.SHA2.finish a st0;
-     (==) { Hacl.Spec.SHA2.EquivScalar.finish_lemma a st0 }
+     == { Hacl.Spec.SHA2.EquivScalar.finish_lemma a st0 }
      Spec.Agile.Hash.finish a st0 ();
     }
   end

--- a/code/hpke/Hacl.Impl.HPKE.fst
+++ b/code/hpke/Hacl.Impl.HPKE.fst
@@ -487,21 +487,21 @@ let nat_to_bytes_2 l tmp =
   let open Lib.ByteSequence in
   calc (==) {
     Seq.index (as_seq h1 tmp) 0;
-  (==) { }
+  == { }
     Seq.index (uint_to_bytes_be l16) 0;
-  (==) { index_uint_to_bytes_be_i l16 1 }
+  == { index_uint_to_bytes_be_i l16 1 }
     uint #U8 (v l / pow2 (8 * 1) % pow2 8);
-  (==) { Lib.ByteSequence.index_nat_to_intseq_be #U8 #SEC 2 (v l) 1 }
+  == { Lib.ByteSequence.index_nat_to_intseq_be #U8 #SEC 2 (v l) 1 }
     Seq.index (Lib.ByteSequence.nat_to_bytes_be 2 (v l)) 0;
  };
 
   calc (==) {
     Seq.index (as_seq h1 tmp) 1;
-  (==) { }
+  == { }
     Seq.index (uint_to_bytes_be l16) 1;
-  (==) { index_uint_to_bytes_be_i l16 0 }
+  == { index_uint_to_bytes_be_i l16 0 }
     uint #U8 (v l / pow2 (8 * 0) % pow2 8);
-  (==) { Lib.ByteSequence.index_nat_to_intseq_be #U8 #SEC 2 (v l) 0 }
+  == { Lib.ByteSequence.index_nat_to_intseq_be #U8 #SEC 2 (v l) 0 }
     Seq.index (Lib.ByteSequence.nat_to_bytes_be 2 (v l)) 1;
  }
 #pop-options

--- a/code/k256/Hacl.Spec.K256.ECSM.Lemmas.fst
+++ b/code/k256/Hacl.Spec.K256.ECSM.Lemmas.fst
@@ -59,19 +59,19 @@ val lemma_aff_point_mul_neg_modq (a:int) (p:S.aff_point) :
 let lemma_aff_point_mul_neg_modq a p =
   calc (==) {
     aff_point_mul_neg a p;
-    (==) { Math.Lemmas.euclidean_division_definition a S.q }
+    == { Math.Lemmas.euclidean_division_definition a S.q }
     aff_point_mul_neg (a / S.q * S.q + a % S.q) p;
-    (==) { lemma_aff_point_mul_neg_add (a / S.q * S.q) (a % S.q) p }
+    == { lemma_aff_point_mul_neg_add (a / S.q * S.q) (a % S.q) p }
     S.aff_point_add (aff_point_mul_neg (a / S.q * S.q) p) (aff_point_mul_neg (a % S.q) p);
-    (==) { lemma_aff_point_mul_neg_mul (a / S.q) S.q p }
+    == { lemma_aff_point_mul_neg_mul (a / S.q) S.q p }
     S.aff_point_add
       (aff_point_mul S.q (aff_point_mul_neg (a / S.q) p))
       (aff_point_mul (a % S.q) p);
-    (==) { lemma_order_of_curve_group (aff_point_mul_neg (a / S.q) p) }
+    == { lemma_order_of_curve_group (aff_point_mul_neg (a / S.q) p) }
     S.aff_point_add S.aff_point_at_inf (aff_point_mul (a % S.q) p);
-    (==) { LS.aff_point_add_comm_lemma S.aff_point_at_inf (aff_point_mul (a % S.q) p) }
+    == { LS.aff_point_add_comm_lemma S.aff_point_at_inf (aff_point_mul (a % S.q) p) }
     S.aff_point_add (aff_point_mul (a % S.q) p) S.aff_point_at_inf;
-    (==) { LS.aff_point_at_inf_lemma (aff_point_mul (a % S.q) p) }
+    == { LS.aff_point_at_inf_lemma (aff_point_mul (a % S.q) p) }
     aff_point_mul (a % S.q) p;
   }
 
@@ -87,13 +87,13 @@ let lemma_aff_point_mul_neg a p =
   if a > 0 then begin
     calc (==) {
       aff_point_mul ((- a) % S.q) p_neg;
-      (==) { lemma_aff_point_mul_neg_modq (- a) p_neg }
+      == { lemma_aff_point_mul_neg_modq (- a) p_neg }
       aff_point_mul_neg (- a) p_neg;
-      (==) { }
+      == { }
       S.aff_point_negate (aff_point_mul a p_neg);
-      (==) { LE.lemma_inverse_pow ag p a }
+      == { LE.lemma_inverse_pow ag p a }
       S.aff_point_negate (S.aff_point_negate (aff_point_mul a p));
-      (==) { LE.lemma_inverse_id ag (aff_point_mul a p) }
+      == { LE.lemma_inverse_id ag (aff_point_mul a p) }
       aff_point_mul a p;
     } end
   else begin
@@ -109,9 +109,9 @@ val aff_point_mul_mul_lemma: a:nat -> b:nat -> p:S.aff_point ->
 let aff_point_mul_mul_lemma a b p =
   calc (==) {
     aff_point_mul a (aff_point_mul b p);
-    (==) { LE.lemma_pow_mul S.mk_k256_comm_monoid p b a }
+    == { LE.lemma_pow_mul S.mk_k256_comm_monoid p b a }
     aff_point_mul (a * b) p;
-    (==) { LE.lemma_pow_mul S.mk_k256_comm_monoid p a b }
+    == { LE.lemma_pow_mul S.mk_k256_comm_monoid p a b }
     aff_point_mul b (aff_point_mul a p);
   }
 
@@ -134,10 +134,10 @@ let aff_point_mul_mul_neg_lemma a b p =
 
   calc (==) {
     aff_point_mul a (S.aff_point_negate (aff_point_mul b p));
-    (==) { aff_point_mul_neg_lemma b p }
+    == { aff_point_mul_neg_lemma b p }
     aff_point_mul a (aff_point_mul b p_neg);
-    (==) { aff_point_mul_mul_lemma a b p_neg }
+    == { aff_point_mul_mul_lemma a b p_neg }
     aff_point_mul b (aff_point_mul a p_neg);
-    (==) { aff_point_mul_neg_lemma a p }
+    == { aff_point_mul_neg_lemma a p }
     aff_point_mul b (S.aff_point_negate (aff_point_mul a p));
   }

--- a/code/k256/Hacl.Spec.K256.Field52.Definitions.Lemmas.fst
+++ b/code/k256/Hacl.Spec.K256.Field52.Definitions.Lemmas.fst
@@ -76,15 +76,15 @@ val lemma_pow2_260_mod_prime: unit -> Lemma (pow2 260 % S.prime = 0x1000003D10)
 let lemma_pow2_260_mod_prime () =
   calc (==) {
     pow2 260 % S.prime;
-    (==) { Math.Lemmas.pow2_plus 256 4 }
+    == { Math.Lemmas.pow2_plus 256 4 }
     pow2 256 * pow2 4 % S.prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (pow2 256) (pow2 4) S.prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (pow2 256) (pow2 4) S.prime }
     (pow2 256 % S.prime) * pow2 4 % S.prime;
-    (==) { lemma_prime () }
+    == { lemma_prime () }
     0x1000003D1 * pow2 4 % S.prime;
-    (==) { assert_norm (0x1000003D1 * pow2 4 = 0x1000003D10) }
+    == { assert_norm (0x1000003D1 * pow2 4 = 0x1000003D10) }
     0x1000003D10 % S.prime;
-    (==) { Math.Lemmas.small_mod 0x1000003D10 S.prime }
+    == { Math.Lemmas.small_mod 0x1000003D10 S.prime }
     0x1000003D10;
   }
 
@@ -98,23 +98,23 @@ let lemma_as_nat_bound_f4_lt_powa f a =
   let (f0,f1,f2,f3,f4) = f in
   calc (<=) { //as_nat5 f ==
     v f0 + v f1 * pow52 + v f2 * pow104 + v f3 * pow156 + v f4 * pow208;
-    (<=) { }
+    <= { }
     pow2 52 - 1 + v f1 * pow52 + v f2 * pow104 + v f3 * pow156 + v f4 * pow208;
-    (<=) {
+    <= {
       Math.Lemmas.lemma_mult_le_right pow52 (v f1) (pow2 52 - 1);
       Math.Lemmas.distributivity_sub_left (pow2 52) 1 pow52 }
     pow2 52 * pow52 + v f2 * pow104 + v f3 * pow156 + v f4 * pow208 - 1;
-    (<=) {
+    <= {
       Math.Lemmas.lemma_mult_le_right pow104 (v f2) (pow2 52 - 1);
       Math.Lemmas.distributivity_sub_left (pow2 52) 1 pow104;
       Math.Lemmas.pow2_plus 52 52 }
     pow2 52 * pow104 + v f3 * pow156 + v f4 * pow208 - 1;
-    (<=) {
+    <= {
       Math.Lemmas.lemma_mult_le_right pow156 (v f3) (pow2 52 - 1);
       Math.Lemmas.distributivity_sub_left (pow2 52) 1 pow156;
       Math.Lemmas.pow2_plus 52 104 }
     pow2 52 * pow156 + v f4 * pow208 - 1;
-    (<=) {
+    <= {
       Math.Lemmas.lemma_mult_le_right pow208 (v f4) (pow2 a - 1);
       Math.Lemmas.distributivity_sub_left (pow2 a) 1 pow208;
       Math.Lemmas.pow2_plus 52 156;
@@ -196,11 +196,11 @@ val lemma_normalize_x_le_1: t4:uint64 -> Lemma
 let lemma_normalize_x_le_1 t4 =
   calc (==) {
     (2 * (pow2 48 - 1)) / pow2 48;
-    (==) { Math.Lemmas.distributivity_add_right 2 (pow2 48) 1 }
+    == { Math.Lemmas.distributivity_add_right 2 (pow2 48) 1 }
     (2 * pow2 48 - 2) / pow2 48;
-    (==) { Math.Lemmas.division_addition_lemma (-2) (pow2 48) 2 }
+    == { Math.Lemmas.division_addition_lemma (-2) (pow2 48) 2 }
     (-2) / pow2 48 + 2;
-    (==) { assert_norm ((-2) / pow2 48 = -1) }
+    == { assert_norm ((-2) / pow2 48 = -1) }
     1;
   };
 
@@ -258,11 +258,11 @@ let lemma_add_rsh52 m1 m2 a b =
   let c = a +. (b >>. 52ul) in
   calc (<) {
     v a + v b / pow2 52;
-    (<) { Math.Lemmas.lemma_div_lt (v b) 64 52 }
+    < { Math.Lemmas.lemma_div_lt (v b) 64 52 }
     m1 * max52 + pow2 12;
-    (<=) { Math.Lemmas.pow2_lt_compat 52 12 }
+    <= { Math.Lemmas.pow2_lt_compat 52 12 }
     m1 * max52 + max52;
-    (==) { Math.Lemmas.distributivity_add_left m1 1 max52 }
+    == { Math.Lemmas.distributivity_add_left m1 1 max52 }
     (m1 + 1) * max52;
   };
 
@@ -282,11 +282,11 @@ let lemma_add_rsh52_last m1 m2 a b =
   let c = a +. (b >>. 52ul) in
   calc (<) {
     v a + v b / pow2 52;
-    (<) { Math.Lemmas.lemma_div_lt (v b) 64 52 }
+    < { Math.Lemmas.lemma_div_lt (v b) 64 52 }
     m1 * max48 + pow2 12;
-    (<=) { Math.Lemmas.pow2_lt_compat 48 12 }
+    <= { Math.Lemmas.pow2_lt_compat 48 12 }
     m1 * max48 + max48;
-    (==) { Math.Lemmas.distributivity_add_left m1 1 max48 }
+    == { Math.Lemmas.distributivity_add_left m1 1 max48 }
     (m1 + 1) * max48;
   };
 
@@ -328,9 +328,9 @@ val lemma_small_sub_mod: a:nat -> n:pos -> Lemma
 let lemma_small_sub_mod a n =
   calc (==) {
     a % n;
-    (==) { Math.Lemmas.sub_div_mod_1 a n }
+    == { Math.Lemmas.sub_div_mod_1 a n }
     (a - n) % n;
-    (==) { Math.Lemmas.small_mod (a - n) n }
+    == { Math.Lemmas.small_mod (a - n) n }
     a - n;
   }
 
@@ -362,13 +362,13 @@ val lemma_a_plus_b_mul_pow256 (a b:int) :
 let lemma_a_plus_b_mul_pow256 a b =
   calc (==) {
     (a + b * pow2 256) % S.prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r a (b * pow2 256) S.prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_r a (b * pow2 256) S.prime }
     (a + b * pow2 256 % S.prime) % S.prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r b (pow2 256) S.prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r b (pow2 256) S.prime }
     (a + b * (pow2 256 % S.prime) % S.prime) % S.prime;
-    (==) { lemma_prime () }
+    == { lemma_prime () }
     (a + b * 0x1000003D1 % S.prime) % S.prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r a (b * 0x1000003D1) S.prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_r a (b * 0x1000003D1) S.prime }
     (a + b * 0x1000003D1) % S.prime;
   }
 
@@ -380,12 +380,12 @@ val as_nat_mod_prime (t0 t1 t2 t3 t4:int) : Lemma
 let as_nat_mod_prime t0 t1 t2 t3 t4 =
   calc (==) {
     (t0 + t1 * pow52 + t2 * pow104 + t3 * pow156 + t4 * pow208) % S.prime;
-    (==) { Math.Lemmas.euclidean_division_definition t4 (pow2 48) }
+    == { Math.Lemmas.euclidean_division_definition t4 (pow2 48) }
     (t0 + t1 * pow52 + t2 * pow104 + t3 * pow156 + (t4 / pow2 48 * pow2 48 + t4 % pow2 48) * pow208) % S.prime;
-    (==) { Math.Lemmas.distributivity_add_left (t4 / pow2 48 * pow2 48) (t4 % pow2 48) pow208 }
+    == { Math.Lemmas.distributivity_add_left (t4 / pow2 48 * pow2 48) (t4 % pow2 48) pow208 }
     (t0 + t1 * pow52 + t2 * pow104 + t3 * pow156 + t4 / pow2 48 * pow2 48 * pow208 + t4 % pow2 48 * pow208) % S.prime;
-    (==) { Math.Lemmas.paren_mul_right (t4 / pow2 48) (pow2 48) pow208; Math.Lemmas.pow2_plus 48 208 }
+    == { Math.Lemmas.paren_mul_right (t4 / pow2 48) (pow2 48) pow208; Math.Lemmas.pow2_plus 48 208 }
     (t0 + t1 * pow52 + t2 * pow104 + t3 * pow156 + t4 / pow2 48 * pow2 256 + t4 % pow2 48 * pow208) % S.prime;
-    (==) { lemma_a_plus_b_mul_pow256 (t0 + t1 * pow52 + t2 * pow104 + t3 * pow156 + t4 % pow2 48 * pow208) (t4 / pow2 48) }
+    == { lemma_a_plus_b_mul_pow256 (t0 + t1 * pow52 + t2 * pow104 + t3 * pow156 + t4 % pow2 48 * pow208) (t4 / pow2 48) }
     (t0 + t1 * pow52 + t2 * pow104 + t3 * pow156 + t4 % pow2 48 * pow208 + t4 / pow2 48 * 0x1000003D1) % S.prime;
   }

--- a/code/k256/Hacl.Spec.K256.Field52.Lemmas.fst
+++ b/code/k256/Hacl.Spec.K256.Field52.Lemmas.fst
@@ -200,7 +200,7 @@ let fnegate5_lemma m a x =
     (0xfffffffffffff * 2 * v x - v a2) * pow104 +
     (0xfffffffffffff * 2 * v x - v a3) * pow156 +
     (0xffffffffffff * 2 * v x - v a4) * pow208;
-  (==) {
+  == {
     Math.Lemmas.paren_mul_right 0xffffefffffc2f 2 (v x);
     Math.Lemmas.paren_mul_right 0xfffffffffffff 2 (v x);
     Math.Lemmas.paren_mul_right 0xffffffffffff 2 (v x);
@@ -208,7 +208,7 @@ let fnegate5_lemma m a x =
       0xffffefffffc2f 0xfffffffffffff 0xfffffffffffff 0xfffffffffffff 0xffffffffffff (2 * v x) }
     - as_nat5 a + 2 * v x * (0xffffefffffc2f + 0xfffffffffffff * pow52 +
     0xfffffffffffff * pow104 + 0xfffffffffffff * pow156 +  0xffffffffffff * pow208);
-  (==) { assert_norm (0xffffefffffc2f + 0xfffffffffffff * pow52 +
+  == { assert_norm (0xffffefffffc2f + 0xfffffffffffff * pow52 +
     0xfffffffffffff * pow104 + 0xfffffffffffff * pow156 +  0xffffffffffff * pow208 = S.prime) }
     - as_nat5 a + 2 * v x * S.prime;
   };

--- a/code/k256/Hacl.Spec.K256.Field52.Lemmas1.fst
+++ b/code/k256/Hacl.Spec.K256.Field52.Lemmas1.fst
@@ -154,15 +154,15 @@ let store_felem5_lemma_as_nat f s =
 
   calc (==) {
     v s0 + v s1 * pow2 64 + v s2 * pow2 128 + v s3 * pow2 192;
-    (==) { }
+    == { }
     v f0 + v f1 % pow2 12 * pow2 52 + (v f1 / pow2 12 + v f2 % pow2 24 * pow2 40) * pow2 64 + v s2 * pow2 128 + v s3 * pow2 192;
-    (==) { ML.lemma_a_mul_c_plus_d_mod_e_mul_f_g (v f1) 12 52 (v f2 % pow2 24) 40 64 }
+    == { ML.lemma_a_mul_c_plus_d_mod_e_mul_f_g (v f1) 12 52 (v f2 % pow2 24) 40 64 }
     v f0 + v f1 * pow2 52 + v f2 % pow2 24 * pow2 104 + (v f2 / pow2 24 + v f3 % pow2 36 * pow2 28) * pow2 128 + v s3 * pow2 192;
-    (==) { ML.lemma_a_mul_c_plus_d_mod_e_mul_f_g (v f2) 24 104 (v f3 % pow2 36) 28 128 }
+    == { ML.lemma_a_mul_c_plus_d_mod_e_mul_f_g (v f2) 24 104 (v f3 % pow2 36) 28 128 }
     v f0 + v f1 * pow2 52 + v f2 * pow2 104 + v f3 % pow2 36 * pow2 156 + (v f3 / pow2 36 + v f4 % pow2 48 * pow2 16) * pow2 192;
-    (==) { ML.lemma_a_mul_c_plus_d_mod_e_mul_f_g (v f3) 36 156 (v f4 % pow2 48) 16 192 }
+    == { ML.lemma_a_mul_c_plus_d_mod_e_mul_f_g (v f3) 36 156 (v f4 % pow2 48) 16 192 }
     v f0 + v f1 * pow2 52 + v f2 * pow2 104 + v f3 * pow2 156 + (v f4 % pow2 48) * pow2 208;
-    (==) { Math.Lemmas.small_mod (v f4) (pow2 48) }
+    == { Math.Lemmas.small_mod (v f4) (pow2 48) }
     v f0 + v f1 * pow2 52 + v f2 * pow2 104 + v f3 * pow2 156 + v f4 * pow2 208;
     }
 
@@ -311,17 +311,17 @@ let mul15_lemma m1 m2 f c =
 
   calc (==) { //as_nat5 (r0,r1,r2,r3,r4);
     v r0 + v r1 * pow52 + v r2 * pow104 + v r3 * pow156 + v r4 * pow208;
-    (==) { mul15_lemma1 mf0 m2 f0 c }
+    == { mul15_lemma1 mf0 m2 f0 c }
     v c * v f0 + v r1 * pow52 + v r2 * pow104 + v r3 * pow156 + v r4 * pow208;
-    (==) { mul15_lemma1 mf1 m2 f1 c }
+    == { mul15_lemma1 mf1 m2 f1 c }
     v c * v f0 + v c * v f1 * pow52 + v r2 * pow104 + v r3 * pow156 + v r4 * pow208;
-    (==) { mul15_lemma1 mf2 m2 f2 c }
+    == { mul15_lemma1 mf2 m2 f2 c }
     v c * v f0 + v c * v f1 * pow52 + v c * v f2 * pow104 + v r3 * pow156 + v r4 * pow208;
-    (==) { mul15_lemma1 mf3 m2 f3 c }
+    == { mul15_lemma1 mf3 m2 f3 c }
     v c * v f0 + v c * v f1 * pow52 + v c * v f2 * pow104 + v c * v f3 * pow156 + v r4 * pow208;
-    (==) { mul15_lemma_last1 mf4 m2 f4 c }
+    == { mul15_lemma_last1 mf4 m2 f4 c }
     v c * v f0 + v c * v f1 * pow52 + v c * v f2 * pow104 + v c * v f3 * pow156 + v c * v f4 * pow208;
-    (==) { ML.lemma_distr5_pow52 (v c) (v f0) (v f1) (v f2) (v f3) (v f4) }
+    == { ML.lemma_distr5_pow52 (v c) (v f0) (v f1) (v f2) (v f3) (v f4) }
     v c * (v f0 + v f1 * pow52 + v f2 * pow104 + v f3 * pow156 + v f4 * pow208);
   };
   assert (as_nat5 (r0,r1,r2,r3,r4) == v c * as_nat5 f)

--- a/code/k256/Hacl.Spec.K256.Field52.Lemmas2.fst
+++ b/code/k256/Hacl.Spec.K256.Field52.Lemmas2.fst
@@ -37,13 +37,13 @@ let minus_x_mul_pow2_256_lemma m f =
   let r = (t0,t1,t2,t3,t4') in
   calc (==) { // as_nat5 f
     v t0 + v t1 * pow52 + v t2 * pow104 + v t3 * pow156 + v t4 * pow208;
-    (==) { Math.Lemmas.euclidean_division_definition (v t4) (pow2 48) }
+    == { Math.Lemmas.euclidean_division_definition (v t4) (pow2 48) }
     v t0 + v t1 * pow52 + v t2 * pow104 + v t3 * pow156 + (v t4 / pow2 48 * pow2 48 + v t4 % pow2 48) * pow208;
-    (==) { Math.Lemmas.distributivity_add_left (v t4 / pow2 48 * pow2 48) (v t4 % pow2 48) pow208 }
+    == { Math.Lemmas.distributivity_add_left (v t4 / pow2 48 * pow2 48) (v t4 % pow2 48) pow208 }
     v t0 + v t1 * pow52 + v t2 * pow104 + v t3 * pow156 + (v t4 / pow2 48 * pow2 48) * pow208 + (v t4 % pow2 48) * pow208;
-    (==) { }
+    == { }
     (v x * pow2 48) * pow208 + as_nat5 r;
-    (==) { Math.Lemmas.paren_mul_right (v x) (pow2 48) pow208; Math.Lemmas.pow2_plus 48 208 }
+    == { Math.Lemmas.paren_mul_right (v x) (pow2 48) pow208; Math.Lemmas.pow2_plus 48 208 }
     v x * pow2 256 + as_nat5 r;
   };
 

--- a/code/k256/Hacl.Spec.K256.Field52.Lemmas4.fst
+++ b/code/k256/Hacl.Spec.K256.Field52.Lemmas4.fst
@@ -25,17 +25,17 @@ let lemma_nat_r432 r2 r3 r4 c9 c11 d4 d11 t3 r =
   let k = d4 % pow2 48 in
   calc (==) {
     (r4 * pow2 52 + r3) * pow2 52 + r2;
-    (==) { Math.Lemmas.pow2_modulo_modulo_lemma_1 d4 48 52 }
+    == { Math.Lemmas.pow2_modulo_modulo_lemma_1 d4 48 52 }
     ((c11 / pow2 52 + k) * pow2 52 + c11 % pow2 52) * pow2 52 + r2;
-    (==) { ML.lemma_distr_eucl c11 k }
+    == { ML.lemma_distr_eucl c11 k }
     (c9 / pow2 52 + r * pow2 12 * d11 + t3 + k * pow2 52) * pow2 52 + c9 % pow2 52;
-    (==) { ML.lemma_distr_eucl c9 (r * pow2 12 * d11 + t3 + k * pow2 52) }
+    == { ML.lemma_distr_eucl c9 (r * pow2 12 * d11 + t3 + k * pow2 52) }
     c9 + (r * pow2 12 * d11 + t3 + k * pow2 52) * pow2 52;
-    (==) { ML.lemma_distr_pow (r * pow2 12 * d11 + t3) k 52 52 }
+    == { ML.lemma_distr_pow (r * pow2 12 * d11 + t3) k 52 52 }
     c9 + (r * pow2 12 * d11 + t3) * pow2 52 + k * pow2 104;
-    (==) { ML.lemma_swap_mul3 r (pow2 12) d11 }
+    == { ML.lemma_swap_mul3 r (pow2 12) d11 }
     c9 + (r * d11 * pow2 12 + t3) * pow2 52 + k * pow2 104;
-    (==) { ML.lemma_distr_pow t3 (r * d11) 12 52 }
+    == { ML.lemma_distr_pow t3 (r * d11) 12 52 }
     c9 + r * d11 * pow2 64 + t3 * pow2 52 + k * pow2 104;
     }
 
@@ -56,19 +56,19 @@ let lemma_nat_r4321 r1 r2 r3 r4 c6 c9 c11 d4 d10 d11 t3 r sum2 =
 
   calc (==) {
     ((r4 * pow2 52 + r3) * pow2 52 + r2) * pow2 52 + r1;
-    (==) { lemma_nat_r432 r2 r3 r4 c9 c11 d4 d11 t3 r }
+    == { lemma_nat_r432 r2 r3 r4 c9 c11 d4 d11 t3 r }
     (c9 + r * d11 * pow2 64 + tmp1) * pow2 52 + r1;
-    (==) { }
+    == { }
     (c6 / pow2 52 + sum2 + r * (d10 % pow2 64) + r * d11 * pow2 64 + tmp1) * pow2 52 + c6 % pow2 52;
-    (==) { ML.lemma_distr_eucl_mul r d10 (pow2 64) }
+    == { ML.lemma_distr_eucl_mul r d10 (pow2 64) }
     (c6 / pow2 52 + sum2 + r * d10 + tmp1) * pow2 52 + c6 % pow2 52;
-    (==) { ML.lemma_distr_eucl c6 (sum2 + r * d10 + tmp1) }
+    == { ML.lemma_distr_eucl c6 (sum2 + r * d10 + tmp1) }
     c6 + (sum2 + r * d10 + tmp1) * pow2 52;
-    (==) { Math.Lemmas.distributivity_add_left (sum2 + r * d10) tmp1 (pow2 52) }
+    == { Math.Lemmas.distributivity_add_left (sum2 + r * d10) tmp1 (pow2 52) }
     c6 + (sum2 + r * d10) * pow2 52 + tmp1 * pow2 52;
-    (==) { Math.Lemmas.distributivity_add_left sum2 (r * d10) (pow2 52) }
+    == { Math.Lemmas.distributivity_add_left sum2 (r * d10) (pow2 52) }
     c6 + sum2 * pow2 52 + r * d10 * pow2 52 + tmp1 * pow2 52;
-    (==) { ML.lemma_distr_pow_pow t3 52 k 104 52 }
+    == { ML.lemma_distr_pow_pow t3 52 k 104 52 }
     c6 + sum2 * pow2 52 + r * d10 * pow2 52 + t3 * pow2 104 + k * pow2 156;
     }
 
@@ -91,27 +91,27 @@ let lemma_nat_r43210 r0 r1 r2 r3 r4 c3 c6 c9 c11 d4 d8 d10 d11 t3 r sum1 sum2 su
 
   calc (==) { // tmp1 * pow2 52
     (sum2 * pow2 52 + t3 * pow2 104 + k * pow2 156) * pow2 52;
-    (==) { ML.lemma_distr_pow (sum2 * pow2 52 + t3 * pow2 104) k 156 52 }
+    == { ML.lemma_distr_pow (sum2 * pow2 52 + t3 * pow2 104) k 156 52 }
     (sum2 * pow2 52 + t3 * pow2 104) * pow2 52 + k * pow2 208;
-    (==) { ML.lemma_distr_pow_pow sum2 52 t3 104 52 }
+    == { ML.lemma_distr_pow_pow sum2 52 t3 104 52 }
     sum2 * pow2 104 + t3 * pow2 156 + k * pow2 208;
   };
 
   calc (==) {
     r0 + r1 * pow52 + r2 * pow104 + r3 * pow156 + r4 * pow208;
-    (==) { ML.lemma_as_nat_horner r0 r1 r2 r3 r4 }
+    == { ML.lemma_as_nat_horner r0 r1 r2 r3 r4 }
     (((r4 * pow2 52 + r3) * pow2 52 + r2) * pow2 52 + r1) * pow2 52 + r0;
-    (==) { lemma_nat_r4321 r1 r2 r3 r4 c6 c9 c11 d4 d10 d11 t3 r sum2 }
+    == { lemma_nat_r4321 r1 r2 r3 r4 c6 c9 c11 d4 d10 d11 t3 r sum2 }
     (c3 / pow2 52 + sum1 + d8 % pow2 52 * r + r * (d8 / pow2 52 + sum7) * pow2 52 + tmp1) * pow2 52 + c3 % pow2 52;
-    (==) { ML.lemma_distr_eucl_mul_add r d8 sum7 (pow2 52) }
+    == { ML.lemma_distr_eucl_mul_add r d8 sum7 (pow2 52) }
     (c3 / pow2 52 + sum1 + r * d8 + r * sum7 * pow2 52 + tmp1) * pow2 52 + c3 % pow2 52;
-    (==) { ML.lemma_distr_eucl c3 (sum1 + r * d8 + r * sum7 * pow2 52 + tmp1) }
+    == { ML.lemma_distr_eucl c3 (sum1 + r * d8 + r * sum7 * pow2 52 + tmp1) }
     c3 + (sum1 + r * d8 + r * sum7 * pow2 52 + tmp1) * pow2 52;
-    (==) { ML.lemma_distr_pow (sum1 + r * d8 + tmp1) (r * sum7) 52 52 }
+    == { ML.lemma_distr_pow (sum1 + r * d8 + tmp1) (r * sum7) 52 52 }
     c3 + (sum1 + r * d8 + tmp1) * pow2 52 + r * sum7 * pow2 104;
-    (==) { Math.Lemmas.distributivity_add_left (sum1 + r * d8) tmp1 (pow2 52) }
+    == { Math.Lemmas.distributivity_add_left (sum1 + r * d8) tmp1 (pow2 52) }
     c3 + (sum1 + r * d8) * pow2 52 + sum2 * pow2 104 + t3 * pow2 156 + k * pow2 208 + r * sum7 * pow2 104;
-    (==) { Math.Lemmas.distributivity_add_left sum2 (r * sum7) (pow2 104) }
+    == { Math.Lemmas.distributivity_add_left sum2 (r * sum7) (pow2 104) }
     c3 + (sum1 + r * d8) * pow2 52 + (sum2 + r * sum7) * pow2 104 + t3 * pow2 156 + k * pow2 208;
     }
 
@@ -127,17 +127,17 @@ let simplify_c3 d4 r sum5 =
 
   calc (==) { //simplify c3
     ((d4 % pow2 52) / pow2 48 + k * pow2 4) * (r / pow2 4);
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 d4 48 52 }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 d4 48 52 }
     ((d4 / pow2 48) % pow2 4 + k * pow2 4) * (r / pow2 4);
-    (==) { Math.Lemmas.euclidean_division_definition (d4 / pow2 48) (pow2 4) }
+    == { Math.Lemmas.euclidean_division_definition (d4 / pow2 48) (pow2 4) }
     (d4 / pow2 48 - (d4 / pow2 48 / pow2 4) * pow2 4 + k * pow2 4) * (r / pow2 4);
-    (==) { Math.Lemmas.division_multiplication_lemma d4 (pow2 48) (pow2 4); Math.Lemmas.pow2_plus 48 4 }
+    == { Math.Lemmas.division_multiplication_lemma d4 (pow2 48) (pow2 4); Math.Lemmas.pow2_plus 48 4 }
     (d4 / pow2 48 - (d4 / pow2 52) * pow2 4 + k * pow2 4) * (r / pow2 4);
-    (==) { Math.Lemmas.distributivity_sub_left k (d4 / pow2 52) (pow2 4) }
+    == { Math.Lemmas.distributivity_sub_left k (d4 / pow2 52) (pow2 4) }
     (d4 / pow2 48 + (k - d4 / pow2 52) * pow2 4) * (r / pow2 4);
-    (==) { Math.Lemmas.distributivity_add_left (d4 / pow2 48) ((k - d4 / pow2 52) * pow2 4) (r / pow2 4) }
+    == { Math.Lemmas.distributivity_add_left (d4 / pow2 48) ((k - d4 / pow2 52) * pow2 4) (r / pow2 4) }
     (d4 / pow2 48) * (r / pow2 4) + (k - d4 / pow2 52) * pow2 4 * (r / pow2 4);
-    (==) { Math.Lemmas.paren_mul_right (k - d4 / pow2 52) (pow2 4) (r / pow2 4); Math.Lemmas.div_exact_r r (pow2 4) }
+    == { Math.Lemmas.paren_mul_right (k - d4 / pow2 52) (pow2 4) (r / pow2 4); Math.Lemmas.div_exact_r r (pow2 4) }
     (d4 / pow2 48) * (r / pow2 4) + (k - d4 / pow2 52) * r;
   }
 
@@ -163,33 +163,33 @@ let lemma_nat_r43210_mod_prime c3 d4 d8 t3 r sum0 sum1 sum2 sum3 sum4 sum5 sum6 
 
   calc (==) {
     c3 + (d4 % pow2 48) * pow2 208 + (sum1 + r * d8) * pow2 52;
-    (==) { simplify_c3 d4 r sum5; assert_norm (0x1000003D10 / pow2 4 = 0x1000003D1) }
+    == { simplify_c3 d4 r sum5; assert_norm (0x1000003D10 / pow2 4 = 0x1000003D1) }
     d4mod + tmp0 + (sum1 + r * d8) * pow2 52;
-    (==) { Math.Lemmas.distributivity_add_left sum1 (r * d8) (pow2 52) }
+    == { Math.Lemmas.distributivity_add_left sum1 (r * d8) (pow2 52) }
     d4mod + sum0 + (tmp1 % pow2 52 - d4 / pow2 52) * r + sum1 * pow2 52 + r * (tmp1 / pow2 52 + sum6) * pow2 52;
-    (==) { Math.Lemmas.distributivity_sub_left (tmp1 % pow2 52) (d4 / pow2 52) r }
+    == { Math.Lemmas.distributivity_sub_left (tmp1 % pow2 52) (d4 / pow2 52) r }
     d4mod + sum0 + (tmp1 % pow2 52) * r - d4 / pow2 52 * r + sum1 * pow2 52 + r * (tmp1 / pow2 52 + sum6) * pow2 52;
-    (==) { ML.lemma_distr_eucl_mul_add r tmp1 sum6 (pow2 52) }
+    == { ML.lemma_distr_eucl_mul_add r tmp1 sum6 (pow2 52) }
     d4mod + sum0 + r * (d4 / pow2 52 + sum5) - d4 / pow2 52 * r + sum1 * pow2 52 + r * sum6 * pow2 52;
-    (==) { Math.Lemmas.distributivity_add_right r (d4 / pow2 52) sum5 }
+    == { Math.Lemmas.distributivity_add_right r (d4 / pow2 52) sum5 }
     d4mod + sum0 + r * sum5 + sum1 * pow2 52 + r * sum6 * pow2 52;
-    (==) { Math.Lemmas.distributivity_add_left sum1 (r * sum6) (pow2 52) }
+    == { Math.Lemmas.distributivity_add_left sum1 (r * sum6) (pow2 52) }
     d4mod + sum0 + r * sum5 + (sum1 + r * sum6) * pow2 52;
     };
 
   calc (==) { //t3 * pow2 156 + d4 * pow2 208;
     (tmp2 % pow2 52) * pow2 156 + (tmp2 / pow2 52 + sum4 + r * pow2 12 * (sum8 / pow2 64)) * pow2 208;
-    (==) { ML.lemma_distr_pow (tmp2 % pow2 52) (tmp2 / pow2 52 + sum4 + r * pow2 12 * (sum8 / pow2 64)) 52 156 }
+    == { ML.lemma_distr_pow (tmp2 % pow2 52) (tmp2 / pow2 52 + sum4 + r * pow2 12 * (sum8 / pow2 64)) 52 156 }
     (tmp2 % pow2 52 + (tmp2 / pow2 52 + sum4 + r * pow2 12 * (sum8 / pow2 64)) * pow2 52) * pow2 156;
-    (==) { ML.lemma_distr_eucl_mul_add 1 tmp2 (sum4 + r * pow2 12 * (sum8 / pow2 64)) (pow2 52) }
+    == { ML.lemma_distr_eucl_mul_add 1 tmp2 (sum4 + r * pow2 12 * (sum8 / pow2 64)) (pow2 52) }
     (tmp2 + (sum4 + r * pow2 12 * (sum8 / pow2 64)) * pow2 52) * pow2 156;
-    (==) { ML.lemma_swap_mul3 r (pow2 12) (sum8 / pow2 64) }
+    == { ML.lemma_swap_mul3 r (pow2 12) (sum8 / pow2 64) }
     (tmp2 + (sum4 + r * (sum8 / pow2 64) * pow2 12) * pow2 52) * pow2 156;
-    (==) { ML.lemma_distr_pow sum4 (r * (sum8 / pow2 64)) 12 52 }
+    == { ML.lemma_distr_pow sum4 (r * (sum8 / pow2 64)) 12 52 }
     (sum3 + r * (sum8 % pow2 64) + sum4 * pow2 52 + r * (sum8 / pow2 64) * pow2 64) * pow2 156;
-    (==) { ML.lemma_distr_eucl_mul r sum8 (pow2 64) }
+    == { ML.lemma_distr_eucl_mul r sum8 (pow2 64) }
     (sum3 + r * sum8 + sum4 * pow2 52) * pow2 156;
-    (==) { ML.lemma_distr_pow (sum3 + r * sum8) sum4 52 156 }
+    == { ML.lemma_distr_pow (sum3 + r * sum8) sum4 52 156 }
     (sum3 + r * sum8) * pow2 156 + sum4 * pow2 208;
     };
 
@@ -226,69 +226,69 @@ let lemma_mul_ab a0 a1 a2 a3 a4 b0 b1 b2 b3 b4 =
   let b_sum = b0 + b1 * pow52 + b2 * pow104 + b3 * pow156 + b4 * pow208 in
   calc (==) {
     (a0 + a1 * pow52 + a2 * pow104 + a3 * pow156 + a4 * pow208) * b_sum;
-    (==) { ML.lemma_distr5 a0 (a1 * pow52) (a2 * pow104) (a3 * pow156) (a4 * pow208) b_sum }
+    == { ML.lemma_distr5 a0 (a1 * pow52) (a2 * pow104) (a3 * pow156) (a4 * pow208) b_sum }
     a0 * b_sum + a1 * pow52 * b_sum + a2 * pow104 * b_sum + a3 * pow156 * b_sum + a4 * pow208 * b_sum;
-    (==) { ML.lemma_distr5_pow52 a0 b0 b1 b2 b3 b4 }
+    == { ML.lemma_distr5_pow52 a0 b0 b1 b2 b3 b4 }
     sum0 + a0 * b1 * pow2 52 + a0 * b2 * pow2 104 + a0 * b3 * pow2 156 + a0 * b4 * pow2 208
     + a1 * pow52 * b_sum + a2 * pow104 * b_sum + a3 * pow156 * b_sum + a4 * pow208 * b_sum;
-    (==) { ML.lemma_distr5_pow52_mul_pow a1 b0 b1 b2 b3 b4 52 }
+    == { ML.lemma_distr5_pow52_mul_pow a1 b0 b1 b2 b3 b4 52 }
     sum0 + a0 * b1 * pow2 52 + a0 * b2 * pow2 104 + a0 * b3 * pow2 156 + a0 * b4 * pow2 208
     + a1 * b0 * pow2 52 + a1 * b1 * pow2 104 + a1 * b2 * pow2 156 + a1 * b3 * pow2 208 + a1 * b4 * pow2 260
     + a2 * pow104 * b_sum + a3 * pow156 * b_sum + a4 * pow208 * b_sum;
-    (==) { ML.lemma_distr5_pow52_mul_pow a2 b0 b1 b2 b3 b4 104 }
+    == { ML.lemma_distr5_pow52_mul_pow a2 b0 b1 b2 b3 b4 104 }
     sum0 + a0 * b1 * pow2 52 + a0 * b2 * pow2 104 + a0 * b3 * pow2 156 + a0 * b4 * pow2 208
     + a1 * b0 * pow2 52 + a1 * b1 * pow2 104 + a1 * b2 * pow2 156 + a1 * b3 * pow2 208 + a1 * b4 * pow2 260
     + a2 * b0 * pow2 104 + a2 * b1 * pow2 156 + a2 * b2 * pow2 208 + a2 * b3 * pow2 260 + a2 * b4 * pow2 312
     + a3 * pow156 * b_sum + a4 * pow208 * b_sum;
-    (==) { ML.lemma_distr5_pow52_mul_pow a3 b0 b1 b2 b3 b4 156 }
+    == { ML.lemma_distr5_pow52_mul_pow a3 b0 b1 b2 b3 b4 156 }
     sum0 + a0 * b1 * pow2 52 + a0 * b2 * pow2 104 + a0 * b3 * pow2 156 + a0 * b4 * pow2 208
     + a1 * b0 * pow2 52 + a1 * b1 * pow2 104 + a1 * b2 * pow2 156 + a1 * b3 * pow2 208 + a1 * b4 * pow2 260
     + a2 * b0 * pow2 104 + a2 * b1 * pow2 156 + a2 * b2 * pow2 208 + a2 * b3 * pow2 260 + a2 * b4 * pow2 312
     + a3 * b0 * pow2 156 + a3 * b1 * pow2 208 + a3 * b2 * pow2 260 + a3 * b3 * pow2 312 + a3 * b4 * pow2 364
     + a4 * pow208 * b_sum;
-    (==) { ML.lemma_distr5_pow52_mul_pow a4 b0 b1 b2 b3 b4 208 }
+    == { ML.lemma_distr5_pow52_mul_pow a4 b0 b1 b2 b3 b4 208 }
     sum0 + a0 * b1 * pow2 52 + a0 * b2 * pow2 104 + a0 * b3 * pow2 156 + a0 * b4 * pow2 208
     + a1 * b0 * pow2 52 + a1 * b1 * pow2 104 + a1 * b2 * pow2 156 + a1 * b3 * pow2 208 + a1 * b4 * pow2 260
     + a2 * b0 * pow2 104 + a2 * b1 * pow2 156 + a2 * b2 * pow2 208 + a2 * b3 * pow2 260 + a2 * b4 * pow2 312
     + a3 * b0 * pow2 156 + a3 * b1 * pow2 208 + a3 * b2 * pow2 260 + a3 * b3 * pow2 312 + a3 * b4 * pow2 364
     + a4 * b0 * pow2 208 + a4 * b1 * pow2 260 + a4 * b2 * pow2 312 + a4 * b3 * pow2 364 + a4 * b4 * pow2 416;
-    (==) { Math.Lemmas.distributivity_add_left (a0 * b1) (a1 * b0) (pow2 52) }
+    == { Math.Lemmas.distributivity_add_left (a0 * b1) (a1 * b0) (pow2 52) }
     sum0 + sum1 * pow2 52 + a0 * b2 * pow2 104 + a0 * b3 * pow2 156 + a0 * b4 * pow2 208
     + a1 * b1 * pow2 104 + a1 * b2 * pow2 156 + a1 * b3 * pow2 208 + a1 * b4 * pow2 260
     + a2 * b0 * pow2 104 + a2 * b1 * pow2 156 + a2 * b2 * pow2 208 + a2 * b3 * pow2 260 + a2 * b4 * pow2 312
     + a3 * b0 * pow2 156 + a3 * b1 * pow2 208 + a3 * b2 * pow2 260 + a3 * b3 * pow2 312 + a3 * b4 * pow2 364
     + a4 * b0 * pow2 208 + a4 * b1 * pow2 260 + a4 * b2 * pow2 312 + a4 * b3 * pow2 364 + a4 * b4 * pow2 416;
-    (==) { ML.lemma_distr5 (a0 * b2) (a1 * b1) (a2 * b0) 0 0 (pow2 104) }
+    == { ML.lemma_distr5 (a0 * b2) (a1 * b1) (a2 * b0) 0 0 (pow2 104) }
     sum0 + sum1 * pow2 52 + sum2 * pow2 104 + a0 * b3 * pow2 156 + a0 * b4 * pow2 208
     + a1 * b2 * pow2 156 + a1 * b3 * pow2 208 + a1 * b4 * pow2 260
     + a2 * b1 * pow2 156 + a2 * b2 * pow2 208 + a2 * b3 * pow2 260 + a2 * b4 * pow2 312
     + a3 * b0 * pow2 156 + a3 * b1 * pow2 208 + a3 * b2 * pow2 260 + a3 * b3 * pow2 312 + a3 * b4 * pow2 364
     + a4 * b0 * pow2 208 + a4 * b1 * pow2 260 + a4 * b2 * pow2 312 + a4 * b3 * pow2 364 + a4 * b4 * pow2 416;
-    (==) { ML.lemma_distr5 (a0 * b3) (a1 * b2) (a2 * b1) (a3 * b0) 0 (pow2 156) }
+    == { ML.lemma_distr5 (a0 * b3) (a1 * b2) (a2 * b1) (a3 * b0) 0 (pow2 156) }
     sum0 + sum1 * pow2 52 + sum2 * pow2 104 + sum3 * pow2 156 + a0 * b4 * pow2 208
     + a1 * b3 * pow2 208 + a1 * b4 * pow2 260
     + a2 * b2 * pow2 208 + a2 * b3 * pow2 260 + a2 * b4 * pow2 312
     + a3 * b1 * pow2 208 + a3 * b2 * pow2 260 + a3 * b3 * pow2 312 + a3 * b4 * pow2 364
     + a4 * b0 * pow2 208 + a4 * b1 * pow2 260 + a4 * b2 * pow2 312 + a4 * b3 * pow2 364 + a4 * b4 * pow2 416;
-    (==) { ML.lemma_distr5 (a0 * b4) (a1 * b3) (a2 * b2) (a3 * b1) (a4 * b0) (pow2 208) }
+    == { ML.lemma_distr5 (a0 * b4) (a1 * b3) (a2 * b2) (a3 * b1) (a4 * b0) (pow2 208) }
     sum0 + sum1 * pow2 52 + sum2 * pow2 104 + sum3 * pow2 156 + sum4 * pow2 208
     + a1 * b4 * pow2 260
     + a2 * b3 * pow2 260 + a2 * b4 * pow2 312
     + a3 * b2 * pow2 260 + a3 * b3 * pow2 312 + a3 * b4 * pow2 364
     + a4 * b1 * pow2 260 + a4 * b2 * pow2 312 + a4 * b3 * pow2 364 + a4 * b4 * pow2 416;
-    (==) { ML.lemma_distr5 (a1 * b4) (a2 * b3) (a3 * b2) (a4 * b1) 0 (pow2 260) }
+    == { ML.lemma_distr5 (a1 * b4) (a2 * b3) (a3 * b2) (a4 * b1) 0 (pow2 260) }
     sum0 + sum1 * pow2 52 + sum2 * pow2 104 + sum3 * pow2 156 + sum4 * pow2 208
     + sum5 * pow2 260
     + a2 * b4 * pow2 312
     + a3 * b3 * pow2 312 + a3 * b4 * pow2 364
     + a4 * b2 * pow2 312 + a4 * b3 * pow2 364 + a4 * b4 * pow2 416;
-    (==) { ML.lemma_distr5 (a2 * b4) (a3 * b3) (a4 * b2) 0 0 (pow2 312) }
+    == { ML.lemma_distr5 (a2 * b4) (a3 * b3) (a4 * b2) 0 0 (pow2 312) }
     sum0 + sum1 * pow2 52 + sum2 * pow2 104 + sum3 * pow2 156 + sum4 * pow2 208
     + sum5 * pow2 260 + sum6 * pow2 312 + a3 * b4 * pow2 364 + a4 * b3 * pow2 364 + a4 * b4 * pow2 416;
-    (==) { Math.Lemmas.distributivity_add_left (a3 * b4) (a4 * b3) (pow2 364) }
+    == { Math.Lemmas.distributivity_add_left (a3 * b4) (a4 * b3) (pow2 364) }
     sum0 + sum1 * pow2 52 + sum2 * pow2 104 + sum3 * pow2 156 + sum4 * pow2 208
     + sum5 * pow2 260 + sum6 * pow2 312 + sum7 * pow2 364 + sum8 * pow2 416;
-    (==) { ML.lemma_distr5_pow52_mul_pow 1 sum5 sum6 sum7 sum8 0 260 }
+    == { ML.lemma_distr5_pow52_mul_pow 1 sum5 sum6 sum7 sum8 0 260 }
     sum0 + sum1 * pow2 52 + sum2 * pow2 104 + sum3 * pow2 156 + sum4 * pow2 208
     + pow2 260 * (sum5 + sum6 * pow2 52 + sum7 * pow2 104 + sum8 * pow2 156);
     }
@@ -330,24 +330,24 @@ let lemma_fmul_ab a0 a1 a2 a3 a4 b0 b1 b2 b3 b4 =
 
   calc (==) {
     a_sum * b_sum % S.prime;
-    (==) { lemma_mul_ab a0 a1 a2 a3 a4 b0 b1 b2 b3 b4 }
+    == { lemma_mul_ab a0 a1 a2 a3 a4 b0 b1 b2 b3 b4 }
     (tmp0 + pow2 260 * tmp1) % S.prime;
-    (==) { Math.Lemmas.pow2_plus 256 4; Math.Lemmas.paren_mul_right (pow2 256) (pow2 4) tmp1 }
+    == { Math.Lemmas.pow2_plus 256 4; Math.Lemmas.paren_mul_right (pow2 256) (pow2 4) tmp1 }
     (tmp0 + pow2 256 * (pow2 4 * tmp1)) % S.prime;
-    (==) { LD.lemma_a_plus_b_mul_pow256 tmp0 (pow2 4 * tmp1) }
+    == { LD.lemma_a_plus_b_mul_pow256 tmp0 (pow2 4 * tmp1) }
     (tmp0 + 0x1000003D1 * (pow2 4 * tmp1)) % S.prime;
-    (==) { Math.Lemmas.paren_mul_right 0x1000003D1 (pow2 4) tmp1; assert_norm (0x1000003D1 * pow2 4 = r) }
+    == { Math.Lemmas.paren_mul_right 0x1000003D1 (pow2 4) tmp1; assert_norm (0x1000003D1 * pow2 4 = r) }
     (tmp0 + r * tmp1) % S.prime;
-    (==) { ML.lemma_distr5_pow52 r sum5 sum6 sum7 sum8 0 }
+    == { ML.lemma_distr5_pow52 r sum5 sum6 sum7 sum8 0 }
     (sum0 + sum1 * pow2 52 + sum2 * pow2 104 + sum3 * pow2 156 + sum4 * pow2 208
     + r * sum5 + r * sum6 * pow2 52 + r * sum7 * pow2 104 + r * sum8 * pow2 156) % S.prime;
-    (==) { Math.Lemmas.distributivity_add_left sum1 (r * sum6) (pow2 52) }
+    == { Math.Lemmas.distributivity_add_left sum1 (r * sum6) (pow2 52) }
     (sum0 + r * sum5 + (sum1 + r * sum6) * pow2 52 + sum2 * pow2 104 + sum3 * pow2 156 + sum4 * pow2 208
     + r * sum7 * pow2 104 + r * sum8 * pow2 156) % S.prime;
-    (==) { Math.Lemmas.distributivity_add_left sum2 (r * sum7) (pow2 104) }
+    == { Math.Lemmas.distributivity_add_left sum2 (r * sum7) (pow2 104) }
     (sum0 + r * sum5 + (sum1 + r * sum6) * pow2 52 + (sum2 + r * sum7) * pow2 104
     + sum3 * pow2 156 + sum4 * pow2 208 + r * sum8 * pow2 156) % S.prime;
-    (==) { Math.Lemmas.distributivity_add_left sum3 (r * sum8) (pow2 156) }
+    == { Math.Lemmas.distributivity_add_left sum3 (r * sum8) (pow2 156) }
     (sum0 + r * sum5 + (sum1 + r * sum6) * pow2 52 + (sum2 + r * sum7) * pow2 104
     + (sum3 + r * sum8) * pow2 156 + sum4 * pow2 208) % S.prime;
     }

--- a/code/k256/Hacl.Spec.K256.Field52.Lemmas5.fst
+++ b/code/k256/Hacl.Spec.K256.Field52.Lemmas5.fst
@@ -50,9 +50,9 @@ let lemma_16_max52_max48 a =
   assert_norm (16 * (max52 * max48) < max52 * max52);
   calc (<) {
     (a * 16) * (max52 * max48);
-    (==) { Math.Lemmas.paren_mul_right a 16 (max52 * max48) }
+    == { Math.Lemmas.paren_mul_right a 16 (max52 * max48) }
     a * (16 * (max52 * max48));
-    (<) { Math.Lemmas.lemma_mult_lt_left a (16 * (max52 * max48)) (max52 * max52) }
+    < { Math.Lemmas.lemma_mult_lt_left a (16 * (max52 * max48)) (max52 * max52) }
     a * (max52 * max52);
   }
 
@@ -83,11 +83,11 @@ let lemma_add_five_mul64_wide md d a0 a1 a2 a3 a4 b0 b1 b2 b3 b4 =
 
   calc (<) {
     md * max52 + 8192 * (max52 * max48) + 12288 * (max52 * max52);
-    (<) { lemma_16_max52_max48 512 }
+    < { lemma_16_max52_max48 512 }
     md * max52 + 12800 * (max52 * max52);
-    (<=) { assert_norm (16385 < max52); Math.Lemmas.lemma_mult_le_right max52 md max52 }
+    <= { assert_norm (16385 < max52); Math.Lemmas.lemma_mult_le_right max52 md max52 }
     max52 * max52 + 12800 * (max52 * max52);
-    (==) { Math.Lemmas.distributivity_add_left 1 12800 (max52 * max52) }
+    == { Math.Lemmas.distributivity_add_left 1 12800 (max52 * max52) }
     12801 * (max52 * max52);
     };
   assert_norm (12801 * (max52 * max52) < pow2 128);
@@ -122,11 +122,11 @@ let lemma_add_four_mul64_wide md d a1 a2 a3 a4 b1 b2 b3 b4 =
 
   calc (<) {
     md * max52 + 8192 * (max52 * max48) + 8192 * (max52 * max52);
-    (<) { lemma_16_max52_max48 512 }
+    < { lemma_16_max52_max48 512 }
     md * max52 + 8704 * (max52 * max52);
-    (<=) { assert_norm (12802 < max52); Math.Lemmas.lemma_mult_le_right max52 md max52 }
+    <= { assert_norm (12802 < max52); Math.Lemmas.lemma_mult_le_right max52 md max52 }
     max52 * max52 + 8704 * (max52 * max52);
-    (==) { Math.Lemmas.distributivity_add_left 1 8704 (max52 * max52) }
+    == { Math.Lemmas.distributivity_add_left 1 8704 (max52 * max52) }
     8705 * (max52 * max52);
     };
   assert_norm (8705 * (max52 * max52) < pow2 128);
@@ -157,9 +157,9 @@ let lemma_add_three_mul64_wide52 md d a0 a1 a2 b0 b1 b2 =
 
   calc (<=) {
     md * max52 + 12288 * (max52 * max52);
-    (<=) { assert_norm (8194 < max52); Math.Lemmas.lemma_mult_le_right max52 md max52 }
+    <= { assert_norm (8194 < max52); Math.Lemmas.lemma_mult_le_right max52 md max52 }
     max52 * max52 + 12288 * (max52 * max52);
-    (==) { Math.Lemmas.distributivity_add_left 1 12288 (max52 * max52) }
+    == { Math.Lemmas.distributivity_add_left 1 12288 (max52 * max52) }
     12289 * (max52 * max52);
     };
   assert_norm (12289 * (max52 * max52) < pow2 128);
@@ -190,11 +190,11 @@ let lemma_add_three_mul64_wide md d a2 a3 a4 b2 b3 b4 =
 
   calc (<) {
     md * max52 + 8192 * (max52 * max48) + 4096 * (max52 * max52);
-    (<) { lemma_16_max52_max48 512 }
+    < { lemma_16_max52_max48 512 }
     md * max52 + 4608 * (max52 * max52);
-    (<=) { assert_norm (8705 < max52); Math.Lemmas.lemma_mult_le_right max52 md max52 }
+    <= { assert_norm (8705 < max52); Math.Lemmas.lemma_mult_le_right max52 md max52 }
     max52 * max52 + 4608 * (max52 * max52);
-    (==) { Math.Lemmas.distributivity_add_left 1 4608 (max52 * max52) }
+    == { Math.Lemmas.distributivity_add_left 1 4608 (max52 * max52) }
     4609 * (max52 * max52);
     };
   assert_norm (4609 * (max52 * max52) < pow2 128);
@@ -221,9 +221,9 @@ let lemma_add_two_mul64_wide52 md d a0 a1 b0 b1 =
 
   calc (<=) {
     md * max52 + 8192 * (max52 * max52);
-    (<=) { assert_norm (4097 < max52); Math.Lemmas.lemma_mult_le_right max52 md max52 }
+    <= { assert_norm (4097 < max52); Math.Lemmas.lemma_mult_le_right max52 md max52 }
     max52 * max52 + 8192 * (max52 * max52);
-    (==) { Math.Lemmas.distributivity_add_left 1 8192 (max52 * max52) }
+    == { Math.Lemmas.distributivity_add_left 1 8192 (max52 * max52) }
     8193 * (max52 * max52);
     };
   assert_norm (8193 * (max52 * max52) < pow2 128);
@@ -250,11 +250,11 @@ let lemma_add_two_mul64_wide md d a3 a4 b3 b4 =
 
   calc (<) {
     md * max52 + 8192 * (max52 * max48);
-    (<) { lemma_16_max52_max48 512 }
+    < { lemma_16_max52_max48 512 }
     md * max52 + 512 * (max52 * max52);
-    (<=) { assert_norm (8193 < max52); Math.Lemmas.lemma_mult_le_right max52 md max52 }
+    <= { assert_norm (8193 < max52); Math.Lemmas.lemma_mult_le_right max52 md max52 }
     max52 * max52 + 512 * (max52 * max52);
-    (==) { Math.Lemmas.distributivity_add_left 1 512 (max52 * max52) }
+    == { Math.Lemmas.distributivity_add_left 1 512 (max52 * max52) }
     513 * (max52 * max52);
     };
   assert_norm (513 * (max52 * max52) < pow2 128);
@@ -274,9 +274,9 @@ let lemma_r_lsh12 () =
 
   calc (<) {
     0x1000003D10 * pow2 12;
-    (<) { Math.Lemmas.lemma_mult_lt_right (pow2 12) 0x1000003D10 (pow2 37) }
+    < { Math.Lemmas.lemma_mult_lt_right (pow2 12) 0x1000003D10 (pow2 37) }
     pow2 37 * pow2 12;
-    (==) { Math.Lemmas.pow2_plus 12 37 }
+    == { Math.Lemmas.pow2_plus 12 37 }
     pow2 49;
   };
 
@@ -309,13 +309,13 @@ let lemma_add_mul64_wide pa pb md d a b =
 
   calc (<) {
     md * (max52 * max52) + pow2 pa * pow2 pb;
-    (==) { Math.Lemmas.pow2_plus pa pb }
+    == { Math.Lemmas.pow2_plus pa pb }
     md * (max52 * max52) + pow2 (pa + pb);
-    (<=) { Math.Lemmas.pow2_le_compat 103 (pa + pb) }
+    <= { Math.Lemmas.pow2_le_compat 103 (pa + pb) }
     md * (max52 * max52) + pow2 103;
-    (<) { assert_norm (pow2 103 < max52 * max52) }
+    < { assert_norm (pow2 103 < max52 * max52) }
     md * (max52 * max52) + max52 * max52;
-    (==) { Math.Lemmas.distributivity_add_left md 1 (max52 * max52) }
+    == { Math.Lemmas.distributivity_add_left md 1 (max52 * max52) }
     (md + 1) * (max52 * max52);
   };
 
@@ -373,13 +373,13 @@ let lemma_bound_add_mul64_wide_r_lsh12_add md c d t3 =
 
   calc (<) {
     md * max52 + pow2 49 * pow2 50 + max52;
-    (==) { Math.Lemmas.pow2_plus 49 50 }
+    == { Math.Lemmas.pow2_plus 49 50 }
     md * max52 + pow2 99 + max52;
-    (==) { Math.Lemmas.distributivity_add_left md 1 max52 }
+    == { Math.Lemmas.distributivity_add_left md 1 max52 }
     (md + 1) * max52 + pow2 99;
-    (<=) { Math.Lemmas.lemma_mult_le_right max52 (md + 1) 12291 }
+    <= { Math.Lemmas.lemma_mult_le_right max52 (md + 1) 12291 }
     12291 * max52 + pow2 99;
-    (<) { assert_norm (12291 * max52 + pow2 99 < pow2 100) }
+    < { assert_norm (12291 * max52 + pow2 99 < pow2 100) }
     pow2 100;
   };
 
@@ -536,11 +536,11 @@ let lemma_tx_logor_u0_lsh4 tx u0 =
 
   calc (<=) {
     v u0 * pow2 4;
-    (<=) { Math.Lemmas.lemma_mult_le_right (pow2 4) (v u0) (pow2 52 - 1) }
+    <= { Math.Lemmas.lemma_mult_le_right (pow2 4) (v u0) (pow2 52 - 1) }
     (pow2 52 - 1) * pow2 4;
-    (==) { Math.Lemmas.distributivity_sub_left (pow2 52) 1 (pow2 4) }
+    == { Math.Lemmas.distributivity_sub_left (pow2 52) 1 (pow2 4) }
     pow2 52 * pow2 4 - pow2 4;
-    (==) { Math.Lemmas.pow2_plus 52 4 }
+    == { Math.Lemmas.pow2_plus 52 4 }
     pow2 56 - pow2 4;
     };
 
@@ -582,11 +582,11 @@ let lemma_mul_by2 m max a =
   let r = a *. u64 2 in
   calc (<=) {
     v a * 2;
-    (<=) { Math.Lemmas.lemma_mult_le_right 2 (v a) (m * max) }
+    <= { Math.Lemmas.lemma_mult_le_right 2 (v a) (m * max) }
     m * max * 2;
-    (==) { Math.Lemmas.swap_mul (m * max) 2 }
+    == { Math.Lemmas.swap_mul (m * max) 2 }
     2 * (m * max);
-    (==) { Math.Lemmas.paren_mul_right 2 m max }
+    == { Math.Lemmas.paren_mul_right 2 m max }
     2 * m * max;
     };
   assert (v a * 2 <= 2 * m * max);
@@ -620,9 +620,9 @@ let lemma_four_sqr64_wide a0 a1 a2 a3 =
   Math.Lemmas.small_mod (v a0 * 2 * v a3 + v a1 * 2 * v a2) (pow2 128);
   calc (==) {
     v a0 * 2 * v a3 + v a1 * 2 * v a2;
-    (==) { Math.Lemmas.swap_mul (v a0) 2; Math.Lemmas.paren_mul_right 2 (v a0) (v a3) }
+    == { Math.Lemmas.swap_mul (v a0) 2; Math.Lemmas.paren_mul_right 2 (v a0) (v a3) }
     v a0 * v a3 + v a0 * v a3 + v a1 * 2 * v a2;
-    (==) { Math.Lemmas.swap_mul (v a1) 2; Math.Lemmas.paren_mul_right 2 (v a1) (v a2) }
+    == { Math.Lemmas.swap_mul (v a1) 2; Math.Lemmas.paren_mul_right 2 (v a1) (v a2) }
     v a0 * v a3 + v a0 * v a3 + v a1 * v a2 + v a2 * v a1;
   }
 
@@ -654,11 +654,11 @@ let lemma_add_five_sqr64_wide md d a0 a1 a2 a3 a4 =
 
   calc (<) {
     md * max52 + 8192 * (max52 * max48) + 12288 * (max52 * max52);
-    (<=) { lemma_16_max52_max48 512 }
+    <= { lemma_16_max52_max48 512 }
     md * max52 + 512 * (max52 * max52) + 12288 * (max52 * max52);
-    (<) { assert_norm (16385 < max52); Math.Lemmas.lemma_mult_lt_right max52 md max52 }
+    < { assert_norm (16385 < max52); Math.Lemmas.lemma_mult_lt_right max52 md max52 }
     max52 * max52 + 12800 * (max52 * max52);
-    (==) { Math.Lemmas.distributivity_add_left (max52 * max52) 1 12800 }
+    == { Math.Lemmas.distributivity_add_left (max52 * max52) 1 12800 }
     12801 * (max52 * max52);
     };
 
@@ -669,9 +669,9 @@ let lemma_add_five_sqr64_wide md d a0 a1 a2 a3 a4 =
 
   calc (==) {
     v d + v a0 * (v a4 * 2) + v a1 * 2 * v a3 + v a2 * v a2;
-    (==) { Math.Lemmas.swap_mul (v a1) 2; Math.Lemmas.paren_mul_right 2 (v a1) (v a3) }
+    == { Math.Lemmas.swap_mul (v a1) 2; Math.Lemmas.paren_mul_right 2 (v a1) (v a3) }
     v d + v a0 * (v a4 * 2) + v a1 * v a3 + v a1 * v a3 + v a2 * v a2;
-    (==) { Math.Lemmas.paren_mul_right (v a0) (v a4) 2; Math.Lemmas.swap_mul 2 (v a0 * v a4) }
+    == { Math.Lemmas.paren_mul_right (v a0) (v a4) 2; Math.Lemmas.swap_mul 2 (v a0 * v a4) }
     v d + v a0 * v a4 + v a0 * v a4 + v a1 * v a3 + v a1 * v a3 + v a2 * v a2;
   }
 
@@ -702,11 +702,11 @@ let lemma_add_four_sqr64_wide md d a1 a2 a3 a4 =
 
   calc (<) {
     md * max52 + 8192 * (max52 * max48) + 8192 * (max52 * max52);
-    (<=) { lemma_16_max52_max48 512 }
+    <= { lemma_16_max52_max48 512 }
     md * max52 + 512 * (max52 * max52) + 8192 * (max52 * max52);
-    (<) { assert_norm (12802 < max52); Math.Lemmas.lemma_mult_lt_right max52 md max52 }
+    < { assert_norm (12802 < max52); Math.Lemmas.lemma_mult_lt_right max52 md max52 }
     max52 * max52 + 8704 * (max52 * max52);
-    (==) { Math.Lemmas.distributivity_add_left (max52 * max52) 1 8704 }
+    == { Math.Lemmas.distributivity_add_left (max52 * max52) 1 8704 }
     8705 * (max52 * max52);
     };
   assert_norm (8705 * (max52 * max52) < pow2 128);
@@ -715,9 +715,9 @@ let lemma_add_four_sqr64_wide md d a1 a2 a3 a4 =
 
   calc (==) {
     v d + v a1 * (2 * v a4) + (v a2 * 2) * v a3;
-    (==) { Math.Lemmas.swap_mul (v a2) 2; Math.Lemmas.paren_mul_right 2 (v a2) (v a3) }
+    == { Math.Lemmas.swap_mul (v a2) 2; Math.Lemmas.paren_mul_right 2 (v a2) (v a3) }
     v d + v a1 * (2 * v a4) + v a2 * v a3 + v a3 * v a2;
-    (==) { Math.Lemmas.swap_mul (v a1) (2 * v a4); Math.Lemmas.paren_mul_right 2 (v a4) (v a1) }
+    == { Math.Lemmas.swap_mul (v a1) (2 * v a4); Math.Lemmas.paren_mul_right 2 (v a4) (v a1) }
     v d + v a1 * v a4 + v a4 * v a1 + v a2 * v a3 + v a3 * v a2;
     }
 
@@ -738,9 +738,9 @@ let lemma_add_two_sqr64_wide52 md d a0 a1 =
 
   calc (<) {
     md * max52 + 8192 * (max52 * max52);
-    (<) { assert_norm (4097 < max52); Math.Lemmas.lemma_mult_lt_right max52 md max52 }
+    < { assert_norm (4097 < max52); Math.Lemmas.lemma_mult_lt_right max52 md max52 }
     max52 * max52 + 8192 * (max52 * max52);
-    (==) { Math.Lemmas.distributivity_add_left (max52 * max52) 1 8192 }
+    == { Math.Lemmas.distributivity_add_left (max52 * max52) 1 8192 }
     8193 * (max52 * max52);
     };
   assert_norm (8193 * (max52 * max52) < pow2 128);
@@ -768,11 +768,11 @@ let lemma_add_three_sqr64_wide md d a2 a3 a4 =
 
   calc (<) {
     md * max52 + 8192 * (max52 * max48) + 4096 * (max52 * max52);
-    (<=) { lemma_16_max52_max48 512 }
+    <= { lemma_16_max52_max48 512 }
     md * max52 + 512 * (max52 * max52) + 4096 * (max52 * max52);
-    (<) { assert_norm (8705 < max52); Math.Lemmas.lemma_mult_lt_right max52 md max52 }
+    < { assert_norm (8705 < max52); Math.Lemmas.lemma_mult_lt_right max52 md max52 }
     max52 * max52 + 4608 * (max52 * max52);
-    (==) { Math.Lemmas.distributivity_add_left (max52 * max52) 1 4608 }
+    == { Math.Lemmas.distributivity_add_left (max52 * max52) 1 4608 }
     4609 * (max52 * max52);
     };
   assert_norm (4609 * (max52 * max52) < pow2 128);
@@ -781,7 +781,7 @@ let lemma_add_three_sqr64_wide md d a2 a3 a4 =
 
   calc (==) {
     v d + v a2 * (v a4 * 2) + v a3 * v a3;
-    (==) { Math.Lemmas.paren_mul_right (v a2) (v a4) 2 }
+    == { Math.Lemmas.paren_mul_right (v a2) (v a4) 2 }
     v d + v a2 * v a4 + v a4 * v a2 + v a3 * v a3;
   }
 
@@ -805,9 +805,9 @@ let lemma_add_three_sqr64_wide52 md d a0 a1 a2 =
 
   calc (<) {
     md * max52 + 12288 * (max52 * max52);
-    (<) { assert_norm (8194 < max52); Math.Lemmas.lemma_mult_lt_right max52 md max52 }
+    < { assert_norm (8194 < max52); Math.Lemmas.lemma_mult_lt_right max52 md max52 }
     max52 * max52 + 12288 * (max52 * max52);
-    (==) { Math.Lemmas.distributivity_add_left (max52 * max52) 1 12288 }
+    == { Math.Lemmas.distributivity_add_left (max52 * max52) 1 12288 }
     12289 * (max52 * max52);
     };
   assert_norm (12289 * (max52 * max52) < pow2 128);
@@ -816,7 +816,7 @@ let lemma_add_three_sqr64_wide52 md d a0 a1 a2 =
 
   calc (==) {
     v d + v a0 * 2 * v a2 + v a1 * v a1;
-    (==) { Math.Lemmas.swap_mul (v a0) 2; Math.Lemmas.paren_mul_right 2 (v a0) (v a2) }
+    == { Math.Lemmas.swap_mul (v a0) 2; Math.Lemmas.paren_mul_right 2 (v a0) (v a2) }
     v d + v a0 * v a2 + v a2 * v a0 + v a1 * v a1;
   }
 
@@ -838,11 +838,11 @@ let lemma_add_two_sqr64_wide md d a3 a4 =
 
   calc (<) {
     md * max52 + 8192 * (max52 * max48);
-    (<=) { lemma_16_max52_max48 512 }
+    <= { lemma_16_max52_max48 512 }
     md * max52 + 512 * (max52 * max52);
-    (<) { assert_norm (64193 < max52); Math.Lemmas.lemma_mult_lt_right max52 md max52 }
+    < { assert_norm (64193 < max52); Math.Lemmas.lemma_mult_lt_right max52 md max52 }
     max52 * max52 + 512 * (max52 * max52);
-    (==) { Math.Lemmas.distributivity_add_left (max52 * max52) 1 512 }
+    == { Math.Lemmas.distributivity_add_left (max52 * max52) 1 512 }
     513 * (max52 * max52);
     };
   assert_norm (513 * (max52 * max52) < pow2 128);

--- a/code/k256/Hacl.Spec.K256.Finv.fst
+++ b/code/k256/Hacl.Spec.K256.Finv.fst
@@ -101,11 +101,11 @@ val lemma_pow_mod_mul: f:S.felem -> a:nat -> b:nat ->
 let lemma_pow_mod_mul f a b =
   calc (==) {
     S.fmul (M.pow f a % S.prime) (M.pow f b % S.prime);
-    (==) {
+    == {
       Math.Lemmas.lemma_mod_mul_distr_l (M.pow f a) (M.pow f b % S.prime) S.prime;
       Math.Lemmas.lemma_mod_mul_distr_r (M.pow f a) (M.pow f b) S.prime }
     M.pow f a * M.pow f b % S.prime;
-    (==) { M.lemma_pow_add f a b }
+    == { M.lemma_pow_add f a b }
     M.pow f (a + b) % S.prime;
   }
 
@@ -115,9 +115,9 @@ val lemma_pow_pow_mod: f:S.felem -> a:nat -> b:nat ->
 let lemma_pow_pow_mod f a b =
   calc (==) {
     M.pow (M.pow f a % S.prime) b % S.prime;
-    (==) { M.lemma_pow_mod_base (M.pow f a) b S.prime }
+    == { M.lemma_pow_mod_base (M.pow f a) b S.prime }
     M.pow (M.pow f a) b % S.prime;
-    (==) { M.lemma_pow_mul f a b }
+    == { M.lemma_pow_mul f a b }
     M.pow f (a * b) % S.prime;
     }
 
@@ -127,9 +127,9 @@ val lemma_pow_pow_mod_mul: f:S.felem -> a:nat -> b:nat -> c:nat ->
 let lemma_pow_pow_mod_mul f a b c =
   calc (==) {
     S.fmul (M.pow (M.pow f a % S.prime) b % S.prime) (M.pow f c % S.prime);
-    (==) { lemma_pow_pow_mod f a b }
+    == { lemma_pow_pow_mod f a b }
     S.fmul (M.pow f (a * b) % S.prime) (M.pow f c % S.prime);
-    (==) { lemma_pow_mod_mul f (a * b) c }
+    == { lemma_pow_mod_mul f (a * b) c }
     M.pow f (a * b + c) % S.prime;
   }
 

--- a/code/k256/Hacl.Spec.K256.GLV.Lemmas.fst
+++ b/code/k256/Hacl.Spec.K256.GLV.Lemmas.fst
@@ -54,23 +54,23 @@ let lemma_scalar_split_lambda_eval k =
   assert (r1 = S.(k +^ r2 *^ minus_lambda));
   calc (==) {
     (r1 + (r2 * lambda % S.q)) % S.q;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r r1 (r2 * lambda) S.q }
+    == { Math.Lemmas.lemma_mod_plus_distr_r r1 (r2 * lambda) S.q }
     (r1 + r2 * lambda) % S.q;
-    (==) { }
+    == { }
     ((k + (r2 * minus_lambda % S.q)) % S.q + r2 * lambda) % S.q;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r k (r2 * minus_lambda) S.q }
+    == { Math.Lemmas.lemma_mod_plus_distr_r k (r2 * minus_lambda) S.q }
     ((k + r2 * minus_lambda) % S.q + r2 * lambda) % S.q;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l (k + r2 * minus_lambda) (r2 * lambda) S.q }
+    == { Math.Lemmas.lemma_mod_plus_distr_l (k + r2 * minus_lambda) (r2 * lambda) S.q }
     (k + r2 * minus_lambda + r2 * lambda) % S.q;
-    (==) { Math.Lemmas.distributivity_add_right r2 minus_lambda lambda }
+    == { Math.Lemmas.distributivity_add_right r2 minus_lambda lambda }
     (k + r2 * (minus_lambda + lambda)) % S.q;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r k (r2 * (minus_lambda + lambda)) S.q }
+    == { Math.Lemmas.lemma_mod_plus_distr_r k (r2 * (minus_lambda + lambda)) S.q }
     (k + (r2 * (minus_lambda + lambda) % S.q)) % S.q;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r r2 (minus_lambda + lambda) S.q }
+    == { Math.Lemmas.lemma_mod_mul_distr_r r2 (minus_lambda + lambda) S.q }
     (k + (r2 * ((minus_lambda + lambda) % S.q) % S.q)) % S.q;
-    (==) { }
+    == { }
     k % S.q;
-    (==) { Math.Lemmas.small_mod k S.q }
+    == { Math.Lemmas.small_mod k S.q }
     k;
   }
 
@@ -88,17 +88,17 @@ let lemma_aff_point_mul_split_lambda k p =
   let r1, r2 = scalar_split_lambda k in
   calc (==) {
     aff_point_mul k p;
-    (==) { lemma_scalar_split_lambda_eval k }
+    == { lemma_scalar_split_lambda_eval k }
     aff_point_mul S.(r1 +^ r2 *^ lambda) p;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r r1 (r2 * lambda) S.q }
+    == { Math.Lemmas.lemma_mod_plus_distr_r r1 (r2 * lambda) S.q }
     aff_point_mul ((r1 + r2 * lambda) % S.q) p;
-    (==) { SM.lemma_aff_point_mul_neg_modq (r1 + r2 * lambda) p }
+    == { SM.lemma_aff_point_mul_neg_modq (r1 + r2 * lambda) p }
     aff_point_mul (r1 + r2 * lambda) p;
-    (==) { SM.lemma_aff_point_mul_neg_mul_add lambda r2 r1 p }
+    == { SM.lemma_aff_point_mul_neg_mul_add lambda r2 r1 p }
     S.aff_point_add (aff_point_mul r2 (aff_point_mul lambda p)) (aff_point_mul r1 p);
-    (==) { lemma_glv_aff p }
+    == { lemma_glv_aff p }
     S.aff_point_add (aff_point_mul r2 (aff_point_mul_lambda p)) (aff_point_mul r1 p);
-    (==) { LS.aff_point_add_comm_lemma (aff_point_mul r2 (aff_point_mul_lambda p)) (aff_point_mul r1 p) }
+    == { LS.aff_point_add_comm_lemma (aff_point_mul r2 (aff_point_mul_lambda p)) (aff_point_mul r1 p) }
     S.aff_point_add (aff_point_mul r1 p) (aff_point_mul r2 (aff_point_mul_lambda p));
   }
 
@@ -206,7 +206,7 @@ let lemma_aff_proj_point_mul_double_split_lambda k1 p1 k2 p2 =
 
     calc (==) {
       aff_proj_point_mul_double_split_lambda k1 p1 k2 p2;
-    (==) {
+    == {
       LE.exp_four_fw_lemma S.mk_k256_comm_monoid
         p11_aff 128 r11 p12_aff r12 p21_aff r21 p22_aff r22 5 }
       S.aff_point_add
@@ -214,15 +214,15 @@ let lemma_aff_proj_point_mul_double_split_lambda k1 p1 k2 p2 =
           (S.aff_point_add (aff_point_mul r11 p11_aff) (aff_point_mul r12 p12_aff))
           (aff_point_mul r21 p21_aff))
         (aff_point_mul r22 p22_aff);
-      (==) { lemma_aff_point_mul_endo_split k1 p1_aff; lemma_ecmult_endo_split_to_aff k1 p1 }
+      == { lemma_aff_point_mul_endo_split k1 p1_aff; lemma_ecmult_endo_split_to_aff k1 p1 }
       S.aff_point_add
         (S.aff_point_add (aff_point_mul k1 p1_aff) (aff_point_mul r21 p21_aff))
         (aff_point_mul r22 p22_aff);
-      (==) { LS.aff_point_add_assoc_lemma
+      == { LS.aff_point_add_assoc_lemma
         (aff_point_mul k1 p1_aff) (aff_point_mul r21 p21_aff) (aff_point_mul r22 p22_aff) }
       S.aff_point_add (aff_point_mul k1 p1_aff)
         (S.aff_point_add (aff_point_mul r21 p21_aff) (aff_point_mul r22 p22_aff));
-      (==) { lemma_aff_point_mul_endo_split k2 p2_aff; lemma_ecmult_endo_split_to_aff k2 p2 }
+      == { lemma_aff_point_mul_endo_split k2 p2_aff; lemma_ecmult_endo_split_to_aff k2 p2 }
       S.aff_point_add (aff_point_mul k1 p1_aff) (aff_point_mul k2 p2_aff);
     } end
   else begin
@@ -245,11 +245,11 @@ let aff_point_negate_cond_pow_lemma is_negate p k =
   if is_negate then
     calc (==) {
       S.aff_point_negate (S.to_aff_point (point_mul_def k p));
-      (==) { SE.pow_lemma S.mk_k256_concrete_ops p k }
+      == { SE.pow_lemma S.mk_k256_concrete_ops p k }
       S.aff_point_negate (aff_point_mul k p_aff);
-      (==) { SM.aff_point_mul_neg_lemma k p_aff }
+      == { SM.aff_point_mul_neg_lemma k p_aff }
       aff_point_mul k (S.aff_point_negate p_aff);
-      (==) { LS.to_aff_point_negate_lemma p }
+      == { LS.to_aff_point_negate_lemma p }
       aff_point_mul k (S.to_aff_point (S.point_negate p));
     }
   else
@@ -268,22 +268,22 @@ let aff_point_negate_cond_lambda_pow_lemma is_negate p k =
   if is_negate then
     calc (==) {
       aff_point_mul lambda (S.aff_point_negate (S.to_aff_point (point_mul_def k p)));
-      (==) { SE.pow_lemma S.mk_k256_concrete_ops p k }
+      == { SE.pow_lemma S.mk_k256_concrete_ops p k }
       aff_point_mul lambda (S.aff_point_negate (aff_point_mul k p_aff));
-      (==) { SM.aff_point_mul_mul_neg_lemma lambda k p_aff }
+      == { SM.aff_point_mul_mul_neg_lemma lambda k p_aff }
       aff_point_mul k (S.aff_point_negate (aff_point_mul lambda p_aff));
-      (==) { lemma_glv p }
+      == { lemma_glv p }
       aff_point_mul k (S.aff_point_negate (S.to_aff_point p_lambda));
-      (==) { LS.to_aff_point_negate_lemma p_lambda }
+      == { LS.to_aff_point_negate_lemma p_lambda }
       aff_point_mul k (S.to_aff_point (S.point_negate p_lambda));
     }
   else
     calc (==) {
       aff_point_mul lambda (S.to_aff_point (point_mul_def k p));
-      (==) { SE.pow_lemma S.mk_k256_concrete_ops p k }
+      == { SE.pow_lemma S.mk_k256_concrete_ops p k }
       aff_point_mul lambda (aff_point_mul k p_aff);
-      (==) { SM.aff_point_mul_mul_lemma lambda k p_aff }
+      == { SM.aff_point_mul_mul_lemma lambda k p_aff }
       aff_point_mul k (aff_point_mul lambda p_aff);
-      (==) { lemma_glv p }
+      == { lemma_glv p }
       aff_point_mul k (S.to_aff_point p_lambda);
     }

--- a/code/k256/Hacl.Spec.K256.MathLemmas.fst
+++ b/code/k256/Hacl.Spec.K256.MathLemmas.fst
@@ -8,11 +8,11 @@ val lemma_swap_mul3 (a b c:int) : Lemma (a * b * c == a * c * b)
 let lemma_swap_mul3 a b c =
   calc (==) {
     a * b * c;
-    (==) { Math.Lemmas.paren_mul_right a b c }
+    == { Math.Lemmas.paren_mul_right a b c }
     a * (b * c);
-    (==) { Math.Lemmas.swap_mul b c }
+    == { Math.Lemmas.swap_mul b c }
     a * (c * b);
-    (==) { Math.Lemmas.paren_mul_right a c b }
+    == { Math.Lemmas.paren_mul_right a c b }
     a * c * b;
   }
 
@@ -52,16 +52,16 @@ val lemma_bound_mul64_wide (ma mb:nat) (mma mmb:nat) (a b:nat) : Lemma
 let lemma_bound_mul64_wide ma mb mma mmb a b =
   calc (<=) {
     a * b;
-    (<=) { lemma_ab_le_cd a b (ma * mma) (mb * mmb) }
+    <= { lemma_ab_le_cd a b (ma * mma) (mb * mmb) }
     (ma * mma) * (mb * mmb);
-    (==) { Math.Lemmas.paren_mul_right ma mma (mb * mmb) }
+    == { Math.Lemmas.paren_mul_right ma mma (mb * mmb) }
     ma * (mma * (mb * mmb));
-    (==) {
+    == {
       Math.Lemmas.paren_mul_right mma mb mmb;
       Math.Lemmas.swap_mul mma mb;
       Math.Lemmas.paren_mul_right mb mma mmb }
     ma * (mb * (mma * mmb));
-    (==) { Math.Lemmas.paren_mul_right ma mb (mma * mmb) }
+    == { Math.Lemmas.paren_mul_right ma mb (mma * mmb) }
     ma * mb * (mma * mmb);
   }
 
@@ -70,9 +70,9 @@ val lemma_distr_pow (a b:int) (c d:nat) : Lemma ((a + b * pow2 c) * pow2 d = a *
 let lemma_distr_pow a b c d =
   calc (==) {
     (a + b * pow2 c) * pow2 d;
-    (==) { Math.Lemmas.distributivity_add_left a (b * pow2 c) (pow2 d) }
+    == { Math.Lemmas.distributivity_add_left a (b * pow2 c) (pow2 d) }
     a * pow2 d + b * pow2 c * pow2 d;
-    (==) { Math.Lemmas.paren_mul_right b (pow2 c) (pow2 d); Math.Lemmas.pow2_plus c d }
+    == { Math.Lemmas.paren_mul_right b (pow2 c) (pow2 d); Math.Lemmas.pow2_plus c d }
     a * pow2 d + b * pow2 (c + d);
   }
 
@@ -82,9 +82,9 @@ val lemma_distr_pow_pow (a:int) (b:nat) (c:int) (d e:nat) :
 let lemma_distr_pow_pow a b c d e =
   calc (==) {
     (a * pow2 b + c * pow2 d) * pow2 e;
-    (==) { lemma_distr_pow (a * pow2 b) c d e }
+    == { lemma_distr_pow (a * pow2 b) c d e }
     a * pow2 b * pow2 e + c * pow2 (d + e);
-    (==) { Math.Lemmas.paren_mul_right a (pow2 b) (pow2 e); Math.Lemmas.pow2_plus b e }
+    == { Math.Lemmas.paren_mul_right a (pow2 b) (pow2 e); Math.Lemmas.pow2_plus b e }
     a * pow2 (b + e) + c * pow2 (d + e);
   }
 
@@ -93,11 +93,11 @@ val lemma_distr_eucl_mul (r a:int) (b:pos) : Lemma (r * (a % b) + r * (a / b) * 
 let lemma_distr_eucl_mul r a b =
   calc (==) {
     r * (a % b) + r * (a / b) * b;
-    (==) { Math.Lemmas.paren_mul_right r (a / b) b }
+    == { Math.Lemmas.paren_mul_right r (a / b) b }
     r * (a % b) + r * ((a / b) * b);
-    (==) { Math.Lemmas.distributivity_add_right r (a % b) (a / b * b) }
+    == { Math.Lemmas.distributivity_add_right r (a % b) (a / b * b) }
     r * (a % b + a / b * b);
-    (==) { Math.Lemmas.euclidean_division_definition a b }
+    == { Math.Lemmas.euclidean_division_definition a b }
     r * a;
   }
 
@@ -106,15 +106,15 @@ val lemma_distr_eucl_mul_add (r a c:int) (b:pos) : Lemma (r * (a % b) + r * (a /
 let lemma_distr_eucl_mul_add r a c b =
   calc (==) {
     r * (a % b) + r * (a / b + c) * b;
-    (==) { Math.Lemmas.paren_mul_right r (a / b + c) b }
+    == { Math.Lemmas.paren_mul_right r (a / b + c) b }
     r * (a % b) + r * ((a / b + c) * b);
-    (==) { Math.Lemmas.distributivity_add_left (a / b) c b }
+    == { Math.Lemmas.distributivity_add_left (a / b) c b }
     r * (a % b) + r * ((a / b * b) + c * b);
-    (==) { Math.Lemmas.distributivity_add_right r (a / b * b) (c * b) }
+    == { Math.Lemmas.distributivity_add_right r (a / b * b) (c * b) }
     r * (a % b) + r * (a / b * b) + r * (c * b);
-    (==) { Math.Lemmas.paren_mul_right r (a / b) b; Math.Lemmas.paren_mul_right r c b }
+    == { Math.Lemmas.paren_mul_right r (a / b) b; Math.Lemmas.paren_mul_right r c b }
     r * (a % b) + r * (a / b) * b + r * c * b;
-    (==) { lemma_distr_eucl_mul r a b }
+    == { lemma_distr_eucl_mul r a b }
     r * a + r * c * b;
   }
 
@@ -137,15 +137,15 @@ val lemma_as_nat64_horner (r0 r1 r2 r3:int) :
 let lemma_as_nat64_horner r0 r1 r2 r3 =
   calc (==) {
     r0 + pow2 64 * (r1 + pow2 64 * (r2 + pow2 64 * r3));
-    (==) { Math.Lemmas.swap_mul (pow2 64) (r1 + pow2 64 * (r2 + pow2 64 * r3)) }
+    == { Math.Lemmas.swap_mul (pow2 64) (r1 + pow2 64 * (r2 + pow2 64 * r3)) }
     r0 + (r1 + pow2 64 * (r2 + pow2 64 * r3)) * pow2 64;
-    (==) { Math.Lemmas.swap_mul (pow2 64) (r2 + pow2 64 * r3) }
+    == { Math.Lemmas.swap_mul (pow2 64) (r2 + pow2 64 * r3) }
     r0 + (r1 + (r2 + pow2 64 * r3) * pow2 64) * pow2 64;
-    (==) { lemma_distr_pow r1 (r2 + pow2 64 * r3) 64 64 }
+    == { lemma_distr_pow r1 (r2 + pow2 64 * r3) 64 64 }
     r0 + r1 * pow2 64 + (r2 + pow2 64 * r3) * pow2 128;
-    (==) { Math.Lemmas.swap_mul (pow2 64) r3 }
+    == { Math.Lemmas.swap_mul (pow2 64) r3 }
     r0 + r1 * pow2 64 + (r2 + r3 * pow2 64) * pow2 128;
-    (==) { lemma_distr_pow r2 r3 64 128 }
+    == { lemma_distr_pow r2 r3 64 128 }
     r0 + r1 * pow2 64 + r2 * pow2 128 + r3 * pow2 192;
   }
 
@@ -157,11 +157,11 @@ val lemma_as_nat_horner (r0 r1 r2 r3 r4:int) :
 let lemma_as_nat_horner r0 r1 r2 r3 r4 =
   calc (==) {
     (((r4 * pow2 52 + r3) * pow2 52 + r2) * pow2 52 + r1) * pow2 52 + r0;
-    (==) { lemma_distr_pow r1 ((r4 * pow2 52 + r3) * pow2 52 + r2) 52 52 }
+    == { lemma_distr_pow r1 ((r4 * pow2 52 + r3) * pow2 52 + r2) 52 52 }
     ((r4 * pow2 52 + r3) * pow2 52 + r2) * pow2 104 + r1 * pow2 52 + r0;
-    (==) { lemma_distr_pow r2 (r4 * pow2 52 + r3) 52 104 }
+    == { lemma_distr_pow r2 (r4 * pow2 52 + r3) 52 104 }
     (r4 * pow2 52 + r3) * pow2 156 + r2 * pow2 104 + r1 * pow2 52 + r0;
-    (==) { lemma_distr_pow r3 r4 52 156 }
+    == { lemma_distr_pow r3 r4 52 156 }
     r4 * pow2 208 + r3 * pow2 156 + r2 * pow2 104 + r1 * pow2 52 + r0;
   }
 
@@ -172,13 +172,13 @@ val lemma_distr5 (a0 a1 a2 a3 a4 b:int) : Lemma
 let lemma_distr5 a0 a1 a2 a3 a4 b =
   calc (==) {
     (a0 + a1 + a2 + a3 + a4) * b;
-    (==) { Math.Lemmas.distributivity_add_left a0 (a1 + a2 + a3 + a4) b }
+    == { Math.Lemmas.distributivity_add_left a0 (a1 + a2 + a3 + a4) b }
     a0 * b + (a1 + a2 + a3 + a4) * b;
-    (==) { Math.Lemmas.distributivity_add_left a1 (a2 + a3 + a4) b }
+    == { Math.Lemmas.distributivity_add_left a1 (a2 + a3 + a4) b }
     a0 * b + a1 * b + (a2 + a3 + a4) * b;
-    (==) { Math.Lemmas.distributivity_add_left a2 (a3 + a4) b }
+    == { Math.Lemmas.distributivity_add_left a2 (a3 + a4) b }
     a0 * b + a1 * b + a2 * b + (a3 + a4) * b;
-    (==) { Math.Lemmas.distributivity_add_left a3 a4 b }
+    == { Math.Lemmas.distributivity_add_left a3 a4 b }
     a0 * b + a1 * b + a2 * b + a3 * b + a4 * b;
   }
 
@@ -190,11 +190,11 @@ val lemma_distr5_pow52 (a b0 b1 b2 b3 b4:int) : Lemma
 let lemma_distr5_pow52 a b0 b1 b2 b3 b4 =
   calc (==) {
     a * (b0 + b1 * pow2 52 + b2 * pow2 104 + b3 * pow2 156 + b4 * pow2 208);
-    (==) { lemma_distr5 b0 (b1 * pow2 52) (b2 * pow2 104) (b3 * pow2 156) (b4 * pow2 208) a }
+    == { lemma_distr5 b0 (b1 * pow2 52) (b2 * pow2 104) (b3 * pow2 156) (b4 * pow2 208) a }
     b0 * a + b1 * pow2 52 * a + b2 * pow2 104 * a + b3 * pow2 156 * a + b4 * pow2 208 * a;
-    (==) { lemma_swap_mul3 b1 (pow2 52) a; lemma_swap_mul3 b2 (pow2 104) a }
+    == { lemma_swap_mul3 b1 (pow2 52) a; lemma_swap_mul3 b2 (pow2 104) a }
     b0 * a + b1 * a * pow2 52 + b2 * a * pow2 104 + b3 * pow2 156 * a + b4 * pow2 208 * a;
-    (==) { lemma_swap_mul3 b3 (pow2 156) a; lemma_swap_mul3 b4 (pow2 208) a }
+    == { lemma_swap_mul3 b3 (pow2 156) a; lemma_swap_mul3 b4 (pow2 208) a }
     b0 * a + b1 * a * pow2 52 + b2 * a * pow2 104 + b3 * a * pow2 156 + b4 * a * pow2 208;
   }
 
@@ -208,17 +208,17 @@ let lemma_distr5_pow52_mul_pow a b0 b1 b2 b3 b4 p =
   let b_sum = b0 + b1 * pow2 52 + b2 * pow2 104 + b3 * pow2 156 + b4 * pow2 208 in
   calc (==) {
     a * pow2 p * b_sum;
-    (==) { lemma_swap_mul3 a (pow2 p) b_sum }
+    == { lemma_swap_mul3 a (pow2 p) b_sum }
     a * b_sum * pow2 p;
-    (==) { lemma_distr5_pow52 a b0 b1 b2 b3 b4 }
+    == { lemma_distr5_pow52 a b0 b1 b2 b3 b4 }
     (a * b0 + a * b1 * pow2 52 + a * b2 * pow2 104 + a * b3 * pow2 156 + a * b4 * pow2 208) * pow2 p;
-    (==) { lemma_distr_pow (a * b0 + a * b1 * pow2 52 + a * b2 * pow2 104 + a * b3 * pow2 156) (a * b4) 208 p }
+    == { lemma_distr_pow (a * b0 + a * b1 * pow2 52 + a * b2 * pow2 104 + a * b3 * pow2 156) (a * b4) 208 p }
     (a * b0 + a * b1 * pow2 52 + a * b2 * pow2 104 + a * b3 * pow2 156) * pow2 p + a * b4 * pow2 (208 + p);
-    (==) { lemma_distr_pow (a * b0 + a * b1 * pow2 52 + a * b2 * pow2 104) (a * b3) 156 p }
+    == { lemma_distr_pow (a * b0 + a * b1 * pow2 52 + a * b2 * pow2 104) (a * b3) 156 p }
     (a * b0 + a * b1 * pow2 52 + a * b2 * pow2 104) * pow2 p + a * b3 * pow2 (156 + p) + a * b4 * pow2 (208 + p);
-    (==) { lemma_distr_pow (a * b0 + a * b1 * pow2 52) (a * b2) 104 p }
+    == { lemma_distr_pow (a * b0 + a * b1 * pow2 52) (a * b2) 104 p }
     (a * b0 + a * b1 * pow2 52) * pow2 p + a * b2 * pow2 (104 + p) + a * b3 * pow2 (156 + p) + a * b4 * pow2 (208 + p);
-    (==) { lemma_distr_pow (a * b0) (a * b1) 52 p }
+    == { lemma_distr_pow (a * b0) (a * b1) 52 p }
     a * b0 * pow2 p + a * b1 * pow2 (52 + p) + a * b2 * pow2 (104 + p) + a * b3 * pow2 (156 + p) + a * b4 * pow2 (208 + p);
   }
 
@@ -233,19 +233,19 @@ let lemma_distr5_pow52_sub a0 a1 a2 a3 a4 b0 b1 b2 b3 b4 c =
   calc (==) {
     (b0 * c - a0) + (b1 * c - a1) * pow2 52 + (b2 * c - a2) * pow2 104 +
     (b3 * c - a3) * pow2 156 + (b4 * c - a4) * pow2 208;
-    (==) { Math.Lemmas.distributivity_sub_left (b1 * c) a1 (pow2 52) }
+    == { Math.Lemmas.distributivity_sub_left (b1 * c) a1 (pow2 52) }
     c * b0 - a0 + c * b1 * pow2 52 - a1 * pow2 52 + (b2 * c - a2) * pow2 104 +
     (b3 * c - a3) * pow2 156 + (b4 * c - a4) * pow2 208;
-    (==) { Math.Lemmas.distributivity_sub_left (b2 * c) a2 (pow2 104) }
+    == { Math.Lemmas.distributivity_sub_left (b2 * c) a2 (pow2 104) }
     c * b0 - a0 + c * b1 * pow2 52 - a1 * pow2 52 + c * b2 * pow2 104 - a2 * pow2 104 +
     (b3 * c - a3) * pow2 156 + (b4 * c - a4) * pow2 208;
-    (==) { Math.Lemmas.distributivity_sub_left (b3 * c) a3 (pow2 156) }
+    == { Math.Lemmas.distributivity_sub_left (b3 * c) a3 (pow2 156) }
     c * b0 - a0 + c * b1 * pow2 52 - a1 * pow2 52 + c * b2 * pow2 104 - a2 * pow2 104 +
     c * b3 * pow2 156 - a3 * pow2 156 + (b4 * c - a4) * pow2 208;
-    (==) { Math.Lemmas.distributivity_sub_left (b4 * c) a4 (pow2 208) }
+    == { Math.Lemmas.distributivity_sub_left (b4 * c) a4 (pow2 208) }
     c * b0 - a0 + c * b1 * pow2 52 - a1 * pow2 52 + c * b2 * pow2 104 - a2 * pow2 104 +
     c * b3 * pow2 156 - a3 * pow2 156 + c * b4 * pow2 208 - a4 * pow2 208;
-    (==) { lemma_distr5_pow52 c b0 b1 b2 b3 b4 }
+    == { lemma_distr5_pow52 c b0 b1 b2 b3 b4 }
     (b0 + b1 * pow2 52 + b2 * pow2 104 + b3 * pow2 156 + b4 * pow2 208) * c -
     (a0 + a1 * pow2 52 + a2 * pow2 104 + a3 * pow2 156 + a4 * pow2 208);
   }
@@ -283,11 +283,11 @@ val lemma_a_mul_c_plus_d_mod_e_mul_f_g (a b c d f g:nat) : Lemma
 let lemma_a_mul_c_plus_d_mod_e_mul_f_g a b c d f g =
   calc (==) {
     a % pow2 b * pow2 c + (a / pow2 b + d * pow2 f) * pow2 g;
-    (==) { lemma_distr_pow (a / pow2 b) d f g }
+    == { lemma_distr_pow (a / pow2 b) d f g }
     a % pow2 b * pow2 c + (a / pow2 b) * pow2 (c + b) + d * pow2 (f + g);
-    (==) { lemma_distr_pow (a % pow2 b) (a / pow2 b) b c }
+    == { lemma_distr_pow (a % pow2 b) (a / pow2 b) b c }
     (a % pow2 b + (a / pow2 b) * pow2 b) * pow2 c + d * pow2 (f + g);
-    (==) { Math.Lemmas.euclidean_division_definition a (pow2 b) }
+    == { Math.Lemmas.euclidean_division_definition a (pow2 b) }
     a * pow2 c + d * pow2 (f + g);
   }
 
@@ -298,11 +298,11 @@ val lemma_a_mod_52_mul_b (a b:nat) :
 let lemma_a_mod_52_mul_b a b =
   calc (==) {
     (a % pow2 52) * pow2 b;
-    (==) { Math.Lemmas.euclidean_division_definition a (pow2 52) }
+    == { Math.Lemmas.euclidean_division_definition a (pow2 52) }
     (a - a / pow2 52 * pow2 52) * pow2 b;
-    (==) { Math.Lemmas.distributivity_sub_left a (a / pow2 52 * pow2 52) (pow2 b) }
+    == { Math.Lemmas.distributivity_sub_left a (a / pow2 52 * pow2 52) (pow2 b) }
     a * pow2 b - a / pow2 52 * pow2 52 * pow2 b;
-    (==) { Math.Lemmas.paren_mul_right (a / pow2 52) (pow2 52) (pow2 b); Math.Lemmas.pow2_plus 52 b }
+    == { Math.Lemmas.paren_mul_right (a / pow2 52) (pow2 52) (pow2 b); Math.Lemmas.pow2_plus 52 b }
     a * pow2 b - a / pow2 52 * pow2 (52 + b);
   }
 
@@ -325,23 +325,23 @@ let lemma_simplify_carry_round t0 t1 t2 t3 t4 =
   calc (==) {
     t0 % pow2 52 + (a % pow2 52) * pow2 52 + (b % pow2 52) * pow2 104 +
     (c % pow2 52) * pow2 156 + d * pow2 208;
-    (==) { lemma_a_mod_52_mul_b a 52 }
+    == { lemma_a_mod_52_mul_b a 52 }
     t0 % pow2 52 + (t1 + t0 / pow2 52) * pow2 52 - a / pow2 52 * pow2 104 + (b % pow2 52) * pow2 104 +
     (c % pow2 52) * pow2 156 + d * pow2 208;
-    (==) { lemma_distr_eucl t0 t1 }
+    == { lemma_distr_eucl t0 t1 }
     t0 + t1 * pow2 52 - a / pow2 52 * pow2 104 + (b % pow2 52) * pow2 104 +
     (c % pow2 52) * pow2 156 + d * pow2 208;
-    (==) { lemma_a_mod_52_mul_b b 104 }
+    == { lemma_a_mod_52_mul_b b 104 }
     t0 + t1 * pow2 52 - a / pow2 52 * pow2 104 + (t2 + a / pow2 52) * pow2 104 - b / pow2 52 * pow2 156 +
     (c % pow2 52) * pow2 156 + d * pow2 208;
-    (==) { Math.Lemmas.distributivity_add_left t2 (a / pow2 52) (pow2 104) }
+    == { Math.Lemmas.distributivity_add_left t2 (a / pow2 52) (pow2 104) }
     t0 + t1 * pow2 52 + t2 * pow2 104 - b / pow2 52 * pow2 156 +
     (c % pow2 52) * pow2 156 + d * pow2 208;
-    (==) { lemma_a_mod_52_mul_b c 156 }
+    == { lemma_a_mod_52_mul_b c 156 }
     t0 + t1 * pow2 52 + t2 * pow2 104 - b / pow2 52 * pow2 156 +
     (t3 + b / pow2 52) * pow2 156 - c / pow2 52 * pow2 208 + d * pow2 208;
-    (==) { Math.Lemmas.distributivity_add_left t3 (b / pow2 52) (pow2 156) }
+    == { Math.Lemmas.distributivity_add_left t3 (b / pow2 52) (pow2 156) }
     t0 + t1 * pow2 52 + t2 * pow2 104 + t3 * pow2 156 - c / pow2 52 * pow2 208 + (t4 + c / pow2 52) * pow2 208;
-    (==) { Math.Lemmas.distributivity_add_left t4 (c / pow2 52) (pow2 208) }
+    == { Math.Lemmas.distributivity_add_left t4 (c / pow2 52) (pow2 208) }
     t0 + t1 * pow2 52 + t2 * pow2 104 + t3 * pow2 156 + t4 * pow2 208;
   }

--- a/code/k256/Hacl.Spec.K256.PrecompTable.fst
+++ b/code/k256/Hacl.Spec.K256.PrecompTable.fst
@@ -79,11 +79,11 @@ val lemma_mod_pow2_sub: x:nat -> a:nat -> b:nat ->
 let lemma_mod_pow2_sub x a b =
   calc (==) {
     x / pow2 a % pow2 b * pow2 a;
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 x a (a + b) }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 x a (a + b) }
     x % pow2 (a + b) / pow2 a * pow2 a;
-    (==) { Math.Lemmas.euclidean_division_definition (x % pow2 (a + b)) (pow2 a) }
+    == { Math.Lemmas.euclidean_division_definition (x % pow2 (a + b)) (pow2 a) }
     x % pow2 (a + b) - x % pow2 (a + b) % pow2 a;
-    (==) { Math.Lemmas.pow2_modulo_modulo_lemma_1 x a (a + b) }
+    == { Math.Lemmas.pow2_modulo_modulo_lemma_1 x a (a + b) }
     x % pow2 (a + b) - x % pow2 a;
   }
 
@@ -103,15 +103,15 @@ let felem_to_list_lemma_eval x =
   assert (nat_x == x0 + x1 * pow52 + x2 * pow104 + x3 * pow156 + x4 * pow208);
   calc (==) {
     x0 + x1 * pow52 + x2 * pow104 + x3 * pow156 + x4 * pow208;
-    (==) { }
+    == { }
     x0 + x1 * pow52 + x2 * pow104 + (x / pow156 % pow52) * pow156 + x / pow208 * pow208;
-    (==) { lemma_mod_pow2_sub x 156 52 }
+    == { lemma_mod_pow2_sub x 156 52 }
     x0 + x1 * pow52 + x2 * pow104 + x % pow208 - x % pow156 + x / pow208 * pow208;
-    (==) { Math.Lemmas.euclidean_division_definition x pow208 }
+    == { Math.Lemmas.euclidean_division_definition x pow208 }
     x0 + x1 * pow52 + (x / pow104 % pow52) * pow104 - x % pow156 + x;
-    (==) { lemma_mod_pow2_sub x 104 52 }
+    == { lemma_mod_pow2_sub x 104 52 }
     x0 + (x / pow52 % pow52) * pow52 - x % pow104 + x;
-    (==) { lemma_mod_pow2_sub x 52 52 }
+    == { lemma_mod_pow2_sub x 52 52 }
     x;
   }
 

--- a/code/k256/Hacl.Spec.K256.Qinv.fst
+++ b/code/k256/Hacl.Spec.K256.Qinv.fst
@@ -143,11 +143,11 @@ val lemma_pow_mod_mul: f:S.qelem -> a:nat -> b:nat ->
 let lemma_pow_mod_mul f a b =
   calc (==) {
     S.qmul (M.pow f a % S.q) (M.pow f b % S.q);
-    (==) {
+    == {
       Math.Lemmas.lemma_mod_mul_distr_l (M.pow f a) (M.pow f b % S.q) S.q;
       Math.Lemmas.lemma_mod_mul_distr_r (M.pow f a) (M.pow f b) S.q }
     M.pow f a * M.pow f b % S.q;
-    (==) { M.lemma_pow_add f a b }
+    == { M.lemma_pow_add f a b }
     M.pow f (a + b) % S.q;
   }
 
@@ -157,14 +157,14 @@ val lemma_pow_pow_mod_mul: f:S.qelem -> a:nat -> b:nat -> c:nat ->
 let lemma_pow_pow_mod_mul f a b c =
   calc (==) {
     S.qmul (M.pow (M.pow f a % S.q) b % S.q) (M.pow f c % S.q);
-    (==) {
+    == {
       M.lemma_pow_mod_base (M.pow f a) b S.q;
       Math.Lemmas.lemma_mod_mul_distr_l (M.pow (M.pow f a) b) (M.pow f c % S.q) S.q;
       Math.Lemmas.lemma_mod_mul_distr_r (M.pow (M.pow f a) b) (M.pow f c) S.q }
     M.pow (M.pow f a) b * M.pow f c % S.q;
-    (==) { M.lemma_pow_mul f a b }
+    == { M.lemma_pow_mul f a b }
     M.pow f (a * b) * M.pow f c % S.q;
-    (==) { M.lemma_pow_add f (a * b) c }
+    == { M.lemma_pow_add f (a * b) c }
     M.pow f (a * b + c) % S.q;
   }
 

--- a/code/k256/Hacl.Spec.K256.Scalar.Lemmas.fst
+++ b/code/k256/Hacl.Spec.K256.Scalar.Lemmas.fst
@@ -335,9 +335,9 @@ val lemma_b_pow2_256_plus_a_modq (a b: nat) :
 let lemma_b_pow2_256_plus_a_modq a b =
   calc (==) {
     (b * (pow2 256 - S.q) + a) % S.q;
-    (==) { Math.Lemmas.distributivity_sub_right b (pow2 256) S.q }
+    == { Math.Lemmas.distributivity_sub_right b (pow2 256) S.q }
     (b * pow2 256 - b * S.q + a) % S.q;
-    (==) { Math.Lemmas.lemma_mod_sub (b * pow2 256 + a) S.q b }
+    == { Math.Lemmas.lemma_mod_sub (b * pow2 256 + a) S.q b }
     (b * pow2 256 + a) % S.q;
   }
 
@@ -372,15 +372,15 @@ let mod_lseq_before_final_lemma a =
 
   calc (==) { //(v c2 * pow2 256 + SD.bn_v r) % S.q;
     rhs_p % S.q;
-    (==) { lemma_b_pow2_256_plus_a_modq_lseq 5 p }
+    == { lemma_b_pow2_256_plus_a_modq_lseq 5 p }
     SD.bn_v p % S.q;
-    (==) { }
+    == { }
     rhs_m % S.q;
-    (==) { lemma_b_pow2_256_plus_a_modq_lseq 7 m }
+    == { lemma_b_pow2_256_plus_a_modq_lseq 7 m }
     SD.bn_v m % S.q;
-    (==) { }
+    == { }
     rhs_a % S.q;
-    (==) { lemma_b_pow2_256_plus_a_modq_lseq 8 a }
+    == { lemma_b_pow2_256_plus_a_modq_lseq 8 a }
     SD.bn_v a % S.q;
     }
 
@@ -444,17 +444,17 @@ val qmul_shift_383_mod_2_lemma : l:lseq uint64 8 ->
 let qmul_shift_383_mod_2_lemma l =
   calc (==) {
     v l.[5] / pow2 63;
-    (==) { SD.bn_eval_index l 5 }
+    == { SD.bn_eval_index l 5 }
     SD.bn_v l / pow2 320 % pow2 64 / pow2 63;
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 (SD.bn_v l) 320 384 }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 (SD.bn_v l) 320 384 }
     SD.bn_v l % pow2 384 / pow2 320 / pow2 63;
-    (==) { Math.Lemmas.division_multiplication_lemma (SD.bn_v l % pow2 384) (pow2 320) (pow2 63) }
+    == { Math.Lemmas.division_multiplication_lemma (SD.bn_v l % pow2 384) (pow2 320) (pow2 63) }
     SD.bn_v l % pow2 384 / (pow2 320 * pow2 63);
-    (==) { Math.Lemmas.pow2_plus 320 63 }
+    == { Math.Lemmas.pow2_plus 320 63 }
     SD.bn_v l % pow2 384 / pow2 383;
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 (SD.bn_v l) 383 384 }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 (SD.bn_v l) 383 384 }
     SD.bn_v l / pow2 383 % pow2 1;
-    (==) { assert_norm (pow2 1 = 2) }
+    == { assert_norm (pow2 1 = 2) }
     SD.bn_v l / pow2 383 % 2;
   }
 

--- a/code/poly1305/Hacl.Impl.Poly1305.Bignum128.fst
+++ b/code/poly1305/Hacl.Impl.Poly1305.Bignum128.fst
@@ -93,17 +93,17 @@ let mod_add128_lemma a b =
 
   calc (==) {
     v r2 * pow2 64 + v r0;
-    (==) { }
+    == { }
     ((v a1 + v b1) % pow2 64 + (v a0 + v b0) / pow2 64) % pow2 64 * pow2 64 + (v a0 + v b0) % pow2 64;
-    (==) { Math.Lemmas.pow2_multiplication_modulo_lemma_2 ((v a1 + v b1) % pow2 64 + (v a0 + v b0) / pow2 64) 128 64 }
+    == { Math.Lemmas.pow2_multiplication_modulo_lemma_2 ((v a1 + v b1) % pow2 64 + (v a0 + v b0) / pow2 64) 128 64 }
     ((v a1 + v b1) % pow2 64 + (v a0 + v b0) / pow2 64) * pow2 64 % pow2 128 + (v a0 + v b0) % pow2 64;
-    (==) { }
+    == { }
     ((v a1 + v b1) % pow2 64 * pow2 64 + (v a0 + v b0) / pow2 64 * pow2 64) % pow2 128 + (v a0 + v b0) % pow2 64;
-    (==) { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v a1 + v b1) 128 64 }
+    == { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v a1 + v b1) 128 64 }
     ((v a1 + v b1) * pow2 64 % pow2 128 + (v a0 + v b0) / pow2 64 * pow2 64) % pow2 128 + (v a0 + v b0) % pow2 64;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l ((v a1 + v b1) * pow2 64) ((v a0 + v b0) / pow2 64 * pow2 64) (pow2 128) }
+    == { Math.Lemmas.lemma_mod_plus_distr_l ((v a1 + v b1) * pow2 64) ((v a0 + v b0) / pow2 64 * pow2 64) (pow2 128) }
     ((v a1 + v b1) * pow2 64 + (v a0 + v b0) / pow2 64 * pow2 64) % pow2 128 + (v a0 + v b0) % pow2 64;
-    (==) { Math.Lemmas.modulo_lemma ((v a0 + v b0) % pow2 64) (pow2 128) }
+    == { Math.Lemmas.modulo_lemma ((v a0 + v b0) % pow2 64) (pow2 128) }
     ((v a1 + v b1) * pow2 64 + (v a0 + v b0) / pow2 64 * pow2 64) % pow2 128 + ((v a0 + v b0) % pow2 64) % pow2 128;
   };
   assert (v r2 * pow2 64 + v r0 ==

--- a/code/poly1305/Hacl.Poly1305.Field32xN.Lemmas0.fst
+++ b/code/poly1305/Hacl.Poly1305.Field32xN.Lemmas0.fst
@@ -143,11 +143,11 @@ let smul_felem5_eval_lemma_i #w #m1 #m2 u1 f2 i =
 
   calc (==) {
     vu1 * (fas_nat5 f2).[i];
-  (==) { }
+  == { }
     vu1 * (v tf20 + v tf21 * pow26 + v tf22 * pow52 + v tf23 * pow78 + v tf24 * pow104);
-  (==) { lemma_mul5_distr_l vu1 (v tf20) (v tf21 * pow26) (v tf22 * pow52) (v tf23 * pow78) (v tf24 * pow104)}
+  == { lemma_mul5_distr_l vu1 (v tf20) (v tf21 * pow26) (v tf22 * pow52) (v tf23 * pow78) (v tf24 * pow104)}
     vu1 * v tf20 + vu1 * (v tf21 * pow26) + vu1 * (v tf22 * pow52) + vu1 * (v tf23 * pow78) + vu1 * (v tf24 * pow104);
-  (==) {
+  == {
     FStar.Math.Lemmas.paren_mul_right vu1 (v tf21) pow26;
     FStar.Math.Lemmas.paren_mul_right vu1 (v tf22) pow52;
     FStar.Math.Lemmas.paren_mul_right vu1 (v tf23) pow78;
@@ -263,17 +263,17 @@ let smul_add_felem5_eval_lemma_i #w #m1 #m2 #m3 u1 f2 acc1 i =
 
   calc (==) {
     (fas_nat5 o).[i];
-    (==) { }
+    == { }
     v ta0 + vu1 * v tf20 + (v ta1 + vu1 * v tf21) * pow26 + (v ta2 + vu1 * v tf22) * pow52 +
     (v ta3 + vu1 * v tf23) * pow78 + (v ta4 + vu1 * v tf24) * pow104;
-    (==) {
+    == {
       FStar.Math.Lemmas.distributivity_add_left (v ta1) (vu1 * v tf21) pow26;
       FStar.Math.Lemmas.distributivity_add_left (v ta2) (vu1 * v tf22) pow52;
       FStar.Math.Lemmas.distributivity_add_left (v ta3) (vu1 * v tf23) pow78;
       FStar.Math.Lemmas.distributivity_add_left (v ta1) (vu1 * v tf24) pow104 }
     v ta0 + v ta1 * pow26 + v ta2 * pow52 + v ta3 * pow78 + v ta4 * pow104 +
     vu1 * v tf20 + vu1 * v tf21 * pow26 + vu1 * v tf22 * pow52 + vu1 * v tf23 * pow78 + vu1 * v tf24 * pow104;
-    (==) { }
+    == { }
     (fas_nat5 acc1).[i] + vu1 * v tf20 + vu1 * v tf21 * pow26 + vu1 * v tf22 * pow52 + vu1 * v tf23 * pow78 + vu1 * v tf24 * pow104;
    };
    assert ((fas_nat5 o).[i] == (fas_nat5 acc1).[i] +
@@ -281,11 +281,11 @@ let smul_add_felem5_eval_lemma_i #w #m1 #m2 #m3 u1 f2 acc1 i =
 
   calc (==) {
     vu1 * (fas_nat5 f2).[i];
-  (==) { }
+  == { }
     vu1 * (v tf20 + v tf21 * pow26 + v tf22 * pow52 + v tf23 * pow78 + v tf24 * pow104);
-  (==) { lemma_mul5_distr_l vu1 (v tf20) (v tf21 * pow26) (v tf22 * pow52) (v tf23 * pow78) (v tf24 * pow104)}
+  == { lemma_mul5_distr_l vu1 (v tf20) (v tf21 * pow26) (v tf22 * pow52) (v tf23 * pow78) (v tf24 * pow104)}
     vu1 * v tf20 + vu1 * (v tf21 * pow26) + vu1 * (v tf22 * pow52) + vu1 * (v tf23 * pow78) + vu1 * (v tf24 * pow104);
-  (==) {
+  == {
     FStar.Math.Lemmas.paren_mul_right vu1 (v tf21) pow26;
     FStar.Math.Lemmas.paren_mul_right vu1 (v tf22) pow52;
     FStar.Math.Lemmas.paren_mul_right vu1 (v tf23) pow78;
@@ -372,26 +372,26 @@ let lemma_fmul5_pow26 r =
   let (r0, r1, r2, r3, r4) = r in
   calc (==) {
     (pow26 * as_nat5 r) % prime;
-  (==) { }
+  == { }
     (pow26 * (v r0 + v r1 * pow26 + v r2 * pow52 + v r3 * pow78 + v r4 * pow104)) % prime;
-  (==) { lemma_mul5_distr_l pow26 (v r0) (v r1 * pow26) (v r2 * pow52) (v r3 * pow78) (v r4 * pow104) }
+  == { lemma_mul5_distr_l pow26 (v r0) (v r1 * pow26) (v r2 * pow52) (v r3 * pow78) (v r4 * pow104) }
     (v r0 * pow26 + pow26 * v r1 * pow26 + pow26 * v r2 * pow52 + pow26 * v r3 * pow78 + pow26 * v r4 * pow104) % prime;
-  (==) { }
+  == { }
     (v r0 * pow26 + v r1 * pow26 * pow26 + v r2 * pow26 * pow52 + v r3 * pow26 * pow78 + v r4 * pow26 * pow104) % prime;
-  (==) {
+  == {
     assert_norm (pow26 * pow26 = pow52);
     assert_norm (pow26 * pow52 = pow78);
     assert_norm (pow26 * pow78 = pow104);
     assert_norm (pow26 * pow104 = pow2 130) }
     (v r0 * pow26 + v r1 * pow52 + v r2 * pow78 + v r3 * pow104 + v r4 * pow2 130) % prime;
-  (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r
+  == { FStar.Math.Lemmas.lemma_mod_plus_distr_r
     (v r0 * pow26 + v r1 * pow52 + v r2 * pow78 + v r3 * pow104) (v r4 * pow2 130) prime }
     (v r0 * pow26 + v r1 * pow52 + v r2 * pow78 + v r3 * pow104 + (v r4 * pow2 130) % prime) % prime;
-  (==) { FStar.Math.Lemmas.lemma_mod_mul_distr_r (v r4) (pow2 130) prime }
+  == { FStar.Math.Lemmas.lemma_mod_mul_distr_r (v r4) (pow2 130) prime }
     (v r0 * pow26 + v r1 * pow52 + v r2 * pow78 + v r3 * pow104 + (v r4 * (pow2 130 % prime)) % prime) % prime;
-  (==) { lemma_prime () }
+  == { lemma_prime () }
     (v r0 * pow26 + v r1 * pow52 + v r2 * pow78 + v r3 * pow104 + (v r4 * 5) % prime) % prime;
-  (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r
+  == { FStar.Math.Lemmas.lemma_mod_plus_distr_r
     (v r0 * pow26 + v r1 * pow52 + v r2 * pow78 + v r3 * pow104) (v r4 * 5) prime }
     (v r0 * pow26 + v r1 * pow52 + v r2 * pow78 + v r3 * pow104 + v r4 * 5) % prime;
   };
@@ -409,17 +409,17 @@ let lemma_fmul5_pow52 r =
   let (r0, r1, r2, r3, r4) = r in
   calc (==) {
     (pow52 * as_nat5 r) % prime;
-    (==) { assert_norm (pow52 == pow26 * pow26) }
+    == { assert_norm (pow52 == pow26 * pow26) }
     (pow26 * pow26 * as_nat5 r) % prime;
-    (==) {
+    == {
       FStar.Math.Lemmas.paren_mul_right pow26 pow26 (as_nat5 r);
       FStar.Math.Lemmas.lemma_mod_mul_distr_r pow26 (pow26 * as_nat5 r) prime }
     (pow26 * (pow26 * as_nat5 r % prime)) % prime;
-    (==) { lemma_fmul5_pow26 r }
+    == { lemma_fmul5_pow26 r }
     (pow26 * (as_nat5 (r4 *! u64 5, r0, r1, r2, r3) % prime)) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_mul_distr_r pow26 (as_nat5 (r4 *! u64 5, r0, r1, r2, r3)) prime }
+    == { FStar.Math.Lemmas.lemma_mod_mul_distr_r pow26 (as_nat5 (r4 *! u64 5, r0, r1, r2, r3)) prime }
     (pow26 * as_nat5 (r4 *! u64 5, r0, r1, r2, r3)) % prime;
-    (==) { lemma_fmul5_pow26 (r4 *! u64 5, r0, r1, r2, r3) }
+    == { lemma_fmul5_pow26 (r4 *! u64 5, r0, r1, r2, r3) }
     as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2) % prime;
   };
   assert ((pow52 * as_nat5 r) % prime == as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2) % prime)
@@ -435,17 +435,17 @@ let lemma_fmul5_pow78 r =
   let (r0, r1, r2, r3, r4) = r in
   calc (==) {
     (pow78 * as_nat5 r) % prime;
-    (==) { assert_norm (pow78 == pow26 * pow52) }
+    == { assert_norm (pow78 == pow26 * pow52) }
     (pow26 * pow52 * as_nat5 r) % prime;
-    (==) {
+    == {
       FStar.Math.Lemmas.paren_mul_right pow26 pow52 (as_nat5 r);
       FStar.Math.Lemmas.lemma_mod_mul_distr_r pow26 (pow52 * as_nat5 r) prime }
     (pow26 * (pow52 * as_nat5 r % prime)) % prime;
-    (==) { lemma_fmul5_pow52 r }
+    == { lemma_fmul5_pow52 r }
     (pow26 * (as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2) % prime)) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_mul_distr_r pow26 (as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2)) prime }
+    == { FStar.Math.Lemmas.lemma_mod_mul_distr_r pow26 (as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2)) prime }
     (pow26 * as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2)) % prime;
-    (==) { lemma_fmul5_pow26 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2) }
+    == { lemma_fmul5_pow26 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2) }
     as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1) % prime;
   };
   assert ((pow78 * as_nat5 r) % prime == as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1) % prime)
@@ -462,17 +462,17 @@ let lemma_fmul5_pow104 r =
   let (r0, r1, r2, r3, r4) = r in
   calc (==) {
     (pow104 * as_nat5 r) % prime;
-    (==) { assert_norm (pow104 == pow26 * pow78) }
+    == { assert_norm (pow104 == pow26 * pow78) }
     (pow26 * pow78 * as_nat5 r) % prime;
-    (==) {
+    == {
       FStar.Math.Lemmas.paren_mul_right pow26 pow78 (as_nat5 r);
       FStar.Math.Lemmas.lemma_mod_mul_distr_r pow26 (pow78 * as_nat5 r) prime }
     (pow26 * (pow78 * as_nat5 r % prime)) % prime;
-    (==) { lemma_fmul5_pow78 r }
+    == { lemma_fmul5_pow78 r }
     (pow26 * (as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1) % prime)) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_mul_distr_r pow26 (as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1)) prime }
+    == { FStar.Math.Lemmas.lemma_mod_mul_distr_r pow26 (as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1)) prime }
     (pow26 * as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1)) % prime;
-    (==) { lemma_fmul5_pow26 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1) }
+    == { lemma_fmul5_pow26 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1) }
     as_nat5 (r1 *! u64 5, r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0) % prime;
   };
   assert ((pow104 * as_nat5 r) % prime == as_nat5 (r1 *! u64 5, r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0) % prime)
@@ -496,22 +496,22 @@ let mul_felem5_lemma_1 f1 r =
 
   calc (==) {
     (as_nat5 f1 * as_nat5 r) % prime;
-    (==) { }
+    == { }
     (v f10 + v f11 * pow26 + v f12 * pow52 + v f13 * pow78 + v f14 * pow104) * as_nat5 r % prime;
-    (==) { lemma_mul5_distr_r (v f10) (v f11 * pow26) (v f12 * pow52) (v f13 * pow78) (v f14 * pow104) (as_nat5 r) }
+    == { lemma_mul5_distr_r (v f10) (v f11 * pow26) (v f12 * pow52) (v f13 * pow78) (v f14 * pow104) (as_nat5 r) }
     (v f10 * as_nat5 r + v f11 * pow26 * as_nat5 r + v f12 * pow52 * as_nat5 r + v f13 * pow78 * as_nat5 r + v f14 * pow104 * as_nat5 r) % prime;
-    (==) {
+    == {
       FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp  (v f11 * pow26 * as_nat5 r) prime }
     (tmp + (v f11 * pow26 * as_nat5 r) % prime) % prime;
-    (==) {
+    == {
       FStar.Math.Lemmas.paren_mul_right (v f11) pow26 (as_nat5 r);
       FStar.Math.Lemmas.lemma_mod_mul_distr_r (v f11) (pow26 * as_nat5 r) prime }
     (tmp + v f11 * (pow26 * as_nat5 r % prime) % prime) % prime;
-    (==) { lemma_fmul5_pow26 r }
+    == { lemma_fmul5_pow26 r }
     (tmp + v f11 * (as_nat5 (r4 *! u64 5, r0, r1, r2, r3) % prime) % prime) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_mul_distr_r (v f11) (as_nat5 (r4 *! u64 5, r0, r1, r2, r3)) prime }
+    == { FStar.Math.Lemmas.lemma_mod_mul_distr_r (v f11) (as_nat5 (r4 *! u64 5, r0, r1, r2, r3)) prime }
     (tmp + v f11 * as_nat5 (r4 *! u64 5, r0, r1, r2, r3) % prime) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f11 * as_nat5 (r4 *! u64 5, r0, r1, r2, r3)) prime }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f11 * as_nat5 (r4 *! u64 5, r0, r1, r2, r3)) prime }
     (tmp + v f11 * as_nat5 (r4 *! u64 5, r0, r1, r2, r3)) % prime;
     };
   assert ((as_nat5 f1 * as_nat5 r) % prime == (tmp + v f11 * as_nat5 (r4 *! u64 5, r0, r1, r2, r3)) % prime)
@@ -538,19 +538,19 @@ let mul_felem5_lemma_2 f1 r =
 
   calc (==) {
     (as_nat5 f1 * as_nat5 r) % prime;
-    (==) { mul_felem5_lemma_1 f1 r }
+    == { mul_felem5_lemma_1 f1 r }
     (tmp + v f12 * pow52 * as_nat5 r) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f12 * pow52 * as_nat5 r) prime }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f12 * pow52 * as_nat5 r) prime }
     (tmp + (v f12 * pow52 * as_nat5 r) % prime) % prime;
-    (==) {
+    == {
       FStar.Math.Lemmas.paren_mul_right (v f12) pow52 (as_nat5 r);
       FStar.Math.Lemmas.lemma_mod_mul_distr_r (v f12) (pow52 * as_nat5 r) prime }
     (tmp + v f12 * (pow52 * as_nat5 r % prime) % prime) % prime;
-    (==) { lemma_fmul5_pow52 r }
+    == { lemma_fmul5_pow52 r }
     (tmp + v f12 * (as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2) % prime) % prime) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_mul_distr_r (v f12) (as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2)) prime }
+    == { FStar.Math.Lemmas.lemma_mod_mul_distr_r (v f12) (as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2)) prime }
     (tmp + v f12 * as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2) % prime) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f12 * as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2)) prime }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f12 * as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2)) prime }
     (tmp + v f12 * as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2)) % prime;
    };
   assert ((as_nat5 f1 * as_nat5 r) % prime == (tmp + v f12 * as_nat5 (r3 *! u64 5, r4 *! u64 5, r0, r1, r2)) % prime)
@@ -578,19 +578,19 @@ let mul_felem5_lemma_3 f1 r =
 
   calc (==) {
     (as_nat5 f1 * as_nat5 r) % prime;
-    (==) { mul_felem5_lemma_2 f1 r }
+    == { mul_felem5_lemma_2 f1 r }
     (tmp +  v f13 * pow78 * as_nat5 r) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f13 * pow78 * as_nat5 r) prime }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f13 * pow78 * as_nat5 r) prime }
     (tmp + (v f13 * pow78 * as_nat5 r) % prime) % prime;
-    (==) {
+    == {
       FStar.Math.Lemmas.paren_mul_right (v f13) pow78 (as_nat5 r);
       FStar.Math.Lemmas.lemma_mod_mul_distr_r (v f13) (pow78 * as_nat5 r) prime }
     (tmp + v f13 * (pow78 * as_nat5 r % prime) % prime) % prime;
-    (==) { lemma_fmul5_pow78 r }
+    == { lemma_fmul5_pow78 r }
     (tmp + v f13 * (as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1) % prime) % prime) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_mul_distr_r (v f13) (as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1)) prime }
+    == { FStar.Math.Lemmas.lemma_mod_mul_distr_r (v f13) (as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1)) prime }
     (tmp + v f13 * as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1) % prime) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f13 * as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1)) prime }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f13 * as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1)) prime }
     (tmp + v f13 * as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1)) % prime;
    };
   assert ((as_nat5 f1 * as_nat5 r) % prime == (tmp + v f13 * as_nat5 (r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0, r1)) % prime)
@@ -618,19 +618,19 @@ let mul_felem5_lemma_4 f1 r =
 
   calc (==) {
     (as_nat5 f1 * as_nat5 r) % prime;
-    (==) { mul_felem5_lemma_3 f1 r }
+    == { mul_felem5_lemma_3 f1 r }
     (tmp + v f14 * pow104 * as_nat5 r) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f14 * pow104 * as_nat5 r) prime }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f14 * pow104 * as_nat5 r) prime }
     (tmp + (v f14 * pow104 * as_nat5 r) % prime) % prime;
-    (==) {
+    == {
       FStar.Math.Lemmas.paren_mul_right (v f14) pow104 (as_nat5 r);
       FStar.Math.Lemmas.lemma_mod_mul_distr_r (v f14) (pow104 * as_nat5 r) prime }
     (tmp + v f14 * (pow104 * as_nat5 r % prime) % prime) % prime;
-    (==) { lemma_fmul5_pow104 r }
+    == { lemma_fmul5_pow104 r }
     (tmp + v f14 * (as_nat5 (r1 *! u64 5, r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0) % prime) % prime) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_mul_distr_r (v f14) (as_nat5 (r1 *! u64 5, r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0)) prime }
+    == { FStar.Math.Lemmas.lemma_mod_mul_distr_r (v f14) (as_nat5 (r1 *! u64 5, r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0)) prime }
     (tmp + v f14 * as_nat5 (r1 *! u64 5, r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0) % prime) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f14 * as_nat5 (r1 *! u64 5, r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0)) prime }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f14 * as_nat5 (r1 *! u64 5, r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0)) prime }
     (tmp + v f14 * as_nat5 (r1 *! u64 5, r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0)) % prime;
    };
   assert ((as_nat5 f1 * as_nat5 r) % prime == (tmp + v f14 * as_nat5 (r1 *! u64 5, r2 *! u64 5, r3 *! u64 5, r4 *! u64 5, r0)) % prime)

--- a/code/poly1305/Hacl.Poly1305.Field32xN.Lemmas1.fst
+++ b/code/poly1305/Hacl.Poly1305.Field32xN.Lemmas1.fst
@@ -317,27 +317,27 @@ let carry_wide_felem5_eval_lemma_i0 inp tmp vc0 vc1 vc2 vc3 vc4 vc6 =
 
   calc (==) {
     as_nat5 inp % prime;
-    (==) { }
+    == { }
     (v xi0 + v xi1 * pow26 + v xi2 * pow52 + v xi3 * pow78 + v xi4 * pow104) % prime;
-    (==) { }
+    == { }
     (vc0 * pow2 26 + v t0 +
     (vc1 * pow2 26 + v t1 - vc0) * pow26 +
     (vc2 * pow2 26 + v t2 - vc1) * pow52 +
     (vc3 * pow2 26 + vc6 * pow2 26 + v t3 - vc2) * pow78 +
     (vc4 * pow2 26 + v t4 - vc6 - vc3) * pow104) % prime;
-    (==) {
+    == {
       assert_norm (pow2 26 * pow26 = pow52);
       assert_norm (pow2 26 * pow52 = pow78);
       assert_norm (pow2 26 * pow78 = pow104);
       assert_norm (pow2 26 * pow104 = pow2 130)}
     (v t0 + v t1 * pow26 + v t2 * pow52 + v t3 * pow78 + v t4 * pow104 + vc4 * pow2 130) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp_n (vc4 * pow2 130) prime }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp_n (vc4 * pow2 130) prime }
     (tmp_n + (vc4 * pow2 130 % prime)) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_mul_distr_r (vc4) (pow2 130) prime }
+    == { FStar.Math.Lemmas.lemma_mod_mul_distr_r (vc4) (pow2 130) prime }
     (tmp_n + (vc4 * (pow2 130 % prime) % prime)) % prime;
-    (==) { lemma_prime () }
+    == { lemma_prime () }
     (tmp_n + (vc4 * 5 % prime)) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp_n (vc4 * 5) prime }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp_n (vc4 * 5) prime }
     (tmp_n + vc4 * 5) % prime;
   };
   assert (as_nat5 inp % prime == (tmp_n + vc4 * 5) % prime)
@@ -443,9 +443,9 @@ let carry_wide_felem5_eval_lemma_i #w inp i =
 
   calc (==) {
     (feval5 out).[i];
-    (==) { }
+    == { }
     (v o0 + v o1 * pow26 + v o2 * pow52 + v o3 * pow78 + v o4 * pow104) % prime;
-    (==) { }
+    == { }
     (v t0 + vc4 * 5 + (v t1 + vc5) * pow26 - vc5 * pow26 + v t2 * pow52 + v t3 * pow78 + v t4 * pow104) % prime;
     };
   Math.Lemmas.distributivity_add_left (v t1) vc5 pow26;
@@ -515,20 +515,20 @@ let lemma_subtract_p5_1 f f' =
   assert (as_nat5 f' < prime);
   calc (==) {
     as_nat5 f' % prime;
-    (==) { }
+    == { }
     (v f0' + v f1' * pow26 + v f2' * pow52 + v f3' * pow78 + v f4' * pow104) % prime;
-    (==) { }
+    == { }
     (v f0 - (pow2 26 - 5) + (v f1 - (pow2 26 - 1)) * pow26 + (v f2 - (pow2 26 - 1)) * pow52 +
     (v f3 - (pow2 26 - 1)) * pow78 + (v f4 - (pow2 26 - 1)) * pow104) % prime;
-    (==) {
+    == {
       assert_norm (pow2 26 * pow26 = pow52);
       assert_norm (pow2 26 * pow52 = pow78);
       assert_norm (pow2 26 * pow78 = pow104);
       assert_norm (pow2 26 * pow104 = pow2 130) }
     (v f0 + v f1 * pow26 + v f2 * pow52 + v f3 * pow78 + v f4 * pow104 - prime) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_sub (v f0 + v f1 * pow26 + v f2 * pow52 + v f3 * pow78 + v f4 * pow104) prime 1 }
+    == { FStar.Math.Lemmas.lemma_mod_sub (v f0 + v f1 * pow26 + v f2 * pow52 + v f3 * pow78 + v f4 * pow104) prime 1 }
     (v f0 + v f1 * pow26 + v f2 * pow52 + v f3 * pow78 + v f4 * pow104) % prime;
-    (==) { }
+    == { }
     as_nat5 f % prime;
     };
   assert (as_nat5 f' % prime == as_nat5 f % prime);
@@ -746,27 +746,27 @@ let carry_full_felem5_eval_lemma_i0 inp tmp vc0 vc1 vc2 vc3 vc4 =
 
   calc (==) {
     as_nat5 inp % prime;
-    (==) { }
+    == { }
     (v ti0 + v ti1 * pow26 + v ti2 * pow52 + v ti3 * pow78 + v ti4 * pow104) % prime;
-    (==) { }
+    == { }
     (vc0 * pow2 26 + v t0 +
     (vc1 * pow2 26 + v t1 - vc0) * pow26 +
     (vc2 * pow2 26 + v t2 - vc1) * pow52 +
     (vc3 * pow2 26 + v t3 - vc2) * pow78 +
     (vc4 * pow2 26 + v t4 - vc3) * pow104) % prime;
-    (==) {
+    == {
       assert_norm (pow2 26 * pow26 = pow52);
       assert_norm (pow2 26 * pow52 = pow78);
       assert_norm (pow2 26 * pow78 = pow104);
       assert_norm (pow2 26 * pow104 = pow2 130)}
     (v t0 + v t1 * pow26 + v t2 * pow52 + v t3 * pow78 + v t4 * pow104 + vc4 * pow2 130) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp_n (vc4 * pow2 130) prime }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp_n (vc4 * pow2 130) prime }
     (tmp_n + (vc4 * pow2 130 % prime)) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_mul_distr_r (vc4) (pow2 130) prime }
+    == { FStar.Math.Lemmas.lemma_mod_mul_distr_r (vc4) (pow2 130) prime }
     (tmp_n + (vc4 * (pow2 130 % prime) % prime)) % prime;
-    (==) { lemma_prime () }
+    == { lemma_prime () }
     (tmp_n + (vc4 * 5 % prime)) % prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp_n (vc4 * 5) prime }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp_n (vc4 * 5) prime }
     (tmp_n + vc4 * 5) % prime;
   };
   assert (as_nat5 inp % prime == (tmp_n + vc4 * 5) % prime)

--- a/code/poly1305/Hacl.Poly1305.Field32xN.Lemmas2.fst
+++ b/code/poly1305/Hacl.Poly1305.Field32xN.Lemmas2.fst
@@ -24,13 +24,13 @@ val load_tup64_lemma0_lo: lo:uint64 ->
 let load_tup64_lemma0_lo lo =
   calc (==) {
     v lo % pow2 26 + ((v lo / pow2 26) % pow2 26) * pow26 + v lo / pow2 52 * pow52;
-  (==) { FStar.Math.Lemmas.pow2_modulo_modulo_lemma_1 (v lo) 26 52 }
+  == { FStar.Math.Lemmas.pow2_modulo_modulo_lemma_1 (v lo) 26 52 }
     (v lo % pow2 52) % pow2 26 + ((v lo / pow2 26) % pow2 26) * pow2 26 + v lo / pow2 52 * pow2 52;
-  (==) { FStar.Math.Lemmas.pow2_modulo_division_lemma_1 (v lo) 26 52 }
+  == { FStar.Math.Lemmas.pow2_modulo_division_lemma_1 (v lo) 26 52 }
     (v lo % pow2 52) % pow2 26 + ((v lo % pow2 52) / pow2 26) * pow2 26 + v lo / pow2 52 * pow2 52;
-  (==) { FStar.Math.Lemmas.euclidean_division_definition (v lo % pow2 52) (pow2 26) }
+  == { FStar.Math.Lemmas.euclidean_division_definition (v lo % pow2 52) (pow2 26) }
     (v lo % pow2 52) + v lo / pow2 52 * pow2 52;
-  (==) { FStar.Math.Lemmas.euclidean_division_definition (v lo) (pow2 52) }
+  == { FStar.Math.Lemmas.euclidean_division_definition (v lo) (pow2 52) }
     v lo;
   }
 
@@ -43,19 +43,19 @@ val load_tup64_lemma0_hi: hi:uint64 ->
 let load_tup64_lemma0_hi hi =
   calc (==) {
     (v hi % pow2 14) * pow2 64 + (v hi / pow2 14) % pow2 26 * pow78 + v hi / pow2 40 * pow104;
-    (==) {
+    == {
       assert_norm (pow78 = pow2 14 * pow2 64);
       assert_norm (pow104 = pow2 40 * pow2 64)}
     (v hi % pow2 14) * pow2 64 + (v hi / pow2 14) % pow2 26 * pow2 14 * pow2 64 + v hi / pow2 40 * pow2 40 * pow2 64;
-    (==) { }
+    == { }
     (v hi % pow2 14 + ((v hi / pow2 14) % pow2 26) * pow2 14 + (v hi / pow2 40) * pow2 40) * pow2 64;
-  (==) { FStar.Math.Lemmas.pow2_modulo_division_lemma_1 (v hi) 14 40 }
+  == { FStar.Math.Lemmas.pow2_modulo_division_lemma_1 (v hi) 14 40 }
     (v hi % pow2 14 + ((v hi % pow2 40) / pow2 14) * pow2 14 + (v hi / pow2 40) * pow2 40) * pow2 64;
-  (==) { FStar.Math.Lemmas.pow2_modulo_modulo_lemma_1 (v hi) 14 40 }
+  == { FStar.Math.Lemmas.pow2_modulo_modulo_lemma_1 (v hi) 14 40 }
     ((v hi % pow2 40) % pow2 14 + ((v hi % pow2 40) / pow2 14) * pow2 14 + (v hi / pow2 40) * pow2 40) * pow2 64;
-  (==) { FStar.Math.Lemmas.euclidean_division_definition (v hi % pow2 40) (pow2 14) }
+  == { FStar.Math.Lemmas.euclidean_division_definition (v hi % pow2 40) (pow2 14) }
     (v hi % pow2 40 + (v hi / pow2 40) * pow2 40) * pow2 64;
-  (==) { FStar.Math.Lemmas.euclidean_division_definition (v hi) (pow2 40) }
+  == { FStar.Math.Lemmas.euclidean_division_definition (v hi) (pow2 40) }
     v hi * pow2 64;
   }
 
@@ -79,17 +79,17 @@ let load_tup64_lemma0 f lo hi =
   let (f0, f1, f2, f3, f4) = f in
   calc (==) {
     as_nat5 f;
-    (==) { }
+    == { }
     v f0 + v f1 * pow26 + v f2 * pow52 + v f3 * pow78 + v f4 * pow104;
-    (==) { }
+    == { }
     v lo % pow2 26 + (v lo / pow2 26) % pow2 26 * pow26 +
     v lo / pow2 52 * pow52 + (v hi % pow2 14) * pow2 12 * pow52 +
     (v hi / pow2 14) % pow2 26 * pow78 + v hi / pow2 40 * pow104;
-    (==) { load_tup64_lemma0_lo lo }
+    == { load_tup64_lemma0_lo lo }
     v lo + (v hi % pow2 14) * pow2 12 * pow52 + (v hi / pow2 14) % pow2 26 * pow78 + v hi / pow2 40 * pow104;
-    (==) { assert_norm (pow2 12 * pow52 = pow2 64) }
+    == { assert_norm (pow2 12 * pow52 = pow2 64) }
     v lo + (v hi % pow2 14) * pow2 64 + (v hi / pow2 14) % pow2 26 * pow78 + v hi / pow2 40 * pow104;
-    (==) { load_tup64_lemma0_hi hi }
+    == { load_tup64_lemma0_hi hi }
     v lo + v hi * pow2 64;
   };
   assert (as_nat5 f == v hi * pow2 64 + v lo)
@@ -129,13 +129,13 @@ let load_tup64_lemma_f2 lo hi =
 
   calc (==) {
     v (tmp <<. 12ul) % pow2 12;
-  (==) { shift_left_lemma (hi &. u64 0x3fff) 12ul }
+  == { shift_left_lemma (hi &. u64 0x3fff) 12ul }
     (v tmp * pow2 12 % pow2 64) % pow2 12;
-  (==) { assert_norm (pow2 64 = pow2 12 * pow2 52) }
+  == { assert_norm (pow2 64 = pow2 12 * pow2 52) }
     (v tmp * pow2 12 % (pow2 12 * pow2 52)) % pow2 12;
-  (==) {FStar.Math.Lemmas.modulo_modulo_lemma (v tmp * pow2 12) (pow2 12) (pow2 52)}
+  == {FStar.Math.Lemmas.modulo_modulo_lemma (v tmp * pow2 12) (pow2 12) (pow2 52)}
     v tmp * pow2 12 % pow2 12;
-  (==) {FStar.Math.Lemmas.multiple_modulo_lemma (v tmp) (pow2 12)}
+  == {FStar.Math.Lemmas.multiple_modulo_lemma (v tmp) (pow2 12)}
     0;
   };
   assert (v (tmp <<. 12ul) % pow2 12 = 0);
@@ -145,11 +145,11 @@ let load_tup64_lemma_f2 lo hi =
 
   calc (==) {
     v f2;
-  (==) {  }
+  == {  }
     v (lo >>. 52ul) + v ((hi &. u64 0x3fff) <<. 12ul);
-  (==) { shift_right_lemma lo 52ul }
+  == { shift_right_lemma lo 52ul }
     v lo / pow2 52 + v ((hi &. u64 0x3fff) <<. 12ul);
-  (==) { shift_left_lemma (hi &. u64 0x3fff) 12ul }
+  == { shift_left_lemma (hi &. u64 0x3fff) 12ul }
     v lo / pow2 52 + v (hi &. u64 0x3fff) * pow2 12 % pow2 64;
   };
   assert (v f2 == v lo / pow2 52 + v (hi &. u64 0x3fff) * pow2 12 % pow2 64);
@@ -236,11 +236,11 @@ val load_tup64_4_compact_lemma_f2_mod: lo:uint64 -> hi:uint64 -> Lemma
 let load_tup64_4_compact_lemma_f2_mod lo hi =
   calc (<) {
     v lo / pow2 52 + (v hi % pow2 14) * pow2 12;
-    (<) { Math.Lemmas.lemma_div_lt (v lo) 64 52 }
+    < { Math.Lemmas.lemma_div_lt (v lo) 64 52 }
     pow2 12 + (v hi % pow2 14) * pow2 12;
-    (<=) { Math.Lemmas.lemma_mult_le_right (pow2 12) (v hi % pow2 14) (pow2 14 - 1) }
+    <= { Math.Lemmas.lemma_mult_le_right (pow2 12) (v hi % pow2 14) (pow2 14 - 1) }
     pow2 12 + (pow2 14 - 1) * pow2 12;
-    (==) { Math.Lemmas.distributivity_sub_left (pow2 14) 1 (pow2 12); Math.Lemmas.pow2_plus 14 12 }
+    == { Math.Lemmas.distributivity_sub_left (pow2 14) 1 (pow2 12); Math.Lemmas.pow2_plus 14 12 }
     pow2 26;
   };
   assert (v lo / pow2 52 + (v hi % pow2 14) * pow2 12 < pow2 26);
@@ -262,15 +262,15 @@ let load_tup64_4_compact_lemma_f2 lo hi =
 
   calc (==) {
     (v lo / pow2 48 + (v hi * pow2 16) % pow2 64) / pow2 4;
-    (==) { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v hi) 64 16 }
+    == { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v hi) 64 16 }
     (v lo / pow2 48 + (v hi % pow2 48) * pow2 16) / pow2 4;
-    (==) { Math.Lemmas.pow2_plus 12 4 }
+    == { Math.Lemmas.pow2_plus 12 4 }
     (v lo / pow2 48 + (v hi % pow2 48) * pow2 12 * pow2 4) / pow2 4;
-    (==) { Math.Lemmas.division_addition_lemma (v lo / pow2 48) (pow2 4) ((v hi % pow2 48) * pow2 12) }
+    == { Math.Lemmas.division_addition_lemma (v lo / pow2 48) (pow2 4) ((v hi % pow2 48) * pow2 12) }
     (v lo / pow2 48) / pow2 4 + (v hi % pow2 48) * pow2 12;
-    (==) { Math.Lemmas.division_multiplication_lemma (v lo) (pow2 48) (pow2 4); Math.Lemmas.pow2_plus 48 4 }
+    == { Math.Lemmas.division_multiplication_lemma (v lo) (pow2 48) (pow2 4); Math.Lemmas.pow2_plus 48 4 }
     v lo / pow2 52 + (v hi % pow2 48) * pow2 12;
-    (==) { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v hi) 60 12 }
+    == { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v hi) 60 12 }
     v lo / pow2 52 + (v hi * pow2 12) % pow2 60;
   };
   assert (v (t3 >>. 4ul) == v lo / pow2 52 + (v hi * pow2 12) % pow2 60);
@@ -281,13 +281,13 @@ let load_tup64_4_compact_lemma_f2 lo hi =
 
   calc (==) {
     (v lo / pow2 52 + (v hi * pow2 12) % pow2 60) % pow2 26;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r (v lo / pow2 52) ((v hi * pow2 12) % pow2 60) (pow2 26) }
+    == { Math.Lemmas.lemma_mod_plus_distr_r (v lo / pow2 52) ((v hi * pow2 12) % pow2 60) (pow2 26) }
     (v lo / pow2 52 + (v hi * pow2 12) % pow2 60 % pow2 26) % pow2 26;
-    (==) { Math.Lemmas.pow2_modulo_modulo_lemma_1 (v hi * pow2 12) 26 60 }
+    == { Math.Lemmas.pow2_modulo_modulo_lemma_1 (v hi * pow2 12) 26 60 }
     (v lo / pow2 52 + (v hi * pow2 12) % pow2 26) % pow2 26;
-    (==) { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v hi) 26 12 }
+    == { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v hi) 26 12 }
     (v lo / pow2 52 + (v hi % pow2 14) * pow2 12) % pow2 26;
-    (==) { load_tup64_4_compact_lemma_f2_mod lo hi }
+    == { load_tup64_4_compact_lemma_f2_mod lo hi }
     v lo / pow2 52 + (v hi % pow2 14) * pow2 12;
   };
   assert (v f2 == v lo / pow2 52 + (v hi % pow2 14) * pow2 12)
@@ -308,18 +308,18 @@ let load_tup64_4_compact_lemma_f3 lo hi =
 
   calc (==) {
     (v lo / pow2 48 + (v hi * pow2 16) % pow2 64) / pow2 30;
-    (==) { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v hi) 64 16 }
+    == { Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v hi) 64 16 }
     (v lo / pow2 48 + (v hi % pow2 48) * pow2 16) / pow2 30;
-    (==) { Math.Lemmas.pow2_plus 16 14;
+    == { Math.Lemmas.pow2_plus 16 14;
       Math.Lemmas.division_multiplication_lemma (v lo / pow2 48 + (v hi % pow2 48) * pow2 16) (pow2 16) (pow2 14) }
     ((v lo / pow2 48 + (v hi % pow2 48) * pow2 16) / pow2 16) / pow2 14;
-    (==) { Math.Lemmas.division_addition_lemma (v lo / pow2 48) (pow2 16) (v hi % pow2 48) }
+    == { Math.Lemmas.division_addition_lemma (v lo / pow2 48) (pow2 16) (v hi % pow2 48) }
     ((v lo / pow2 48) / pow2 16 + (v hi % pow2 48)) / pow2 14;
-    (==) { Math.Lemmas.division_multiplication_lemma (v lo) (pow2 48) (pow2 16); Math.Lemmas.pow2_plus 48 16 }
+    == { Math.Lemmas.division_multiplication_lemma (v lo) (pow2 48) (pow2 16); Math.Lemmas.pow2_plus 48 16 }
     (v lo / pow2 64 + (v hi % pow2 48)) / pow2 14;
-    (==) { Math.Lemmas.small_div (v lo) (pow2 64) }
+    == { Math.Lemmas.small_div (v lo) (pow2 64) }
     (v hi % pow2 48) / pow2 14;
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 (v hi) 14 48 }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 (v hi) 14 48 }
     (v hi / pow2 14) % pow2 34;
     };
 
@@ -444,13 +444,13 @@ let lemma_tup64_mod_pow2_128 f =
 
   calc (==) {
     (as_nat5 f) % pow2 128;
-    (==) { }
+    == { }
     (v f0 + v f1 * pow26 + v f2 * pow52 + v f3 * pow78 + v f4 * pow104) % pow2 128;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f4 * pow104) (pow2 128) }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r tmp (v f4 * pow104) (pow2 128) }
     (tmp + (v f4 * pow104 % pow2 128)) % pow2 128;
-    (==) { FStar.Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v f4) 128 104 }
+    == { FStar.Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v f4) 128 104 }
     (tmp + (v f4 % pow2 24) * pow104) % pow2 128;
-    (==) { lemma_tup64_pow2_128 f; FStar.Math.Lemmas.modulo_lemma (tmp + (v f4 % pow2 24) * pow104) (pow2 128) }
+    == { lemma_tup64_pow2_128 f; FStar.Math.Lemmas.modulo_lemma (tmp + (v f4 % pow2 24) * pow104) (pow2 128) }
     tmp + (v f4 % pow2 24) * pow104;
   };
   assert ((as_nat5 f) % pow2 128 == tmp + (v f4 % pow2 24) * pow104)
@@ -473,30 +473,30 @@ let store_tup64_lemma f =
 
   calc (==) {
     v lo + v hi * pow2 64;
-    (==) { }
+    == { }
     v f0 + v f1 * pow2 26 + (v f2 * pow2 52) % pow2 64 +
     (v f2 / pow2 12 + v f3 * pow2 14 + (v f4 * pow2 40) % pow2 64) * pow2 64;
-    (==) { }
+    == { }
     v f0 + v f1 * pow2 26 + (v f2 * pow2 52) % pow2 64 +
     v f2 / pow2 12 * pow2 64 + v f3 * pow2 14 * pow2 64 + (v f4 * pow2 40) % pow2 64 * pow2 64;
-    (==) { FStar.Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v f4) 64 40 }
+    == { FStar.Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v f4) 64 40 }
     v f0 + v f1 * pow2 26 + (v f2 * pow2 52) % pow2 64 +
     v f2 / pow2 12 * pow2 64 + v f3 * pow2 14 * pow2 64 + (v f4 % pow2 24) * pow2 40 * pow2 64;
-    (==) { FStar.Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v f2) 64 52 }
+    == { FStar.Math.Lemmas.pow2_multiplication_modulo_lemma_2 (v f2) 64 52 }
     v f0 + v f1 * pow2 26 + (v f2 % pow2 12) * pow2 52 +
     v f2 / pow2 12 * pow2 64 + v f3 * pow2 14 * pow2 64 + (v f4 % pow2 24) * pow2 40 * pow2 64;
-    (==) { assert_norm (pow2 40 * pow2 64 = pow104) }
+    == { assert_norm (pow2 40 * pow2 64 = pow104) }
     v f0 + v f1 * pow2 26 + (v f2 % pow2 12) * pow2 52 +
     v f2 / pow2 12 * pow2 64 + v f3 * pow2 14 * pow2 64 + (v f4 % pow2 24) * pow104;
-    (==) { assert_norm (pow2 14 * pow2 64 = pow78) }
+    == { assert_norm (pow2 14 * pow2 64 = pow78) }
     v f0 + v f1 * pow2 26 + (v f2 % pow2 12) * pow2 52 +
     v f2 / pow2 12 * pow2 64 + v f3 * pow78 + (v f4 % pow2 24) * pow104;
-    (==) { assert_norm (pow2 12 * pow52 = pow2 64) }
+    == { assert_norm (pow2 12 * pow52 = pow2 64) }
     v f0 + v f1 * pow2 26 + (v f2 % pow2 12 + v f2 / pow2 12 * pow2 12) * pow52 +
     v f3 * pow78 + (v f4 % pow2 24) * pow104;
-    (==) { FStar.Math.Lemmas.euclidean_division_definition (v f2) (pow2 12) }
+    == { FStar.Math.Lemmas.euclidean_division_definition (v f2) (pow2 12) }
     v f0 + v f1 * pow2 26 + v f2 * pow52 + v f3 * pow78 + (v f4 % pow2 24) * pow104;
-    (==) { lemma_tup64_mod_pow2_128 f }
+    == { lemma_tup64_mod_pow2_128 f }
     (as_nat5 f) % pow2 128;
     };
   assert (v lo + v hi * pow2 64 == (as_nat5 f) % pow2 128);
@@ -574,11 +574,11 @@ let lset_bit5_lemma0 f i =
   let (o0, o1, o2, o3, o4) = (out.[0], out.[1], out.[2], out.[3], out.[4]) in
   calc (==) {
     as_nat5 (o0, o1, o2, o3, o4);
-    (==) { }
+    == { }
     v o0 + v o1 * pow26 + v o2 * pow52 + v o3 * pow78 + v o4 * pow104;
-    (==) { }
+    == { }
     pow2 (i % 26) + as_nat5 (f0, f1, f2, f3, f4);
-    (==) { FStar.Math.Lemmas.euclidean_division_definition i 26 }
+    == { FStar.Math.Lemmas.euclidean_division_definition i 26 }
     pow2 i + as_nat5 (f0, f1, f2, f3, f4);
     };
   assert (as_nat5 (o0, o1, o2, o3, o4) == pow2 i + as_nat5 (f0, f1, f2, f3, f4))
@@ -614,13 +614,13 @@ let lset_bit5_lemma1 f i =
 
   calc (==) {
     as_nat5 (o0, o1, o2, o3, o4);
-    (==) { }
+    == { }
     v o0 + v o1 * pow26 + v o2 * pow52 + v o3 * pow78 + v o4 * pow104;
-    (==) { }
+    == { }
     pow2 (i % 26) * pow26 + as_nat5 (f0, f1, f2, f3, f4);
-    (==) { FStar.Math.Lemmas.pow2_plus (i % 26) 26 }
+    == { FStar.Math.Lemmas.pow2_plus (i % 26) 26 }
     pow2 (i % 26 + 26) + as_nat5 (f0, f1, f2, f3, f4);
-    (==) { FStar.Math.Lemmas.euclidean_division_definition i 26 }
+    == { FStar.Math.Lemmas.euclidean_division_definition i 26 }
     pow2 i + as_nat5 (f0, f1, f2, f3, f4);
     };
   assert (as_nat5 (o0, o1, o2, o3, o4) == pow2 i + as_nat5 (f0, f1, f2, f3, f4))
@@ -656,13 +656,13 @@ let lset_bit5_lemma2 f i =
 
   calc (==) {
     as_nat5 (o0, o1, o2, o3, o4);
-    (==) { }
+    == { }
     v o0 + v o1 * pow26 + v o2 * pow52 + v o3 * pow78 + v o4 * pow104;
-    (==) { }
+    == { }
     pow2 (i % 26) * pow52 + as_nat5 (f0, f1, f2, f3, f4);
-    (==) { FStar.Math.Lemmas.pow2_plus (i % 26) 52 }
+    == { FStar.Math.Lemmas.pow2_plus (i % 26) 52 }
     pow2 (i % 26 + 52) + as_nat5 (f0, f1, f2, f3, f4);
-    (==) { FStar.Math.Lemmas.euclidean_division_definition i 26 }
+    == { FStar.Math.Lemmas.euclidean_division_definition i 26 }
     pow2 i + as_nat5 (f0, f1, f2, f3, f4);
     };
   assert (as_nat5 (o0, o1, o2, o3, o4) == pow2 i + as_nat5 (f0, f1, f2, f3, f4))
@@ -698,13 +698,13 @@ let lset_bit5_lemma3 f i =
 
   calc (==) {
     as_nat5 (o0, o1, o2, o3, o4);
-    (==) { }
+    == { }
     v o0 + v o1 * pow26 + v o2 * pow52 + v o3 * pow78 + v o4 * pow104;
-    (==) { }
+    == { }
     pow2 (i % 26) * pow78 + as_nat5 (f0, f1, f2, f3, f4);
-    (==) { FStar.Math.Lemmas.pow2_plus (i % 26) 78 }
+    == { FStar.Math.Lemmas.pow2_plus (i % 26) 78 }
     pow2 (i % 26 + 78) + as_nat5 (f0, f1, f2, f3, f4);
-    (==) { FStar.Math.Lemmas.euclidean_division_definition i 26 }
+    == { FStar.Math.Lemmas.euclidean_division_definition i 26 }
     pow2 i + as_nat5 (f0, f1, f2, f3, f4);
     };
   assert (as_nat5 (o0, o1, o2, o3, o4) == pow2 i + as_nat5 (f0, f1, f2, f3, f4))
@@ -740,13 +740,13 @@ let lset_bit5_lemma4 f i =
 
   calc (==) {
     as_nat5 (o0, o1, o2, o3, o4);
-    (==) { }
+    == { }
     v o0 + v o1 * pow26 + v o2 * pow52 + v o3 * pow78 + v o4 * pow104;
-    (==) { }
+    == { }
     pow2 (i % 26) * pow104 + as_nat5 (f0, f1, f2, f3, f4);
-    (==) { FStar.Math.Lemmas.pow2_plus (i % 26) 104 }
+    == { FStar.Math.Lemmas.pow2_plus (i % 26) 104 }
     pow2 (i % 26 + 104) + as_nat5 (f0, f1, f2, f3, f4);
-    (==) { FStar.Math.Lemmas.euclidean_division_definition i 26 }
+    == { FStar.Math.Lemmas.euclidean_division_definition i 26 }
     pow2 i + as_nat5 (f0, f1, f2, f3, f4);
     };
   assert (as_nat5 (o0, o1, o2, o3, o4) == pow2 i + as_nat5 (f0, f1, f2, f3, f4))

--- a/code/poly1305/Hacl.Spec.Poly1305.Field32xN.Lemmas.fst
+++ b/code/poly1305/Hacl.Spec.Poly1305.Field32xN.Lemmas.fst
@@ -349,14 +349,14 @@ let fmul_r2_normalize51 a fa1 =
 
   calc (==) {
     ((feval5 a).[0] + (feval5 a).[1]) % Vec.prime;
-    (==) { }
+    == { }
     (as_nat5 (a0, a1, a2, a3, a4) % Vec.prime + as_nat5 (a10, a11, a12, a13, a14) % Vec.prime) % Vec.prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_l
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_l
     (as_nat5 (a0, a1, a2, a3, a4)) (as_nat5 (a10, a11, a12, a13, a14)) Vec.prime;
   FStar.Math.Lemmas.lemma_mod_plus_distr_r
     (as_nat5 (a0, a1, a2, a3, a4) % Vec.prime) (as_nat5 (a10, a11, a12, a13, a14)) Vec.prime }
     (as_nat5 (a0, a1, a2, a3, a4) + as_nat5 (a10, a11, a12, a13, a14)) % Vec.prime;
-    (==) { }
+    == { }
     (feval5 out).[0];
   };
   out
@@ -529,19 +529,19 @@ let lemma_fmul_r4_normalize51_expand v2 out =
 
   calc (==) {
     as_nat5 (v20, v21, v22, v23, v24) % Vec.prime;
-    (==) { }
+    == { }
     (as_nat5 (as_tup64_i out 0) + as_nat5 (as_tup64_i out 1) + as_nat5 (as_tup64_i out 2) + as_nat5 (as_tup64_i out 3)) % Vec.prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_l (as_nat5 (as_tup64_i out 0) + as_nat5 (as_tup64_i out 1))
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_l (as_nat5 (as_tup64_i out 0) + as_nat5 (as_tup64_i out 1))
 	 (as_nat5 (as_tup64_i out 2) + as_nat5 (as_tup64_i out 3)) Vec.prime }
     ((as_nat5 (as_tup64_i out 0) + as_nat5 (as_tup64_i out 1)) % Vec.prime + as_nat5 (as_tup64_i out 2) + as_nat5 (as_tup64_i out 3)) % Vec.prime;
-    (==) { FStar.Math.Lemmas.modulo_distributivity (as_nat5 (as_tup64_i out 0)) (as_nat5 (as_tup64_i out 1)) Vec.prime }
+    == { FStar.Math.Lemmas.modulo_distributivity (as_nat5 (as_tup64_i out 0)) (as_nat5 (as_tup64_i out 1)) Vec.prime }
     (((feval5 out).[0] + (feval5 out).[1]) % Vec.prime + as_nat5 (as_tup64_i out 2) + as_nat5 (as_tup64_i out 3)) % Vec.prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_l (((feval5 out).[0] + (feval5 out).[1]) % Vec.prime + as_nat5 (as_tup64_i out 2))
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_l (((feval5 out).[0] + (feval5 out).[1]) % Vec.prime + as_nat5 (as_tup64_i out 2))
 	(as_nat5 (as_tup64_i out 3)) Vec.prime }
     ((((feval5 out).[0] + (feval5 out).[1]) % Vec.prime + as_nat5 (as_tup64_i out 2)) % Vec.prime + as_nat5 (as_tup64_i out 3)) % Vec.prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r (((feval5 out).[0] + (feval5 out).[1]) % Vec.prime) (as_nat5 (as_tup64_i out 2)) Vec.prime }
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r (((feval5 out).[0] + (feval5 out).[1]) % Vec.prime) (as_nat5 (as_tup64_i out 2)) Vec.prime }
     ((((feval5 out).[0] + (feval5 out).[1]) % Vec.prime + (feval5 out).[2]) % Vec.prime + as_nat5 (as_tup64_i out 3)) % Vec.prime;
-    (==) { FStar.Math.Lemmas.lemma_mod_plus_distr_r ((((feval5 out).[0] + (feval5 out).[1]) % Vec.prime + (feval5 out).[2]) % Vec.prime)
+    == { FStar.Math.Lemmas.lemma_mod_plus_distr_r ((((feval5 out).[0] + (feval5 out).[1]) % Vec.prime + (feval5 out).[2]) % Vec.prime)
 	 (as_nat5 (as_tup64_i out 3)) Vec.prime }
     ((((feval5 out).[0] + (feval5 out).[1]) % Vec.prime + (feval5 out).[2]) % Vec.prime + (feval5 out).[3]) % Vec.prime;
    };

--- a/code/rsapss/Hacl.Spec.RSAPSS.fst
+++ b/code/rsapss/Hacl.Spec.RSAPSS.fst
@@ -42,13 +42,13 @@ val bn_eval_lt_pow2_modBits:
 let bn_eval_lt_pow2_modBits #t modBits m =
   calc (==) {
     bn_v m;
-    (==) { Math.Lemmas.euclidean_division_definition (bn_v m) (pow2 (modBits - 1)) }
+    == { Math.Lemmas.euclidean_division_definition (bn_v m) (pow2 (modBits - 1)) }
     bn_v m / pow2 (modBits - 1) * pow2 (modBits - 1) + bn_v m % pow2 (modBits - 1);
-    (==) { Math.Lemmas.euclidean_division_definition (bn_v m / pow2 (modBits - 1)) 2 }
+    == { Math.Lemmas.euclidean_division_definition (bn_v m / pow2 (modBits - 1)) 2 }
     (bn_v m / pow2 (modBits - 1) / 2 * 2 + bn_v m / pow2 (modBits - 1) % 2) * pow2 (modBits - 1) + bn_v m % pow2 (modBits - 1);
-    (==) { Math.Lemmas.division_multiplication_lemma (bn_v m) (pow2 (modBits - 1)) 2; Math.Lemmas.pow2_plus (modBits - 1) 1}
+    == { Math.Lemmas.division_multiplication_lemma (bn_v m) (pow2 (modBits - 1)) 2; Math.Lemmas.pow2_plus (modBits - 1) 1}
     (bn_v m / pow2 modBits * 2 + bn_v m / pow2 (modBits - 1) % 2) * pow2 (modBits - 1) + bn_v m % pow2 (modBits - 1);
-    (==) { Math.Lemmas.small_division_lemma_1 (bn_v m) (pow2 modBits) }
+    == { Math.Lemmas.small_division_lemma_1 (bn_v m) (pow2 modBits) }
     (bn_v m / pow2 (modBits - 1) % 2) * pow2 (modBits - 1) + bn_v m % pow2 (modBits - 1);
     }
 

--- a/code/sha2-mb/Hacl.SHA2.Scalar32.Lemmas.fst
+++ b/code/sha2-mb/Hacl.SHA2.Scalar32.Lemmas.fst
@@ -39,11 +39,11 @@ let lemma_spec_update_224_256 b st: Lemma (ensures
 =
   calc (==) {
     Hacl.Spec.SHA2.update SHA2_256 b st;
-  (==) { Hacl.Spec.SHA2.EquivScalar.update_lemma SHA2_256 b st }
+  == { Hacl.Spec.SHA2.EquivScalar.update_lemma SHA2_256 b st }
     Spec.Agile.Hash.update SHA2_256 st b;
-  (==) { Spec.SHA2.Lemmas.update_224_256 st b }
+  == { Spec.SHA2.Lemmas.update_224_256 st b }
     Spec.Agile.Hash.update SHA2_224 st b;
-  (==) { Hacl.Spec.SHA2.EquivScalar.update_lemma SHA2_224 b st }
+  == { Hacl.Spec.SHA2.EquivScalar.update_lemma SHA2_224 b st }
     Hacl.Spec.SHA2.update SHA2_224 b st;
   }
 
@@ -58,13 +58,13 @@ let lemma_spec_update_vec_224_256 b0 st0 : Lemma (ensures
   let st1_m32 = (state_spec_v st1).[0] <: words_state SHA2_256 in
     calc (==) {
       st1_m32;
-    (==) {}
+    == {}
       (state_spec_v (SpecVec.update #SHA2_256 b0 st0)).[0];
-    (==) { Hacl.Spec.SHA2.Equiv.update_lemma_l #SHA2_256 #M32 b0 st0 0 }
+    == { Hacl.Spec.SHA2.Equiv.update_lemma_l #SHA2_256 #M32 b0 st0 0 }
       Hacl.Spec.SHA2.update SHA2_256 b0.(|0|) st0_m32;
-    (==) { lemma_spec_update_224_256 b0.(|0|) st0_m32 }
+    == { lemma_spec_update_224_256 b0.(|0|) st0_m32 }
       Hacl.Spec.SHA2.update SHA2_224 b0.(|0|) st0_m32;
-    (==) { Hacl.Spec.SHA2.Equiv.update_lemma_l #SHA2_224 #M32 b0 st0 0 }
+    == { Hacl.Spec.SHA2.Equiv.update_lemma_l #SHA2_224 #M32 b0 st0 0 }
       (state_spec_v #SHA2_224 #M32 (SpecVec.update #SHA2_224 b0 st0)).[0];
     };
     state_spec_v_extensionality SHA2_256
@@ -85,13 +85,13 @@ let lemma_spec_update_nblocks_vec_224_256 (len:size_t) b0 st0 : Lemma (ensures (
     let st1_m32 = (state_spec_v st1).[0] <: words_state SHA2_256 in
     calc (==) {
       st1_m32;
-    (==) {}
+    == {}
       (state_spec_v (SpecVec.update_nblocks #SHA2_256 (v len) b0 st0)).[0];
-    (==) { Hacl.Spec.SHA2.Equiv.update_nblocks_lemma_l #SHA2_256 #M32 (v len) b0 st0 0 }
+    == { Hacl.Spec.SHA2.Equiv.update_nblocks_lemma_l #SHA2_256 #M32 (v len) b0 st0 0 }
       Hacl.Spec.SHA2.update_nblocks SHA2_256 (v len) b0.(|0|) st0_m32;
-    (==) { Hacl.Spec.SHA2.EquivScalar.update_nblocks_is_repeat_blocks_multi SHA2_256 (v len) b0.(|0|) st0_m32 }
+    == { Hacl.Spec.SHA2.EquivScalar.update_nblocks_is_repeat_blocks_multi SHA2_256 (v len) b0.(|0|) st0_m32 }
       Lib.Sequence.repeat_blocks_multi (block_length SHA2_256) b0_m32' (Hacl.Spec.SHA2.update SHA2_256) st0_m32;
-    (==) {
+    == {
       FStar.Classical.forall_intro_2 lemma_spec_update_224_256;
       Lib.Sequence.Lemmas.repeat_blocks_multi_extensionality #uint8 #(words_state SHA2_256) (block_length SHA2_256) b0_m32'
         (Hacl.Spec.SHA2.update SHA2_256)
@@ -99,11 +99,11 @@ let lemma_spec_update_nblocks_vec_224_256 (len:size_t) b0 st0 : Lemma (ensures (
         st0_m32
     }
       Lib.Sequence.repeat_blocks_multi #uint8 #(words_state SHA2_256) (block_length SHA2_256) b0_m32' (Hacl.Spec.SHA2.update SHA2_224) st0_m32;
-    (==) { }
+    == { }
       Lib.Sequence.repeat_blocks_multi #uint8 #(words_state SHA2_224) (block_length SHA2_224) b0_m32' (Hacl.Spec.SHA2.update SHA2_224) (st0_m32 <: words_state SHA2_224);
-    (==) { Hacl.Spec.SHA2.EquivScalar.update_nblocks_is_repeat_blocks_multi SHA2_224 (v len) b0.(|0|) st0_m32 }
+    == { Hacl.Spec.SHA2.EquivScalar.update_nblocks_is_repeat_blocks_multi SHA2_224 (v len) b0.(|0|) st0_m32 }
       Hacl.Spec.SHA2.update_nblocks SHA2_224 (v len) b0.(|0|) st0_m32;
-    (==) { Hacl.Spec.SHA2.Equiv.update_nblocks_lemma_l #SHA2_224 #M32 (v len) b0 st0 0 }
+    == { Hacl.Spec.SHA2.Equiv.update_nblocks_lemma_l #SHA2_224 #M32 (v len) b0 st0 0 }
       (state_spec_v #SHA2_224 #M32 (SpecVec.update_nblocks #SHA2_224 (v len) b0 st0)).[0];
     };
     state_spec_v_extensionality SHA2_256
@@ -129,13 +129,13 @@ let lemma_spec_update_last_vec_224_256 totlen (len:size_t{v len <= block_length 
     in
     calc (==) {
       st1_m32;
-    (==) {}
+    == {}
       (state_spec_v (SpecVec.update_last #SHA2_256 totlen (v len) b0 st0)).[0];
-    (==) { Hacl.Spec.SHA2.Equiv.update_last_lemma_l #SHA2_256 #M32 totlen (v len) b0 st0 0 }
+    == { Hacl.Spec.SHA2.Equiv.update_last_lemma_l #SHA2_256 #M32 totlen (v len) b0 st0 0 }
       Hacl.Spec.SHA2.update_last SHA2_256 totlen (v len) b0.(|0|) st0_m32;
-    (==) { }
+    == { }
       Hacl.Spec.SHA2.update_last SHA2_224 totlen (v len) b0.(|0|) st0_m32;
-    (==) { Hacl.Spec.SHA2.Equiv.update_last_lemma_l #SHA2_224 #M32 totlen (v len) b0 st0 0 }
+    == { Hacl.Spec.SHA2.Equiv.update_last_lemma_l #SHA2_224 #M32 totlen (v len) b0 st0 0 }
       (state_spec_v (SpecVec.update_last #SHA2_224 #M32 totlen (v len) b0 st0)).[0];
     };
     state_spec_v_extensionality SHA2_256
@@ -149,11 +149,11 @@ let lemma_spec_update_384_512 b st: Lemma (ensures
 =
   calc (==) {
     Hacl.Spec.SHA2.update SHA2_512 b st;
-  (==) { Hacl.Spec.SHA2.EquivScalar.update_lemma SHA2_512 b st }
+  == { Hacl.Spec.SHA2.EquivScalar.update_lemma SHA2_512 b st }
     Spec.Agile.Hash.update SHA2_512 st b;
-  (==) { Spec.SHA2.Lemmas.update_384_512 st b }
+  == { Spec.SHA2.Lemmas.update_384_512 st b }
     Spec.Agile.Hash.update SHA2_384 st b;
-  (==) { Hacl.Spec.SHA2.EquivScalar.update_lemma SHA2_384 b st }
+  == { Hacl.Spec.SHA2.EquivScalar.update_lemma SHA2_384 b st }
     Hacl.Spec.SHA2.update SHA2_384 b st;
   }
 
@@ -168,13 +168,13 @@ let lemma_spec_update_vec_384_512 b0 st0 : Lemma (ensures
   let st1_m32 = (state_spec_v st1).[0] <: words_state SHA2_512 in
     calc (==) {
       st1_m32;
-    (==) {}
+    == {}
       (state_spec_v (SpecVec.update #SHA2_512 b0 st0)).[0];
-    (==) { Hacl.Spec.SHA2.Equiv.update_lemma_l #SHA2_512 #M32 b0 st0 0 }
+    == { Hacl.Spec.SHA2.Equiv.update_lemma_l #SHA2_512 #M32 b0 st0 0 }
       Hacl.Spec.SHA2.update SHA2_512 b0.(|0|) st0_m32;
-    (==) { lemma_spec_update_384_512 b0.(|0|) st0_m32 }
+    == { lemma_spec_update_384_512 b0.(|0|) st0_m32 }
       Hacl.Spec.SHA2.update SHA2_384 b0.(|0|) st0_m32;
-    (==) { Hacl.Spec.SHA2.Equiv.update_lemma_l #SHA2_384 #M32 b0 st0 0 }
+    == { Hacl.Spec.SHA2.Equiv.update_lemma_l #SHA2_384 #M32 b0 st0 0 }
       (state_spec_v #SHA2_384 #M32 (SpecVec.update #SHA2_384 b0 st0)).[0];
     };
     state_spec_v_extensionality SHA2_512
@@ -195,13 +195,13 @@ let lemma_spec_update_nblocks_vec_384_512 (len:size_t) b0 st0 : Lemma (ensures (
     let st1_m32 = (state_spec_v st1).[0] <: words_state SHA2_512 in
     calc (==) {
       st1_m32;
-    (==) {}
+    == {}
       (state_spec_v (SpecVec.update_nblocks #SHA2_512 (v len) b0 st0)).[0];
-    (==) { Hacl.Spec.SHA2.Equiv.update_nblocks_lemma_l #SHA2_512 #M32 (v len) b0 st0 0 }
+    == { Hacl.Spec.SHA2.Equiv.update_nblocks_lemma_l #SHA2_512 #M32 (v len) b0 st0 0 }
       Hacl.Spec.SHA2.update_nblocks SHA2_512 (v len) b0.(|0|) st0_m32;
-    (==) { Hacl.Spec.SHA2.EquivScalar.update_nblocks_is_repeat_blocks_multi SHA2_512 (v len) b0.(|0|) st0_m32 }
+    == { Hacl.Spec.SHA2.EquivScalar.update_nblocks_is_repeat_blocks_multi SHA2_512 (v len) b0.(|0|) st0_m32 }
       Lib.Sequence.repeat_blocks_multi (block_length SHA2_512) b0_m32' (Hacl.Spec.SHA2.update SHA2_512) st0_m32;
-    (==) {
+    == {
       FStar.Classical.forall_intro_2 lemma_spec_update_384_512;
       Lib.Sequence.Lemmas.repeat_blocks_multi_extensionality #uint8 #(words_state SHA2_512) (block_length SHA2_512) b0_m32'
         (Hacl.Spec.SHA2.update SHA2_512)
@@ -209,11 +209,11 @@ let lemma_spec_update_nblocks_vec_384_512 (len:size_t) b0 st0 : Lemma (ensures (
         st0_m32
     }
       Lib.Sequence.repeat_blocks_multi #uint8 #(words_state SHA2_512) (block_length SHA2_512) b0_m32' (Hacl.Spec.SHA2.update SHA2_384) st0_m32;
-    (==) { }
+    == { }
       Lib.Sequence.repeat_blocks_multi #uint8 #(words_state SHA2_384) (block_length SHA2_384) b0_m32' (Hacl.Spec.SHA2.update SHA2_384) (st0_m32 <: words_state SHA2_384);
-    (==) { Hacl.Spec.SHA2.EquivScalar.update_nblocks_is_repeat_blocks_multi SHA2_384 (v len) b0.(|0|) st0_m32 }
+    == { Hacl.Spec.SHA2.EquivScalar.update_nblocks_is_repeat_blocks_multi SHA2_384 (v len) b0.(|0|) st0_m32 }
       Hacl.Spec.SHA2.update_nblocks SHA2_384 (v len) b0.(|0|) st0_m32;
-    (==) { Hacl.Spec.SHA2.Equiv.update_nblocks_lemma_l #SHA2_384 #M32 (v len) b0 st0 0 }
+    == { Hacl.Spec.SHA2.Equiv.update_nblocks_lemma_l #SHA2_384 #M32 (v len) b0 st0 0 }
       (state_spec_v #SHA2_384 #M32 (SpecVec.update_nblocks #SHA2_384 (v len) b0 st0)).[0];
     };
     state_spec_v_extensionality SHA2_512
@@ -239,13 +239,13 @@ let lemma_spec_update_last_vec_384_512 totlen (len:size_t{v len <= block_length 
     in
     calc (==) {
       st1_m32;
-    (==) {}
+    == {}
       (state_spec_v (SpecVec.update_last #SHA2_512 totlen (v len) b0 st0)).[0];
-    (==) { Hacl.Spec.SHA2.Equiv.update_last_lemma_l #SHA2_512 #M32 totlen (v len) b0 st0 0 }
+    == { Hacl.Spec.SHA2.Equiv.update_last_lemma_l #SHA2_512 #M32 totlen (v len) b0 st0 0 }
       Hacl.Spec.SHA2.update_last SHA2_512 totlen (v len) b0.(|0|) st0_m32;
-    (==) { }
+    == { }
       Hacl.Spec.SHA2.update_last SHA2_384 totlen (v len) b0.(|0|) st0_m32;
-    (==) { Hacl.Spec.SHA2.Equiv.update_last_lemma_l #SHA2_384 #M32 totlen (v len) b0 st0 0 }
+    == { Hacl.Spec.SHA2.Equiv.update_last_lemma_l #SHA2_384 #M32 totlen (v len) b0 st0 0 }
       (state_spec_v (SpecVec.update_last #SHA2_384 #M32 totlen (v len) b0 st0)).[0];
     };
     state_spec_v_extensionality SHA2_512

--- a/code/sha2-mb/Hacl.Spec.SHA2.Equiv.fst
+++ b/code/sha2-mb/Hacl.Spec.SHA2.Equiv.fst
@@ -330,7 +330,7 @@ let load_blocks_lemma_ij #a #m b j i =
 
   calc (==) {
     idx_j * blocksize_l + j * blocksize;
-    (==) { Math.Lemmas.paren_mul_right idx_j l blocksize;
+    == { Math.Lemmas.paren_mul_right idx_j l blocksize;
       Math.Lemmas.distributivity_add_left (idx_j * l) j blocksize }
     (idx_j * l + j) * blocksize;
   };
@@ -367,25 +367,25 @@ let load_blocks_lemma_ij_subst #a #m b j i =
 
   calc (==) {
     i_new % l;
-    (==) { }
+    == { }
     (i / l * l + j) % l;
-    (==) { Math.Lemmas.modulo_addition_lemma j l (i / l) }
+    == { Math.Lemmas.modulo_addition_lemma j l (i / l) }
     j % l;
-    (==) { Math.Lemmas.small_mod j l }
+    == { Math.Lemmas.small_mod j l }
     j;
     };
 
   calc (==) {
     i_new / l * l + j_new;
-    (==) { }
+    == { }
     (i / l * l + j) / l * l + i % l;
-    (==) { Math.Lemmas.division_addition_lemma j l (i / l) }
+    == { Math.Lemmas.division_addition_lemma j l (i / l) }
     (i / l + j / l) * l + i % l;
-    (==) { Math.Lemmas.distributivity_add_left (i / l) (j / l) l }
+    == { Math.Lemmas.distributivity_add_left (i / l) (j / l) l }
     i / l * l + j / l * l + i % l;
-    (==) { Math.Lemmas.euclidean_division_definition i l }
+    == { Math.Lemmas.euclidean_division_definition i l }
     i + j / l * l;
-    (==) { Math.Lemmas.small_div j l }
+    == { Math.Lemmas.small_div j l }
     i;
     }
 
@@ -512,35 +512,35 @@ let store_state_lemma_ij #a #m st j i =
 
   calc (==) { // j_v % blocksize_v / word_length a
     (j * (8 * word_length a) + i) % blocksize_v / word_length a;
-    (==) { Math.Lemmas.modulo_division_lemma (j * (8 * word_length a) + i) (word_length a) (lanes a m) }
+    == { Math.Lemmas.modulo_division_lemma (j * (8 * word_length a) + i) (word_length a) (lanes a m) }
     (j * (8 * word_length a) + i) / word_length a % lanes a m;
-    (==) { Math.Lemmas.paren_mul_right j 8 (word_length a);
+    == { Math.Lemmas.paren_mul_right j 8 (word_length a);
            Math.Lemmas.division_addition_lemma i (word_length a) (8 * j) }
     (8 * j + i / word_length a) % lanes a m;
     };
 
   calc (==) { // j_v / blocksize_v
     (j * (8 * word_length a) + i) / (word_length a * lanes a m);
-    (==) { Math.Lemmas.division_multiplication_lemma (j * (8 * word_length a) + i) (word_length a) (lanes a m) }
+    == { Math.Lemmas.division_multiplication_lemma (j * (8 * word_length a) + i) (word_length a) (lanes a m) }
     (j * (8 * word_length a) + i) / word_length a / lanes a m;
-    (==) { Math.Lemmas.paren_mul_right j 8 (word_length a);
+    == { Math.Lemmas.paren_mul_right j 8 (word_length a);
            Math.Lemmas.division_addition_lemma i (word_length a) (8 * j) }
     (8 * j + i / word_length a) / lanes a m;
     };
 
   calc (==) {
     Seq.index (store_state st) j_v;
-    (==) { index_vecs_to_bytes_be #(word_t a) #(lanes a m) #8 st1 j_v }
+    == { index_vecs_to_bytes_be #(word_t a) #(lanes a m) #8 st1 j_v }
     (BSeq.uints_to_bytes_be (vec_v st1.[j_v / blocksize_v])).[j_v % blocksize_v];
-    (==) { BSeq.index_uints_to_bytes_be (vec_v st1.[j_v / blocksize_v]) (j_v % blocksize_v) }
+    == { BSeq.index_uints_to_bytes_be (vec_v st1.[j_v / blocksize_v]) (j_v % blocksize_v) }
     (BSeq.uint_to_bytes_be
       (Seq.index (vec_v st1.[j_v / blocksize_v]) (j_v % blocksize_v / word_length a))).[(j_v % blocksize_v) % word_length a];
-    (==) { Math.Lemmas.modulo_modulo_lemma j_v (word_length a) (lanes a m) }
+    == { Math.Lemmas.modulo_modulo_lemma j_v (word_length a) (lanes a m) }
     (BSeq.uint_to_bytes_be
       (Seq.index (vec_v st1.[j_v / blocksize_v]) (j_v % blocksize_v / word_length a))).[j_v % word_length a];
-    (==) { Lemmas.transpose_state_lemma_ij #a #m st j i }
+    == { Lemmas.transpose_state_lemma_ij #a #m st j i }
     (BSeq.uint_to_bytes_be (Seq.index (state_spec_v st).[j] (i / word_length a))).[j_v % word_length a];
-    (==) { Math.Lemmas.paren_mul_right j 8 (word_length a);
+    == { Math.Lemmas.paren_mul_right j 8 (word_length a);
            Math.Lemmas.modulo_addition_lemma i (word_length a) (j * 8) }
     (BSeq.uint_to_bytes_be (Seq.index (state_spec_v st).[j] (i / word_length a))).[i % word_length a];
     }

--- a/code/sha2-mb/Hacl.Spec.SHA2.EquivScalar.fst
+++ b/code/sha2-mb/Hacl.Spec.SHA2.EquivScalar.fst
@@ -716,21 +716,21 @@ let load_last_lemma a totlen totlen_seq len b =
   let fin = padded_blocks a rem * block_length a in
   calc (==) {
     pad0_length a len <: int;
-    (==) { }
+    == { }
     (block_length a - (len + len_length a + 1)) % block_length a;
-    (==) {
+    == {
       FStar.Math.Lemmas.lemma_mod_sub_distr (block_length a) (len + len_length a + 1) (block_length a);
       FStar.Math.Lemmas.lemma_mod_add_distr (len_length a + 1) len (block_length a)
       }
     (block_length a - (len % block_length a + len_length a + 1) % block_length a) % block_length a;
-    (==) { assert (len % block_length a == totlen % block_length a) }
+    == { assert (len % block_length a == totlen % block_length a) }
     (block_length a - (totlen % block_length a + len_length a + 1) % block_length a) % block_length a;
-    (==) {
+    == {
       FStar.Math.Lemmas.lemma_mod_sub_distr (block_length a) (totlen + len_length a + 1) (block_length a);
       FStar.Math.Lemmas.lemma_mod_add_distr (len_length a + 1) totlen (block_length a)
     }
     (block_length a - (totlen + len_length a + 1)) % block_length a;
-    (==) { }
+    == { }
     pad0_length a totlen;
   };
   assert (fin - len_length a == rem + 1 + pad0_length a totlen);

--- a/code/sha3/Hacl.Spec.SHA3.Equiv.fst
+++ b/code/sha3/Hacl.Spec.SHA3.Equiv.fst
@@ -404,7 +404,7 @@ let load_blocks_lemma_ij #m b j i =
 
   calc (==) {
     idx_j * blocksize_l + j * blocksize;
-    (==) { Math.Lemmas.paren_mul_right idx_j l blocksize;
+    == { Math.Lemmas.paren_mul_right idx_j l blocksize;
       Math.Lemmas.distributivity_add_left (idx_j * l) j blocksize }
     (idx_j * l + j) * blocksize;
   };
@@ -436,25 +436,25 @@ let load_blocks_lemma_ij_subst #m b j i =
 
   calc (==) {
     i_new % l;
-    (==) { }
+    == { }
     (i / l * l + j) % l;
-    (==) { Math.Lemmas.modulo_addition_lemma j l (i / l) }
+    == { Math.Lemmas.modulo_addition_lemma j l (i / l) }
     j % l;
-    (==) { Math.Lemmas.small_mod j l }
+    == { Math.Lemmas.small_mod j l }
     j;
     };
 
   calc (==) {
     i_new / l * l + j_new;
-    (==) { }
+    == { }
     (i / l * l + j) / l * l + i % l;
-    (==) { Math.Lemmas.division_addition_lemma j l (i / l) }
+    == { Math.Lemmas.division_addition_lemma j l (i / l) }
     (i / l + j / l) * l + i % l;
-    (==) { Math.Lemmas.distributivity_add_left (i / l) (j / l) l }
+    == { Math.Lemmas.distributivity_add_left (i / l) (j / l) l }
     i / l * l + j / l * l + i % l;
-    (==) { Math.Lemmas.euclidean_division_definition i l }
+    == { Math.Lemmas.euclidean_division_definition i l }
     i + j / l * l;
-    (==) { Math.Lemmas.small_div j l }
+    == { Math.Lemmas.small_div j l }
     i;
     }
 
@@ -582,38 +582,38 @@ let storeState_lemma_ij #m s j i =
 
   calc (==) { // j_v % blocksize_v / 8
     (j * (32 * 8) + i) % blocksize_v / 8;
-    (==) { Math.Lemmas.modulo_division_lemma (j * (32 * 8) + i) 8 (lanes m) }
+    == { Math.Lemmas.modulo_division_lemma (j * (32 * 8) + i) 8 (lanes m) }
     (j * (32 * 8) + i) / 8 % lanes m;
-    (==) { Math.Lemmas.paren_mul_right j 32 8;
+    == { Math.Lemmas.paren_mul_right j 32 8;
            Math.Lemmas.division_addition_lemma i 8 (32 * j) }
     (32 * j + i / 8) % lanes m;
     };
 
   calc (==) { // j_v / blocksize_v
     (j * (32 * 8) + i) / (8 * lanes m);
-    (==) { Math.Lemmas.division_multiplication_lemma (j * (32 * 8) + i) 8 (lanes m) }
+    == { Math.Lemmas.division_multiplication_lemma (j * (32 * 8) + i) 8 (lanes m) }
     (j * (32 * 8) + i) / 8 / lanes m;
-    (==) { Math.Lemmas.paren_mul_right j 32 8;
+    == { Math.Lemmas.paren_mul_right j 32 8;
            Math.Lemmas.division_addition_lemma i 8 (32 * j) }
     (32 * j + i / 8) / lanes m;
     };
 
   calc (==) {
     Seq.index (storeState #m s) j_v;
-    (==) { index_vecs_to_bytes_le #U64 #(lanes m) #32 ws1 j_v }
+    == { index_vecs_to_bytes_le #U64 #(lanes m) #32 ws1 j_v }
     (BSeq.uints_to_bytes_le (vec_v ws1.[j_v / blocksize_v])).[j_v % blocksize_v];
-    (==) { BSeq.index_uints_to_bytes_le (vec_v ws1.[j_v / blocksize_v]) (j_v % blocksize_v) }
+    == { BSeq.index_uints_to_bytes_le (vec_v ws1.[j_v / blocksize_v]) (j_v % blocksize_v) }
     (BSeq.uint_to_bytes_le
       (Seq.index (vec_v ws1.[j_v / blocksize_v]) (j_v % blocksize_v / 8))).[(j_v % blocksize_v) % 8];
-    (==) { Math.Lemmas.modulo_modulo_lemma j_v 8 (lanes m) }
+    == { Math.Lemmas.modulo_modulo_lemma j_v 8 (lanes m) }
     (BSeq.uint_to_bytes_le
       (Seq.index (vec_v ws1.[j_v / blocksize_v]) (j_v % blocksize_v / 8))).[j_v % 8];
-    (==) { Lemmas.transpose_s_lemma_ij #m ws j i }
+    == { Lemmas.transpose_s_lemma_ij #m ws j i }
     (BSeq.uint_to_bytes_le (Seq.index (ws_spec_v ws).[j] (i / 8))).[j_v % 8];
-    (==) { Math.Lemmas.paren_mul_right j 32 8;
+    == { Math.Lemmas.paren_mul_right j 32 8;
            Math.Lemmas.modulo_addition_lemma i 8 (j * 32) }
     (BSeq.uint_to_bytes_le (Seq.index (ws_spec_v ws).[j] (i / 8))).[i % 8];
-    (==) { }
+    == { }
     (BSeq.uint_to_bytes_le (Seq.index (state_spec_v s).[j] (i / 8))).[i % 8];
     }
 

--- a/code/streaming/Hacl.Streaming.Blake2.Common.fst
+++ b/code/streaming/Hacl.Streaming.Blake2.Common.fst
@@ -464,26 +464,26 @@ let update_multi_associative #a acc prevlen1 prevlen2 input1 input2 =
   let open Lib.Sequence.Lemmas in
   calc (==) {
     update_multi_s (update_multi_s acc prevlen1 input1) prevlen2 input2;
-    (==) { }
+    == { }
     repeati nb2 f2 (repeati nb1 f1 acc);
-    (==) {
+    == {
       Classical.forall_intro_2 aux1;
       repeati_extensionality nb1 f1 f acc
     }
     repeati nb2 f2 (repeati nb1 f acc);
-    (==) {
+    == {
       repeati_def nb1 f acc;
       repeati_def nb2 f2 (repeat_right 0 nb1 (fixed_a (Spec.state a)) f acc)
     }
     repeat_right 0 nb2 (fixed_a (Spec.state a)) f2 (repeat_right 0 nb1 (fixed_a (Spec.state a)) f acc);
-    (==) {
+    == {
       Classical.forall_intro_2 aux2;
       repeat_gen_right_extensionality nb2 nb1 (fixed_a (Spec.state a)) (fixed_a (Spec.state a)) f2 f (repeat_right 0 nb1 (fixed_a (Spec.state a)) f acc)
     }
     repeat_right nb1 (nb1 + nb2) (fixed_a (Spec.state a)) f (repeat_right 0 nb1 (fixed_a (Spec.state a)) f acc);
-    (==) { repeat_right_plus 0 nb1 nb (fixed_a (Spec.state a)) f acc; repeati_def nb f acc }
+    == { repeat_right_plus 0 nb1 nb (fixed_a (Spec.state a)) f acc; repeati_def nb f acc }
     repeati nb f acc;
-    (==) { }
+    == { }
     update_multi_s acc prevlen1 input;
   }
 #pop-options

--- a/code/streaming/Hacl.Streaming.Blake2b_256.fst
+++ b/code/streaming/Hacl.Streaming.Blake2b_256.fst
@@ -175,15 +175,15 @@ let malloc_with_key k kk r =
     assert (nn == (Spec.blake2_default_params Spec.Blake2B).digest_length);
     calc (==) {
       F.reveal_key blake2b_256 i h1 s;
-    (==) { }
+    == { }
       blake2b_256.key.v i h0 (p, k);
-    (==) { }
+    == { }
       Common.key_v i h0 (p, k);
-    (==) { _ by (FStar.Tactics.trefl ()) }
+    == { _ by (FStar.Tactics.trefl ()) }
       P.v #Spec.Blake2B h0 p, (if i.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h0 (k <: B.buffer Lib.IntTypes.uint8));
-    (==) { }
+    == { }
       { Spec.blake2_default_params Spec.Blake2B with Spec.key_length = kk; Spec.digest_length = nn }, (if i.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h0 (k <: B.buffer Lib.IntTypes.uint8));
-    (==) { }
+    == { }
       { Spec.blake2_default_params Spec.Blake2B with Spec.key_length = kk }, (if i.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h0 (k <: B.buffer Lib.IntTypes.uint8));
   }
   end);
@@ -289,13 +289,13 @@ let reset_with_key (i: G.erased (Common.index Spec.Blake2B)) s k () =
 
   calc (==) {
     F.reveal_key blake2b_256 idx h2 s;
-  (==) { }
+  == { }
     blake2b_256.key.v idx h1 (p, k);
-  (==) { }
+  == { }
     Common.key_v idx h1 (p, k);
-  (==) { _ by (FStar.Tactics.trefl())  }
+  == { _ by (FStar.Tactics.trefl())  }
     P.v #Spec.Blake2B h1 p, (if idx.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h1 (k <: B.buffer Lib.IntTypes.uint8));
-  (==) { }
+  == { }
     { Spec.blake2_default_params Spec.Blake2B with Spec.key_length = idx.key_length; Spec.digest_length = idx.digest_length }, (if idx.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h1 (k <: B.buffer Lib.IntTypes.uint8));
   };
 

--- a/code/streaming/Hacl.Streaming.Blake2b_32.fst
+++ b/code/streaming/Hacl.Streaming.Blake2b_32.fst
@@ -169,15 +169,15 @@ let malloc_with_key k kk r =
     assert (nn == (Spec.blake2_default_params Spec.Blake2B).digest_length);
     calc (==) {
       F.reveal_key blake2b_32 i h1 s;
-    (==) { }
+    == { }
       blake2b_32.key.v i h0 (p, k);
-    (==) { }
+    == { }
       Common.key_v i h0 (p, k);
-    (==) { _ by (FStar.Tactics.trefl ()) }
+    == { _ by (FStar.Tactics.trefl ()) }
       P.v #Spec.Blake2B h0 p, (if i.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h0 (k <: B.buffer Lib.IntTypes.uint8));
-    (==) { }
+    == { }
       { Spec.blake2_default_params Spec.Blake2B with Spec.key_length = kk; Spec.digest_length = nn }, (if i.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h0 (k <: B.buffer Lib.IntTypes.uint8));
-    (==) { }
+    == { }
       { Spec.blake2_default_params Spec.Blake2B with Spec.key_length = kk }, (if i.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h0 (k <: B.buffer Lib.IntTypes.uint8));
   }
   end);
@@ -283,13 +283,13 @@ let reset_with_key (i: G.erased (Common.index Spec.Blake2B)) s k () =
 
   calc (==) {
     F.reveal_key blake2b_32 idx h2 s;
-  (==) { }
+  == { }
     blake2b_32.key.v idx h1 (p, k);
-  (==) { }
+  == { }
     Common.key_v idx h1 (p, k);
-  (==) { _ by (FStar.Tactics.trefl())  }
+  == { _ by (FStar.Tactics.trefl())  }
     P.v #Spec.Blake2B h1 p, (if idx.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h1 (k <: B.buffer Lib.IntTypes.uint8));
-  (==) { }
+  == { }
     { Spec.blake2_default_params Spec.Blake2B with Spec.key_length = idx.key_length; Spec.digest_length = idx.digest_length }, (if idx.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h1 (k <: B.buffer Lib.IntTypes.uint8));
   };
 

--- a/code/streaming/Hacl.Streaming.Blake2s_128.fst
+++ b/code/streaming/Hacl.Streaming.Blake2s_128.fst
@@ -176,15 +176,15 @@ let malloc_with_key k kk r =
     assert (nn == (Spec.blake2_default_params Spec.Blake2S).digest_length);
     calc (==) {
       F.reveal_key blake2s_128 i h1 s;
-    (==) { }
+    == { }
       blake2s_128.key.v i h0 (p, k);
-    (==) { }
+    == { }
       Common.key_v i h0 (p, k);
-    (==) { _ by (FStar.Tactics.trefl ()) }
+    == { _ by (FStar.Tactics.trefl ()) }
       P.v #Spec.Blake2S h0 p, (if i.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h0 (k <: B.buffer Lib.IntTypes.uint8));
-    (==) { }
+    == { }
       { Spec.blake2_default_params Spec.Blake2S with Spec.key_length = kk; Spec.digest_length = nn }, (if i.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h0 (k <: B.buffer Lib.IntTypes.uint8));
-    (==) { }
+    == { }
       { Spec.blake2_default_params Spec.Blake2S with Spec.key_length = kk }, (if i.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h0 (k <: B.buffer Lib.IntTypes.uint8));
   }
   end);
@@ -290,13 +290,13 @@ let reset_with_key (i: G.erased (Common.index Spec.Blake2S)) s k () =
 
   calc (==) {
     F.reveal_key blake2s_128 idx h2 s;
-  (==) { }
+  == { }
     blake2s_128.key.v idx h1 (p, k);
-  (==) { }
+  == { }
     Common.key_v idx h1 (p, k);
-  (==) { _ by (FStar.Tactics.trefl())  }
+  == { _ by (FStar.Tactics.trefl())  }
     P.v #Spec.Blake2S h1 p, (if idx.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h1 (k <: B.buffer Lib.IntTypes.uint8));
-  (==) { }
+  == { }
     { Spec.blake2_default_params Spec.Blake2S with Spec.key_length = idx.key_length; Spec.digest_length = idx.digest_length }, (if idx.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h1 (k <: B.buffer Lib.IntTypes.uint8));
   };
 

--- a/code/streaming/Hacl.Streaming.Blake2s_32.fst
+++ b/code/streaming/Hacl.Streaming.Blake2s_32.fst
@@ -169,15 +169,15 @@ let malloc_with_key k kk r =
     assert (nn == (Spec.blake2_default_params Spec.Blake2S).digest_length);
     calc (==) {
       F.reveal_key blake2s_32 i h1 s;
-    (==) { }
+    == { }
       blake2s_32.key.v i h0 (p, k);
-    (==) { }
+    == { }
       Common.key_v i h0 (p, k);
-    (==) { _ by (FStar.Tactics.trefl ()) }
+    == { _ by (FStar.Tactics.trefl ()) }
       P.v #Spec.Blake2S h0 p, (if i.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h0 (k <: B.buffer Lib.IntTypes.uint8));
-    (==) { }
+    == { }
       { Spec.blake2_default_params Spec.Blake2S with Spec.key_length = kk; Spec.digest_length = nn }, (if i.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h0 (k <: B.buffer Lib.IntTypes.uint8));
-    (==) { }
+    == { }
       { Spec.blake2_default_params Spec.Blake2S with Spec.key_length = kk }, (if i.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h0 (k <: B.buffer Lib.IntTypes.uint8));
   }
   end);
@@ -283,13 +283,13 @@ let reset_with_key (i: G.erased (Common.index Spec.Blake2S)) s k () =
 
   calc (==) {
     F.reveal_key blake2s_32 idx h2 s;
-  (==) { }
+  == { }
     blake2s_32.key.v idx h1 (p, k);
-  (==) { }
+  == { }
     Common.key_v idx h1 (p, k);
-  (==) { _ by (FStar.Tactics.trefl())  }
+  == { _ by (FStar.Tactics.trefl())  }
     P.v #Spec.Blake2S h1 p, (if idx.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h1 (k <: B.buffer Lib.IntTypes.uint8));
-  (==) { }
+  == { }
     { Spec.blake2_default_params Spec.Blake2S with Spec.key_length = idx.key_length; Spec.digest_length = idx.digest_length }, (if idx.key_length = 0uy then S.empty #Lib.IntTypes.uint8 else B.as_seq h1 (k <: B.buffer Lib.IntTypes.uint8));
   };
 

--- a/code/streaming/Hacl.Streaming.Functor.fst
+++ b/code/streaming/Hacl.Streaming.Functor.fst
@@ -780,13 +780,13 @@ let rest #index (c: block index) (i: index)
     (**) FStar.Math.Lemmas.small_modulo_lemma_1 (U64.v r) (pow2 32);
     (**) calc (==) {
     (**)   U32.v r';
-    (**) (==) { }
+    (**) == { }
     (**)   U64.v r % pow2 32;
-    (**) (==) { FStar.Math.Lemmas.small_modulo_lemma_1 (U64.v r) (pow2 32) }
+    (**) == { FStar.Math.Lemmas.small_modulo_lemma_1 (U64.v r) (pow2 32) }
     (**)   U64.v r;
-    (**) (==) { FStar.Math.Lemmas.euclidean_division_definition (U64.v total_len) (U64.v (uint32_to_uint64 (c.blocks_state_len i))) }
+    (**) == { FStar.Math.Lemmas.euclidean_division_definition (U64.v total_len) (U64.v (uint32_to_uint64 (c.blocks_state_len i))) }
     (**)   U64.v total_len % U64.v (uint32_to_uint64 (c.blocks_state_len i) );
-    (**) (==) { }
+    (**) == { }
     (**)   U64.v total_len % U32.v (c.blocks_state_len i);
     (**) };
     (**) assert(

--- a/code/streaming/Hacl.Streaming.Poly1305.fst
+++ b/code/streaming/Hacl.Streaming.Poly1305.fst
@@ -185,16 +185,16 @@ let update_last_not_block_is_update input acc r =
   assert_norm (block_length < pow2 32);
   calc (==) {
     update_last (acc, r) input;
-  (==) { }
+  == { }
     update_last' r acc input, r;
-  (==) { Lib.UpdateMulti.update_multi_zero Spec.Poly1305.size_block (update' r) acc }
+  == { Lib.UpdateMulti.update_multi_zero Spec.Poly1305.size_block (update' r) acc }
     update_last' r (update_multi' r acc S.empty) input, r;
-  (==) { update_full_is_repeat_blocks block_length (update' r) (update_last' r) acc input input }
+  == { update_full_is_repeat_blocks block_length (update' r) (update_last' r) acc input input }
     Lib.Sequence.repeat_blocks #uint8 #Spec.Poly1305.felem block_length input
       (repeat_f block_length (update' r))
       (repeat_l block_length (update_last' r) input)
       acc, r;
-  (==) { Lib.Sequence.Lemmas.repeat_blocks_extensionality block_length input
+  == { Lib.Sequence.Lemmas.repeat_blocks_extensionality block_length input
       (repeat_f block_length (update' r))
       Spec.Poly1305.(poly1305_update1 r size_block)
       (repeat_l block_length (update_last' r) input)
@@ -252,13 +252,13 @@ let update_last_block_is_update input acc r =
   assert(acc1 == acc1');
   calc (==) {
     update_last (acc, r) input;
-  (==) { }
+  == { }
     update_last' r acc input, r;
-  (==) { }
+  == { }
     update_last' r (update' r acc input) S.empty, r;
-  (==) {  }
+  == {  }
    update_last' r (update_multi' r acc input) S.empty, r;
-  (==) { update_full_is_repeat_blocks block_length (update' r) (update_last' r) acc input input }
+  == { update_full_is_repeat_blocks block_length (update' r) (update_last' r) acc input input }
     Lib.Sequence.repeat_blocks #uint8 #Spec.Poly1305.felem block_length input
       (repeat_f block_length (update' r))
       (repeat_l block_length (update_last' r) input)
@@ -293,16 +293,16 @@ let update_multi_is_update input acc r =
   assert_norm (block_length < pow2 32);
   calc (==) {
     update_multi (acc, r) input;
-  (==) { with_or_without_r acc r input }
+  == { with_or_without_r acc r input }
     update_multi' r acc input, r;
-  (==) { }
+  == { }
     update_last' r (update_multi' r acc input) S.empty, r;
-  (==) { update_full_is_repeat_blocks block_length (update' r) (update_last' r) acc input input }
+  == { update_full_is_repeat_blocks block_length (update' r) (update_last' r) acc input input }
     Lib.Sequence.repeat_blocks #uint8 #Spec.Poly1305.felem block_length input
       (repeat_f block_length (update' r))
       (repeat_l block_length (update_last' r) input)
       acc, r;
-  (==) { Lib.Sequence.Lemmas.repeat_blocks_extensionality block_length input
+  == { Lib.Sequence.Lemmas.repeat_blocks_extensionality block_length input
       (repeat_f block_length (update' r))
       Spec.Poly1305.(poly1305_update1 r size_block)
       (repeat_l block_length (update_last' r) input)

--- a/code/streaming/Hacl.Streaming.Spec.fst
+++ b/code/streaming/Hacl.Streaming.Spec.fst
@@ -339,13 +339,13 @@ let split_at_last_blocks #index (c: block index) (i: index) (b: bytes) (d: bytes
   Math.Lemmas.modulo_distributivity (S.length b) (S.length blocks') l;
   calc (==) {
     S.length (S.append b blocks') % l;
-  (==) {}
+  == {}
     (S.length b + S.length blocks') % l;
-  (==) { Math.Lemmas.modulo_distributivity (S.length b) (S.length blocks') l }
+  == { Math.Lemmas.modulo_distributivity (S.length b) (S.length blocks') l }
     ((S.length b % l) + (S.length blocks' % l)) % l;
-  (==) {}
+  == {}
     0 % l;
-  (==) { Math.Lemmas.modulo_lemma 0 l }
+  == { Math.Lemmas.modulo_lemma 0 l }
     0;
   };
 

--- a/lib/Lib.Exponentiation.Definition.fst
+++ b/lib/Lib.Exponentiation.Definition.fst
@@ -18,13 +18,13 @@ val lemma_mul_cancel_inverse: #t:Type -> k:abelian_group t -> a:t -> b:t ->
 let lemma_mul_cancel_inverse #t k a b =
   calc (==) {
     cm.mul (inverse a) (cm.mul a b);
-    (==) { cm.lemma_mul_assoc (inverse a) a b }
+    == { cm.lemma_mul_assoc (inverse a) a b }
     cm.mul (cm.mul (inverse a) a) b;
-    (==) { lemma_inverse a }
+    == { lemma_inverse a }
     cm.mul cm.one b;
-    (==) { cm.lemma_mul_comm cm.one b }
+    == { cm.lemma_mul_comm cm.one b }
     cm.mul b cm.one;
-    (==) { cm.lemma_one b }
+    == { cm.lemma_one b }
     b;
   }
 
@@ -54,15 +54,15 @@ let lemma_inverse_mul #t k a b =
   assert (cm.mul (cm.mul a b) (inverse (cm.mul a b)) == cm.one);
   calc (==) {
     cm.mul (cm.mul a b) (cm.mul (inverse a) (inverse b));
-    (==) { cm.lemma_mul_assoc (cm.mul a b) (inverse a) (inverse b) }
+    == { cm.lemma_mul_assoc (cm.mul a b) (inverse a) (inverse b) }
     cm.mul (cm.mul (cm.mul a b) (inverse a)) (inverse b);
-    (==) { cm.lemma_mul_comm (cm.mul a b) (inverse a) }
+    == { cm.lemma_mul_comm (cm.mul a b) (inverse a) }
     cm.mul (cm.mul (inverse a) (cm.mul a b)) (inverse b);
-    (==) { lemma_mul_cancel_inverse k a b }
+    == { lemma_mul_cancel_inverse k a b }
     cm.mul b (inverse b);
-    (==) { cm.lemma_mul_comm b (inverse b) }
+    == { cm.lemma_mul_comm b (inverse b) }
     cm.mul (inverse b) b;
-    (==) { lemma_inverse b }
+    == { lemma_inverse b }
     cm.one;
   };
 
@@ -97,23 +97,23 @@ let rec lemma_pow_add #t k x n m =
   if n = 0 then begin
     calc (==) {
       mul (pow k x n) (pow k x m);
-      (==) { lemma_pow0 k x }
+      == { lemma_pow0 k x }
       mul one (pow k x m);
-      (==) { lemma_mul_comm one (pow k x m) }
+      == { lemma_mul_comm one (pow k x m) }
       mul (pow k x m) one;
-      (==) { lemma_one (pow k x m) }
+      == { lemma_one (pow k x m) }
       pow k x m;
       }; () end
   else begin
     calc (==) {
       mul (pow k x n) (pow k x m);
-      (==) { lemma_pow_unfold k x n }
+      == { lemma_pow_unfold k x n }
       mul (mul x (pow k x (n - 1))) (pow k x m);
-      (==) { lemma_mul_assoc x (pow k x (n - 1)) (pow k x m) }
+      == { lemma_mul_assoc x (pow k x (n - 1)) (pow k x m) }
       mul x (mul (pow k x (n - 1)) (pow k x m));
-      (==) { lemma_pow_add #t k x (n - 1) m }
+      == { lemma_pow_add #t k x (n - 1) m }
       mul x (pow k x (n - 1 + m));
-      (==) { lemma_pow_unfold k x (n + m) }
+      == { lemma_pow_unfold k x (n + m) }
       pow k x (n + m);
       }; () end
 
@@ -126,11 +126,11 @@ let rec lemma_pow_mul #t k x n m =
   else begin
     calc (==) {
       pow k (pow k x n) m;
-      (==) { lemma_pow_unfold k (pow k x n) m }
+      == { lemma_pow_unfold k (pow k x n) m }
       mul (pow k x n) (pow k (pow k x n) (m - 1));
-      (==) { lemma_pow_mul k x n (m - 1) }
+      == { lemma_pow_mul k x n (m - 1) }
       mul (pow k x n) (pow k x (n * (m - 1)));
-      (==) { lemma_pow_add k x n (n * (m - 1)) }
+      == { lemma_pow_add k x n (n * (m - 1)) }
       pow k x (n * m);
     }; () end
 
@@ -144,19 +144,19 @@ let rec lemma_pow_mul_base #t k a b n =
   else begin
     calc (==) {
       mul (pow k a n) (pow k b n);
-      (==) { lemma_pow_unfold k a n; lemma_pow_unfold k b n }
+      == { lemma_pow_unfold k a n; lemma_pow_unfold k b n }
       mul (mul a (pow k a (n - 1))) (mul b (pow k b (n - 1)));
-      (==) { lemma_mul_comm b (pow k b (n - 1));
+      == { lemma_mul_comm b (pow k b (n - 1));
        lemma_mul_assoc a (pow k a (n - 1)) (mul (pow k b (n - 1)) b) }
       mul a (mul (pow k a (n - 1)) (mul (pow k b (n - 1)) b));
-      (==) { lemma_mul_assoc (pow k a (n - 1)) (pow k b (n - 1)) b }
+      == { lemma_mul_assoc (pow k a (n - 1)) (pow k b (n - 1)) b }
       mul a (mul (mul (pow k a (n - 1)) (pow k b (n - 1))) b);
-      (==) { lemma_pow_mul_base #t k a b (n - 1) }
+      == { lemma_pow_mul_base #t k a b (n - 1) }
       mul a (mul (pow k (mul a b) (n - 1)) b);
-      (==) { lemma_mul_comm (pow k (mul a b) (n - 1)) b;
+      == { lemma_mul_comm (pow k (mul a b) (n - 1)) b;
 	lemma_mul_assoc a b (pow k (mul a b) (n - 1)) }
       mul (mul a b) (pow k (mul a b) (n - 1));
-      (==) { lemma_pow_unfold k (mul a b) n }
+      == { lemma_pow_unfold k (mul a b) n }
       pow k (mul a b) n;
     }; () end
 
@@ -164,9 +164,9 @@ let rec lemma_pow_mul_base #t k a b n =
 let lemma_pow_double #t k x b =
   calc (==) {
     pow k (mul x x) b;
-    (==) { lemma_pow_mul_base k x x b}
+    == { lemma_pow_mul_base k x x b}
     mul (pow k x b) (pow k x b);
-    (==) { lemma_pow_add k x b b }
+    == { lemma_pow_add k x b b }
     pow k x (b + b);
     }
 
@@ -181,13 +181,13 @@ let rec lemma_inverse_pow #t k x n =
   else begin
     calc (==) {
       k.inverse (pow k.cm x n);
-      (==) { lemma_pow_unfold k.cm x n }
+      == { lemma_pow_unfold k.cm x n }
       k.inverse (k.cm.mul x (pow k.cm x (n - 1)));
-      (==) { lemma_inverse_mul k x (pow k.cm x (n - 1)) }
+      == { lemma_inverse_mul k x (pow k.cm x (n - 1)) }
       k.cm.mul (k.inverse x) (k.inverse (pow k.cm x (n - 1)));
-      (==) { lemma_inverse_pow k x (n - 1) }
+      == { lemma_inverse_pow k x (n - 1) }
       k.cm.mul (k.inverse x) (pow k.cm (k.inverse x) (n - 1));
-      (==) { lemma_pow_unfold k.cm (inverse x) n }
+      == { lemma_pow_unfold k.cm (inverse x) n }
       pow k.cm (k.inverse x) n;
     } end
 
@@ -210,31 +210,31 @@ let lemma_pow_neg_add_aux #t k x n m =
   if -n <= m then begin
   calc (==) {
     k.cm.mul (k.inverse (pow k.cm x (-n))) (pow k.cm x m);
-    (==) { lemma_pow_add k.cm x (-n) (m + n) }
+    == { lemma_pow_add k.cm x (-n) (m + n) }
     k.cm.mul (k.inverse (pow k.cm x (-n))) (k.cm.mul (pow k.cm x (-n)) (pow k.cm x (m + n)));
-    (==) { k.cm.lemma_mul_assoc
+    == { k.cm.lemma_mul_assoc
       (k.inverse (pow k.cm x (-n))) (pow k.cm x (-n)) (pow k.cm x (m + n)) }
     k.cm.mul (k.cm.mul (k.inverse (pow k.cm x (- n))) (pow k.cm x (-n))) (pow k.cm x (m + n));
-    (==) { k.lemma_inverse (pow k.cm x (- n)) }
+    == { k.lemma_inverse (pow k.cm x (- n)) }
     k.cm.mul k.cm.one (pow k.cm x (m + n));
-    (==) { k.cm.lemma_mul_comm k.cm.one (pow k.cm x (m + n)) }
+    == { k.cm.lemma_mul_comm k.cm.one (pow k.cm x (m + n)) }
     k.cm.mul (pow k.cm x (m + n)) k.cm.one;
-    (==) { k.cm.lemma_one (pow k.cm x (m + n)) }
+    == { k.cm.lemma_one (pow k.cm x (m + n)) }
     pow k.cm x (m + n);
   } end
   else begin
   calc (==) {
     k.cm.mul (k.inverse (pow k.cm x (-n))) (pow k.cm x m);
-    (==) { lemma_pow_add k.cm x (-n-m) m }
+    == { lemma_pow_add k.cm x (-n-m) m }
     k.cm.mul (k.inverse (k.cm.mul (pow k.cm x (-n-m)) (pow k.cm x m))) (pow k.cm x m);
-    (==) { lemma_inverse_mul k (pow k.cm x (-n-m)) (pow k.cm x m) }
+    == { lemma_inverse_mul k (pow k.cm x (-n-m)) (pow k.cm x m) }
     k.cm.mul (k.cm.mul (k.inverse (pow k.cm x (-n-m))) (k.inverse (pow k.cm x m))) (pow k.cm x m);
-    (==) { k.cm.lemma_mul_assoc
+    == { k.cm.lemma_mul_assoc
       (k.inverse (pow k.cm x (-n-m))) (k.inverse (pow k.cm x m)) (pow k.cm x m) }
     k.cm.mul (k.inverse (pow k.cm x (-n-m))) (k.cm.mul (k.inverse (pow k.cm x m)) (pow k.cm x m));
-    (==) { k.lemma_inverse (pow k.cm x m) }
+    == { k.lemma_inverse (pow k.cm x m) }
     k.cm.mul (k.inverse (pow k.cm x (-n-m))) k.cm.one;
-    (==) { k.cm.lemma_one (k.inverse (pow k.cm x (-n-m))) }
+    == { k.cm.lemma_one (k.inverse (pow k.cm x (-n-m))) }
     k.inverse (pow k.cm x (-n-m));
   } end
 
@@ -246,11 +246,11 @@ let lemma_pow_neg_add #t k x n m =
     if n < 0 && m < 0 then begin
       calc (==) {
         k.cm.mul (pow_neg k x n) (pow_neg k x m);
-        (==) { }
+        == { }
         k.cm.mul (k.inverse (pow k.cm x (- n))) (k.inverse (pow k.cm x (- m)));
-        (==) { lemma_inverse_mul k (pow k.cm x (- n)) (pow k.cm x (- m)) }
+        == { lemma_inverse_mul k (pow k.cm x (- n)) (pow k.cm x (- m)) }
         k.inverse (k.cm.mul (pow k.cm x (- n)) (pow k.cm x (- m)));
-        (==) { lemma_pow_add k.cm x (- n) (- m) }
+        == { lemma_pow_add k.cm x (- n) (- m) }
         k.inverse (pow k.cm x (- n - m));
       } end
     else begin
@@ -294,11 +294,11 @@ val lemma_pow_neg_mul_nneg: #t:Type -> k:abelian_group t -> x:t -> n:int -> m:in
 let lemma_pow_neg_mul_nneg #t k x n m =
   calc (==) {
     pow_neg k (pow_neg k x n) m;
-    (==) { }
+    == { }
     pow k.cm (k.inverse (pow k.cm x (-n))) m;
-    (==) { lemma_inverse_pow k (pow k.cm x (-n)) m }
+    == { lemma_inverse_pow k (pow k.cm x (-n)) m }
     k.inverse (pow k.cm (pow k.cm x (-n)) m);
-    (==) { lemma_pow_mul k.cm x (-n) m }
+    == { lemma_pow_mul k.cm x (-n) m }
     k.inverse (pow k.cm x (-n * m));
   }
 
@@ -310,9 +310,9 @@ val lemma_pow_neg_mul_mneg: #t:Type -> k:abelian_group t -> x:t -> n:int -> m:in
 let lemma_pow_neg_mul_mneg #t k x n m =
   calc (==) {
     pow_neg k (pow_neg k x n) m;
-    (==) { }
+    == { }
     k.inverse (pow k.cm (pow k.cm x n) (-m));
-    (==) { lemma_pow_mul k.cm x n (-m) }
+    == { lemma_pow_mul k.cm x n (-m) }
     k.inverse (pow k.cm x (-n * m));
   }
 
@@ -324,13 +324,13 @@ let lemma_pow_neg_mul #t k x n m =
     if n < 0 && m < 0 then
     calc (==) {
       pow_neg k (pow_neg k x n) m;
-      (==) { }
+      == { }
       k.inverse (pow k.cm (k.inverse (pow k.cm x (-n))) (-m));
-      (==) { lemma_inverse_pow k (pow k.cm x (-n)) (-m) }
+      == { lemma_inverse_pow k (pow k.cm x (-n)) (-m) }
       k.inverse (k.inverse (pow k.cm (pow k.cm x (-n)) (-m)));
-      (==) { lemma_inverse_id k (pow k.cm (pow k.cm x (-n)) (-m)) }
+      == { lemma_inverse_id k (pow k.cm (pow k.cm x (-n)) (-m)) }
       pow k.cm (pow k.cm x (-n)) (-m);
-      (==) { lemma_pow_mul k.cm x (-n) (-m) }
+      == { lemma_pow_mul k.cm x (-n) (-m) }
       pow k.cm x (n * m);
     }
     else begin
@@ -349,11 +349,11 @@ let lemma_pow_neg_mul_base #t k a b n =
   else begin
     calc (==) {
       k.cm.mul (pow_neg k a n) (pow_neg k b n);
-      (==) { }
+      == { }
       k.cm.mul (k.inverse (pow k.cm a (-n))) (k.inverse (pow k.cm b (-n)));
-      (==) { lemma_inverse_mul k (pow k.cm a (-n)) (pow k.cm b (-n)) }
+      == { lemma_inverse_mul k (pow k.cm a (-n)) (pow k.cm b (-n)) }
       k.inverse (k.cm.mul (pow k.cm a (-n)) (pow k.cm b (-n)));
-      (==) { lemma_pow_mul_base k.cm a b (- n) }
+      == { lemma_pow_mul_base k.cm a b (- n) }
       k.inverse (pow k.cm (k.cm.mul a b) (-n));
      } end
 
@@ -361,8 +361,8 @@ let lemma_pow_neg_mul_base #t k a b n =
 let lemma_pow_neg_double #t k x b =
   calc (==) {
     pow_neg k (k.cm.mul x x) b;
-    (==) { lemma_pow_neg_mul_base k x x b}
+    == { lemma_pow_neg_mul_base k x x b}
     k.cm.mul (pow_neg k x b) (pow_neg k x b);
-    (==) { lemma_pow_neg_add k x b b }
+    == { lemma_pow_neg_add k x b b }
     pow_neg k x (b + b);
   }

--- a/lib/Lib.Exponentiation.fst
+++ b/lib/Lib.Exponentiation.fst
@@ -11,11 +11,11 @@ val lemma_b_mod_pow2i: bBits:nat -> b:nat{b < pow2 bBits} -> i:pos{i <= bBits} -
 let lemma_b_mod_pow2i bBits b i =
   calc (==) {
     b % pow2 i;
-    (==) { Math.Lemmas.euclidean_division_definition (b % pow2 i) (pow2 (i - 1)) }
+    == { Math.Lemmas.euclidean_division_definition (b % pow2 i) (pow2 (i - 1)) }
     b % pow2 i / pow2 (i - 1) * pow2 (i - 1) + b % pow2 i % pow2 (i - 1);
-    (==) { Math.Lemmas.pow2_modulo_modulo_lemma_1 b (i - 1) i }
+    == { Math.Lemmas.pow2_modulo_modulo_lemma_1 b (i - 1) i }
     b % pow2 i / pow2 (i - 1) * pow2 (i - 1) + b % pow2 (i - 1);
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 b (i - 1) i; assert_norm (pow2 1 = 2) }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 b (i - 1) i; assert_norm (pow2 1 = 2) }
     b / pow2 (i - 1) % 2 * pow2 (i - 1) + b % pow2 (i - 1);
   }
 
@@ -29,13 +29,13 @@ let lemma_b_div_pow2ki bBits b k i =
   let c = b / pow2 (bk - k * i) in
   calc (==) {
     b / pow2 (bk - k * i);
-    (==) { Math.Lemmas.euclidean_division_definition c (pow2 k) }
+    == { Math.Lemmas.euclidean_division_definition c (pow2 k) }
     c / pow2 k * pow2 k + c % pow2 k;
-    (==) { Math.Lemmas.division_multiplication_lemma b (pow2 (bk - k * i)) (pow2 k) }
+    == { Math.Lemmas.division_multiplication_lemma b (pow2 (bk - k * i)) (pow2 k) }
     b / (pow2 (bk - k * i) * pow2 k) * pow2 k + c % pow2 k;
-    (==) { Math.Lemmas.pow2_plus (bk - k * i) k }
+    == { Math.Lemmas.pow2_plus (bk - k * i) k }
     b / pow2 (bk - k * i + k) * pow2 k + c % pow2 k;
-    (==) { Math.Lemmas.distributivity_sub_right k i 1 }
+    == { Math.Lemmas.distributivity_sub_right k i 1 }
     b / pow2 (bk - k * (i - 1)) * pow2 k + c % pow2 k;
     }
 
@@ -317,13 +317,13 @@ let exp_fw_lemma_step #t k a bBits b l i acc1 =
 
   calc (==) {
     k.mul (pow k acc1 (pow2 l)) (pow k a r2);
-    (==) { }
+    == { }
     k.mul (pow k (pow k a r1) (pow2 l)) (pow k a r2);
-    (==) { lemma_pow_mul k a r1 (pow2 l) }
+    == { lemma_pow_mul k a r1 (pow2 l) }
     k.mul (pow k a (r1 * pow2 l)) (pow k a r2);
-    (==) { lemma_pow_add k a (r1 * pow2 l) r2 }
+    == { lemma_pow_add k a (r1 * pow2 l) r2 }
     pow k a (r1 * pow2 l + r2);
-    (==) { lemma_b_div_pow2ki bBits b l i }
+    == { lemma_b_div_pow2ki bBits b l i }
     pow k a (b_acc l bBits b i);
   }
 
@@ -412,13 +412,13 @@ val lemma_pow_distr_mul: #t:Type -> k:comm_monoid t -> x:t -> a:t -> r1:nat -> r
 let lemma_pow_distr_mul #t k x a r1 r2 r3 =
   calc (==) {
     k.mul (k.mul x (pow k (pow k a r1) r3)) (pow k a r2);
-    (==) { lemma_pow_mul k a r1 r3 }
+    == { lemma_pow_mul k a r1 r3 }
     k.mul (k.mul x (pow k a (r1 * r3))) (pow k a r2);
-    (==) { k.lemma_mul_assoc x (pow k a (r1 * r3)) (pow k a r2) }
+    == { k.lemma_mul_assoc x (pow k a (r1 * r3)) (pow k a r2) }
     k.mul x (k.mul (pow k a (r1 * r3)) (pow k a r2));
-    (==) { lemma_pow_add k a (r1 * r3) r2 }
+    == { lemma_pow_add k a (r1 * r3) r2 }
     k.mul x (pow k a (r1 * r3 + r2));
-    (==) { k.lemma_mul_comm x (pow k a (r1 * r3 + r2)) }
+    == { k.lemma_mul_comm x (pow k a (r1 * r3 + r2)) }
     k.mul (pow k a (r1 * r3 + r2)) x;
   }
 
@@ -447,25 +447,25 @@ let exp_double_fw_lemma_step #t k a1 bBits b1 a2 b2 l i acc =
 
   calc (==) {
     k.mul acc1 (pow k a2 r22);
-    (==) { exp_pow2_lemma k acc l }
+    == { exp_pow2_lemma k acc l }
     k.mul (pow k acc (pow2 l)) (pow k a2 r22);
-    (==) { }
+    == { }
     k.mul (pow k (k.mul (pow k a1 r11) (pow k a2 r21)) (pow2 l)) (pow k a2 r22);
-    (==) { lemma_pow_mul_base k (pow k a1 r11) (pow k a2 r21) (pow2 l) }
+    == { lemma_pow_mul_base k (pow k a1 r11) (pow k a2 r21) (pow2 l) }
     k.mul (k.mul (pow k (pow k a1 r11) (pow2 l)) (pow k (pow k a2 r21) (pow2 l))) (pow k a2 r22);
-    (==) { lemma_pow_distr_mul k (pow k (pow k a1 r11) (pow2 l)) a2 r21 r22 (pow2 l) }
+    == { lemma_pow_distr_mul k (pow k (pow k a1 r11) (pow2 l)) a2 r21 r22 (pow2 l) }
     k.mul (pow k a2 (r21 * pow2 l + r22)) (pow k (pow k a1 r11) (pow2 l));
-    (==) { lemma_b_div_pow2ki bBits b2 l i }
+    == { lemma_b_div_pow2ki bBits b2 l i }
     k.mul res_a2 (pow k (pow k a1 r11) (pow2 l));
   };
 
   calc (==) {
     k.mul (k.mul acc1 (pow k a2 r22)) (pow k a1 r12);
-    (==) { }
+    == { }
     k.mul (k.mul res_a2 (pow k (pow k a1 r11) (pow2 l))) (pow k a1 r12);
-    (==) { lemma_pow_distr_mul k res_a2 a1 r11 r12 (pow2 l) }
+    == { lemma_pow_distr_mul k res_a2 a1 r11 r12 (pow2 l) }
     k.mul (pow k a1 (r11 * pow2 l + r12)) res_a2;
-    (==) { lemma_b_div_pow2ki bBits b1 l i }
+    == { lemma_b_div_pow2ki bBits b1 l i }
     k.mul res_a1 res_a2;
   }
 
@@ -536,9 +536,9 @@ val lemma_mul_assoc4: #t:Type -> k:comm_monoid t -> a1:t -> a2:t -> a3:t -> a4:t
 let lemma_mul_assoc4 #t k a1 a2 a3 a4 =
   calc (==) {
     k.mul a1 (k.mul (k.mul a2 a3) a4);
-    (==) { k.lemma_mul_assoc a1 (k.mul a2 a3) a4 }
+    == { k.lemma_mul_assoc a1 (k.mul a2 a3) a4 }
     k.mul (k.mul a1 (k.mul a2 a3)) a4;
-    (==) { k.lemma_mul_assoc a1 a2 a3 }
+    == { k.lemma_mul_assoc a1 a2 a3 }
     k.mul (k.mul (k.mul a1 a2) a3) a4;
   }
 
@@ -595,31 +595,31 @@ let exp_four_fw_lemma_step #t k a1 bBits b1 a2 b2 a3 b3 a4 b4 l i acc =
 
   calc (==) {
     k.mul acc1 (pow k a4 r42);
-    (==) { exp_pow2_lemma k acc l }
+    == { exp_pow2_lemma k acc l }
     k.mul (pow k acc (pow2 l)) (pow k a4 r42);
-    (==) { }
+    == { }
     k.mul (pow k (k.mul acc_123 (pow k a4 r41)) (pow2 l)) (pow k a4 r42);
-    (==) { lemma_pow_mul_base k acc_123 (pow k a4 r41) (pow2 l) }
+    == { lemma_pow_mul_base k acc_123 (pow k a4 r41) (pow2 l) }
     k.mul (k.mul acc_123_l (pow k (pow k a4 r41) (pow2 l))) (pow k a4 r42);
-    (==) { lemma_pow_distr_mul k acc_123_l a4 r41 r42 (pow2 l) }
+    == { lemma_pow_distr_mul k acc_123_l a4 r41 r42 (pow2 l) }
     k.mul (pow k a4 (r41 * pow2 l + r42)) acc_123_l;
-    (==) { lemma_b_div_pow2ki bBits b4 l i }
+    == { lemma_b_div_pow2ki bBits b4 l i }
     k.mul res_a4 acc_123_l;
   };
 
   calc (==) {
     k.mul (k.mul acc1 (pow k a4 r42)) (pow k a3 r32);
-    (==) { }
+    == { }
     k.mul (k.mul res_a4 (pow k (k.mul acc_12 (pow k a3 r31)) (pow2 l))) (pow k a3 r32);
-    (==) {k.lemma_mul_assoc res_a4 (pow k (k.mul acc_12 (pow k a3 r31)) (pow2 l)) (pow k a3 r32)}
+    == {k.lemma_mul_assoc res_a4 (pow k (k.mul acc_12 (pow k a3 r31)) (pow2 l)) (pow k a3 r32)}
     k.mul res_a4 (k.mul (pow k (k.mul acc_12 (pow k a3 r31)) (pow2 l)) (pow k a3 r32));
-    (==) { lemma_pow_mul_base k acc_12 (pow k a3 r31) (pow2 l) }
+    == { lemma_pow_mul_base k acc_12 (pow k a3 r31) (pow2 l) }
     k.mul res_a4 (k.mul (k.mul acc_12_l (pow k (pow k a3 r31) (pow2 l))) (pow k a3 r32));
-    (==) { lemma_pow_distr_mul k acc_12_l a3 r31 r32 (pow2 l) }
+    == { lemma_pow_distr_mul k acc_12_l a3 r31 r32 (pow2 l) }
     k.mul res_a4 (k.mul (pow k a3 (r31 * pow2 l + r32)) acc_12_l);
-    (==) { lemma_b_div_pow2ki bBits b3 l i }
+    == { lemma_b_div_pow2ki bBits b3 l i }
     k.mul res_a4 (k.mul res_a3 acc_12_l);
-    (==) { k.lemma_mul_assoc res_a4 res_a3 acc_12_l; k.lemma_mul_comm res_a4 res_a3 }
+    == { k.lemma_mul_assoc res_a4 res_a3 acc_12_l; k.lemma_mul_comm res_a4 res_a3 }
     k.mul (k.mul res_a3 res_a4) acc_12_l;
   };
 
@@ -627,31 +627,31 @@ let exp_four_fw_lemma_step #t k a1 bBits b1 a2 b2 a3 b3 a4 b4 l i acc =
   let res_a34 = k.mul res_a3 res_a4 in
   calc (==) {
     k.mul (k.mul (k.mul acc1 (pow k a4 r42)) (pow k a3 r32)) (pow k a2 r22);
-    (==) { }
+    == { }
     k.mul (k.mul res_a34 (pow k (k.mul acc_1 (pow k a2 r21)) (pow2 l))) (pow k a2 r22);
-    (==) { lemma_mul_assoc res_a34 (pow k (k.mul acc_1 (pow k a2 r21)) (pow2 l)) (pow k a2 r22) }
+    == { lemma_mul_assoc res_a34 (pow k (k.mul acc_1 (pow k a2 r21)) (pow2 l)) (pow k a2 r22) }
     k.mul res_a34 (k.mul (pow k (k.mul acc_1 (pow k a2 r21)) (pow2 l)) (pow k a2 r22));
-    (==) { lemma_pow_mul_base k acc_1 (pow k a2 r21) (pow2 l) }
+    == { lemma_pow_mul_base k acc_1 (pow k a2 r21) (pow2 l) }
     k.mul res_a34 (k.mul (k.mul acc_1_l (pow k (pow k a2 r21) (pow2 l))) (pow k a2 r22));
-    (==) { lemma_pow_distr_mul k acc_1_l a2 r21 r22 (pow2 l) }
+    == { lemma_pow_distr_mul k acc_1_l a2 r21 r22 (pow2 l) }
     k.mul res_a34 (k.mul (pow k a2 (r21 * pow2 l + r22)) acc_1_l);
-    (==) { lemma_b_div_pow2ki bBits b2 l i }
+    == { lemma_b_div_pow2ki bBits b2 l i }
     k.mul res_a34 (k.mul res_a2 acc_1_l);
-    (==) { k.lemma_mul_assoc res_a34 res_a2 acc_1_l; k.lemma_mul_comm res_a34 res_a2 }
+    == { k.lemma_mul_assoc res_a34 res_a2 acc_1_l; k.lemma_mul_comm res_a34 res_a2 }
     k.mul (k.mul res_a2 res_a34) acc_1_l;
-    (==) { k.lemma_mul_assoc res_a2 res_a3 res_a4 }
+    == { k.lemma_mul_assoc res_a2 res_a3 res_a4 }
     k.mul res_a234 acc_1_l;
   };
 
   calc (==) {
     k.mul (k.mul (k.mul (k.mul acc1 (pow k a4 r42)) (pow k a3 r32)) (pow k a2 r22)) (pow k a1 r12);
-    (==) { }
+    == { }
     k.mul (k.mul res_a234 (pow k (pow k a1 r11) (pow2 l))) (pow k a1 r12);
-    (==) { lemma_pow_distr_mul k res_a234 a1 r11 r12 (pow2 l) }
+    == { lemma_pow_distr_mul k res_a234 a1 r11 r12 (pow2 l) }
     k.mul (pow k a1 (r11 * pow2 l + r12)) res_a234;
-    (==) { lemma_b_div_pow2ki bBits b1 l i }
+    == { lemma_b_div_pow2ki bBits b1 l i }
     k.mul res_a1 (k.mul (k.mul res_a2 res_a3) res_a4);
-    (==) { lemma_mul_assoc4 k res_a1 res_a2 res_a3 res_a4 }
+    == { lemma_mul_assoc4 k res_a1 res_a2 res_a3 res_a4 }
     k.mul (k.mul (k.mul res_a1 res_a2) res_a3) res_a4;
   }
 

--- a/lib/Lib.IntVector.Transpose.fst
+++ b/lib/Lib.IntVector.Transpose.fst
@@ -121,19 +121,19 @@ let lemma_l_plus_pow2i_lt #w n i l =
 
   calc (<) {
     l + pow2 i;
-    (==) { Math.Lemmas.euclidean_division_definition l pow2i1 }
+    == { Math.Lemmas.euclidean_division_definition l pow2i1 }
     l / pow2i1 * pow2i1 + l % pow2i1 + pow2 i;
-    (==) { Math.Lemmas.pow2_plus 1 i }
+    == { Math.Lemmas.pow2_plus 1 i }
     l / pow2i1 * pow2i1 + l % (2 * pow2 i) + pow2 i;
-    (<) { assert (l % (2 * pow2 i) < pow2 i) }
+    < { assert (l % (2 * pow2 i) < pow2 i) }
     l / pow2i1 * pow2i1 + pow2 i + pow2 i;
-    (==) { Math.Lemmas.pow2_double_sum i }
+    == { Math.Lemmas.pow2_double_sum i }
     l / pow2i1 * pow2i1 + pow2i1;
-    (==) { Math.Lemmas.distributivity_add_left (l / pow2i1) 1 pow2i1 }
+    == { Math.Lemmas.distributivity_add_left (l / pow2i1) 1 pow2i1 }
     (l / pow2i1 + 1) * pow2i1;
-    (<=) { Math.Lemmas.lemma_div_lt_nat l n (i + 1) }
+    <= { Math.Lemmas.lemma_div_lt_nat l n (i + 1) }
     pow2 (n - i - 1) * pow2 (i + 1);
-    (==) { Math.Lemmas.pow2_plus (n - i - 1) (i + 1) }
+    == { Math.Lemmas.pow2_plus (n - i - 1) (i + 1) }
     pow2 n;
   }
 

--- a/lib/Lib.NatMod.fst
+++ b/lib/Lib.NatMod.fst
@@ -87,17 +87,17 @@ let rec lemma_pow_mod_base a b n =
   else begin
     calc (==) {
       pow a b % n;
-      (==) { lemma_pow_unfold a b }
+      == { lemma_pow_unfold a b }
       a * pow a (b - 1) % n;
-      (==) { Math.Lemmas.lemma_mod_mul_distr_r a (pow a (b - 1)) n }
+      == { Math.Lemmas.lemma_mod_mul_distr_r a (pow a (b - 1)) n }
       a * (pow a (b - 1) % n) % n;
-      (==) { lemma_pow_mod_base a (b - 1) n }
+      == { lemma_pow_mod_base a (b - 1) n }
       a * (pow (a % n) (b - 1) % n) % n;
-      (==) { Math.Lemmas.lemma_mod_mul_distr_r a (pow (a % n) (b - 1)) n }
+      == { Math.Lemmas.lemma_mod_mul_distr_r a (pow (a % n) (b - 1)) n }
       a * pow (a % n) (b - 1) % n;
-      (==) { Math.Lemmas.lemma_mod_mul_distr_l a (pow (a % n) (b - 1)) n }
+      == { Math.Lemmas.lemma_mod_mul_distr_l a (pow (a % n) (b - 1)) n }
       a % n * pow (a % n) (b - 1) % n;
-      (==) { lemma_pow_unfold (a % n) b }
+      == { lemma_pow_unfold (a % n) b }
       pow (a % n) b % n;
     };
     assert (pow a b % n == pow (a % n) b % n)
@@ -110,11 +110,11 @@ let lemma_mul_mod_one #m a = ()
 let lemma_mul_mod_assoc #m a b c =
   calc (==) {
     (a * b % m) * c % m;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (a * b) c m }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (a * b) c m }
     (a * b) * c % m;
-    (==) { Math.Lemmas.paren_mul_right a b c }
+    == { Math.Lemmas.paren_mul_right a b c }
     a * (b * c) % m;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r a (b * c) m }
+    == { Math.Lemmas.lemma_mod_mul_distr_r a (b * c) m }
     a * (b * c % m) % m;
     }
 
@@ -151,34 +151,34 @@ let rec lemma_pow_mod_ n a b =
     if b % 2 = 0 then begin
       calc (==) {
 	pow_mod #n a b;
-	(==) { lemma_pow_mod_unfold0 n a b }
+	== { lemma_pow_mod_unfold0 n a b }
 	pow_mod #n (mul_mod #n a a) (b / 2);
-	(==) { lemma_pow_mod_ n (mul_mod #n a a) (b / 2) }
+	== { lemma_pow_mod_ n (mul_mod #n a a) (b / 2) }
 	pow (mul_mod #n a a) (b / 2) % n;
-	(==) { lemma_pow_mod_base (a * a) (b / 2) n }
+	== { lemma_pow_mod_base (a * a) (b / 2) n }
 	pow (a * a) (b / 2) % n;
-	(==) { lemma_pow_double a (b / 2) }
+	== { lemma_pow_double a (b / 2) }
 	pow a b % n;
       };
       assert (pow_mod #n a b == pow a b % n) end
     else begin
       calc (==) {
 	pow_mod #n a b;
-	(==) { lemma_pow_mod_unfold1 n a b }
+	== { lemma_pow_mod_unfold1 n a b }
 	mul_mod a (pow_mod (mul_mod #n a a) (b / 2));
-	(==) { lemma_pow_mod_ n (mul_mod #n a a) (b / 2) }
+	== { lemma_pow_mod_ n (mul_mod #n a a) (b / 2) }
 	mul_mod a (pow (mul_mod #n a a) (b / 2) % n);
-	(==) { lemma_pow_mod_base (a * a) (b / 2) n }
+	== { lemma_pow_mod_base (a * a) (b / 2) n }
 	mul_mod a (pow (a * a) (b / 2) % n);
-	(==) { lemma_pow_double a (b / 2) }
+	== { lemma_pow_double a (b / 2) }
 	mul_mod a (pow a (b / 2 * 2) % n);
-	(==) { Math.Lemmas.lemma_mod_mul_distr_r a (pow a (b / 2 * 2)) n }
+	== { Math.Lemmas.lemma_mod_mul_distr_r a (pow a (b / 2 * 2)) n }
 	a * pow a (b / 2 * 2) % n;
-	(==) { lemma_pow1 a }
+	== { lemma_pow1 a }
 	pow a 1 * pow a (b / 2 * 2) % n;
-	(==) { lemma_pow_add a 1 (b / 2 * 2) }
+	== { lemma_pow_add a 1 (b / 2 * 2) }
 	pow a (b / 2 * 2 + 1) % n;
-	(==) { Math.Lemmas.euclidean_division_definition b 2 }
+	== { Math.Lemmas.euclidean_division_definition b 2 }
 	pow a b % n;
 	};
       assert (pow_mod #n a b == pow a b % n) end
@@ -195,15 +195,15 @@ let rec lemma_pow_nat_mod_is_pow #n a b =
   else begin
     calc (==) {
       pow a b % n;
-      (==) { lemma_pow_unfold a b }
+      == { lemma_pow_unfold a b }
       a * pow a (b - 1) % n;
-      (==) { Math.Lemmas.lemma_mod_mul_distr_r a (pow a (b - 1)) n }
+      == { Math.Lemmas.lemma_mod_mul_distr_r a (pow a (b - 1)) n }
       a * (pow a (b - 1) % n) % n;
-      (==) { lemma_pow_nat_mod_is_pow #n a (b - 1) }
+      == { lemma_pow_nat_mod_is_pow #n a (b - 1) }
       a * LE.pow k a (b - 1) % n;
-      (==) { }
+      == { }
       k.LE.mul a (LE.pow k a (b - 1));
-      (==) { LE.lemma_pow_unfold k a b }
+      == { LE.lemma_pow_unfold k a b }
       LE.pow k a b;
       }; () end
 
@@ -215,11 +215,11 @@ let lemma_add_mod_one #m a =
 let lemma_add_mod_assoc #m a b c =
   calc (==) {
     add_mod (add_mod a b) c;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l (a + b) c m }
+    == { Math.Lemmas.lemma_mod_plus_distr_l (a + b) c m }
     ((a + b) + c) % m;
-    (==) { }
+    == { }
     (a + (b + c)) % m;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r a (b + c) m }
+    == { Math.Lemmas.lemma_mod_plus_distr_r a (b + c) m }
     add_mod a (add_mod b c);
   }
 
@@ -230,13 +230,13 @@ let lemma_add_mod_comm #m a b = ()
 let lemma_mod_distributivity_add_right #m a b c =
   calc (==) {
     mul_mod a (add_mod b c);
-    (==) { }
+    == { }
     a * ((b + c) % m) % m;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r a (b + c) m }
+    == { Math.Lemmas.lemma_mod_mul_distr_r a (b + c) m }
     a * (b + c) % m;
-    (==) { Math.Lemmas.distributivity_add_right a b c }
+    == { Math.Lemmas.distributivity_add_right a b c }
     (a * b + a * c) % m;
-    (==) { Math.Lemmas.modulo_distributivity (a * b) (a * c) m }
+    == { Math.Lemmas.modulo_distributivity (a * b) (a * c) m }
     add_mod (mul_mod a b) (mul_mod a c);
     }
 
@@ -248,15 +248,15 @@ let lemma_mod_distributivity_add_left #m a b c =
 let lemma_mod_distributivity_sub_right #m a b c =
   calc (==) {
     mul_mod a (sub_mod b c);
-    (==) { }
+    == { }
     a * ((b - c) % m) % m;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r a (b - c) m }
+    == { Math.Lemmas.lemma_mod_mul_distr_r a (b - c) m }
     a * (b - c) % m;
-    (==) { Math.Lemmas.distributivity_sub_right a b c }
+    == { Math.Lemmas.distributivity_sub_right a b c }
     (a * b - a * c) % m;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l (a * b) (- a * c) m }
+    == { Math.Lemmas.lemma_mod_plus_distr_l (a * b) (- a * c) m }
     (mul_mod a b - a * c) % m;
-    (==) { Math.Lemmas.lemma_mod_sub_distr (mul_mod a b) (a * c) m }
+    == { Math.Lemmas.lemma_mod_sub_distr (mul_mod a b) (a * c) m }
     sub_mod (mul_mod a b) (mul_mod a c);
     }
 
@@ -271,17 +271,17 @@ let lemma_inv_mod_both #m a b =
 
   calc (==) {
     mul_mod (inv_mod a) (inv_mod b);
-    (==) { lemma_pow_mod #m a (m - 2); lemma_pow_mod #m b (m - 2) }
+    == { lemma_pow_mod #m a (m - 2); lemma_pow_mod #m b (m - 2) }
     p1 % m * (p2 % m) % m;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l p1 (p2 % m) m }
+    == { Math.Lemmas.lemma_mod_mul_distr_l p1 (p2 % m) m }
     p1 * (p2 % m) % m;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r p1 p2 m }
+    == { Math.Lemmas.lemma_mod_mul_distr_r p1 p2 m }
     p1 * p2 % m;
-    (==) { lemma_pow_mul_base a b (m - 2) }
+    == { lemma_pow_mul_base a b (m - 2) }
     pow (a * b) (m - 2) % m;
-    (==) { lemma_pow_mod_base (a * b) (m - 2) m }
+    == { lemma_pow_mod_base (a * b) (m - 2) m }
     pow (mul_mod a b) (m - 2) % m;
-    (==) { lemma_pow_mod #m (mul_mod a b) (m - 2) }
+    == { lemma_pow_mod #m (mul_mod a b) (m - 2) }
     inv_mod (mul_mod a b);
     }
 
@@ -301,15 +301,15 @@ let lemma_div_mod_prime #m a =
 
   calc (==) {
     pow_mod #m a (m - 2) * a % m;
-    (==) { lemma_pow_mod #m a (m - 2) }
+    == { lemma_pow_mod #m a (m - 2) }
     pow a (m - 2) % m * a % m;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (pow a (m - 2)) a m }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (pow a (m - 2)) a m }
     pow a (m - 2) * a % m;
-    (==) { lemma_pow1 a; lemma_pow_add a (m - 2) 1 }
+    == { lemma_pow1 a; lemma_pow_add a (m - 2) 1 }
     pow a (m - 1) % m;
-    (==) { pow_eq a (m - 1) }
+    == { pow_eq a (m - 1) }
     Fermat.pow a (m - 1) % m;
-    (==) { Fermat.fermat_alt m a }
+    == { Fermat.fermat_alt m a }
     1;
     }
 
@@ -323,15 +323,15 @@ let lemma_div_mod_prime_one #m a =
 let lemma_div_mod_prime_cancel #m a b c =
   calc (==) {
     mul_mod (mul_mod a c) (inv_mod (mul_mod c b));
-    (==) { lemma_inv_mod_both c b }
+    == { lemma_inv_mod_both c b }
     mul_mod (mul_mod a c) (mul_mod (inv_mod c) (inv_mod b));
-    (==) { lemma_mul_mod_assoc (mul_mod a c) (inv_mod c) (inv_mod b) }
+    == { lemma_mul_mod_assoc (mul_mod a c) (inv_mod c) (inv_mod b) }
     mul_mod (mul_mod (mul_mod a c) (inv_mod c)) (inv_mod b);
-    (==) { lemma_mul_mod_assoc a c (inv_mod c) }
+    == { lemma_mul_mod_assoc a c (inv_mod c) }
     mul_mod (mul_mod a (mul_mod c (inv_mod c))) (inv_mod b);
-    (==) { lemma_div_mod_prime c }
+    == { lemma_div_mod_prime c }
     mul_mod (mul_mod a 1) (inv_mod b);
-    (==) { Math.Lemmas.small_mod a m }
+    == { Math.Lemmas.small_mod a m }
     mul_mod a (inv_mod b);
     }
 
@@ -339,17 +339,17 @@ let lemma_div_mod_prime_cancel #m a b c =
 let lemma_div_mod_prime_to_one_denominator #m a b c d =
   calc (==) {
     mul_mod (div_mod a c) (div_mod b d);
-    (==) { }
+    == { }
     mul_mod (mul_mod a (inv_mod c)) (mul_mod b (inv_mod d));
-    (==) {
+    == {
       lemma_mul_mod_comm #m b (inv_mod d);
       lemma_mul_mod_assoc #m (mul_mod a (inv_mod c)) (inv_mod d) b }
     mul_mod (mul_mod (mul_mod a (inv_mod c)) (inv_mod d)) b;
-    (==) { lemma_mul_mod_assoc #m a (inv_mod c) (inv_mod d) }
+    == { lemma_mul_mod_assoc #m a (inv_mod c) (inv_mod d) }
     mul_mod (mul_mod a (mul_mod (inv_mod c) (inv_mod d))) b;
-    (==) { lemma_inv_mod_both c d }
+    == { lemma_inv_mod_both c d }
     mul_mod (mul_mod a (inv_mod (mul_mod c d))) b;
-    (==) {
+    == {
       lemma_mul_mod_assoc #m a (inv_mod (mul_mod c d)) b;
       lemma_mul_mod_comm #m (inv_mod (mul_mod c d)) b;
       lemma_mul_mod_assoc #m a b (inv_mod (mul_mod c d)) }
@@ -365,13 +365,13 @@ let lemma_div_mod_eq_mul_mod1 #m a b c =
     assert (mul_mod (div_mod a b) b = mul_mod c b);
     calc (==) {
       mul_mod (div_mod a b) b;
-      (==) { lemma_div_mod_prime_one b }
+      == { lemma_div_mod_prime_one b }
       mul_mod (div_mod a b) (div_mod b 1);
-      (==) { lemma_div_mod_prime_to_one_denominator a b b 1 }
+      == { lemma_div_mod_prime_to_one_denominator a b b 1 }
       div_mod (mul_mod a b) (mul_mod b 1);
-      (==) { lemma_div_mod_prime_cancel a 1 b }
+      == { lemma_div_mod_prime_cancel a 1 b }
       div_mod a 1;
-      (==) { lemma_div_mod_prime_one a }
+      == { lemma_div_mod_prime_one a }
       a;
       } end
   else ()
@@ -385,11 +385,11 @@ let lemma_div_mod_eq_mul_mod2 #m a b c =
     assert (div_mod a b == div_mod (mul_mod c b) b);
     calc (==) {
       div_mod (mul_mod c b) b;
-      (==) { Math.Lemmas.small_mod b m }
+      == { Math.Lemmas.small_mod b m }
       div_mod (mul_mod c b) (mul_mod b 1);
-      (==) { lemma_div_mod_prime_cancel c 1 b }
+      == { lemma_div_mod_prime_cancel c 1 b }
       div_mod c 1;
-      (==) { lemma_div_mod_prime_one c }
+      == { lemma_div_mod_prime_one c }
       c;
     } end
   else ()

--- a/lib/Lib.Sequence.Lemmas.fst
+++ b/lib/Lib.Sequence.Lemmas.fst
@@ -97,13 +97,13 @@ let repeat_gen_blocks_extensionality_zero #inp_t #c blocksize mi hi_f hi_g n inp
 
   calc (==) {
     repeat_gen_blocks blocksize mi hi_f inp a_f f l_f acc0;
-    (==) { }
+    == { }
     l_f (mi + n) rem block_l acc_f;
-    (==) { repeat_gen_blocks_multi_extensionality_zero #inp_t blocksize mi hi_f hi_g n blocks a_f a_g f g acc0 }
+    == { repeat_gen_blocks_multi_extensionality_zero #inp_t blocksize mi hi_f hi_g n blocks a_f a_g f g acc0 }
     l_f (mi + n) rem block_l acc_g;
-    (==) { }
+    == { }
     l_g n rem block_l acc_g;
-    (==) { }
+    == { }
     repeat_gen_blocks blocksize 0 hi_g inp a_g g l_g acc0;
     }
 
@@ -247,17 +247,17 @@ let aux_repeat_bf_s1 #inp_t blocksize len0 mi hi n inp a f i acc =
   let i_b1 = i - mi - n0 in
   calc (<=) {
     i_b1 * blocksize + blocksize;
-    (<=) { Math.Lemmas.lemma_mult_le_right blocksize (i_b1 + 1) n1 }
+    <= { Math.Lemmas.lemma_mult_le_right blocksize (i_b1 + 1) n1 }
     n1 * blocksize;
-    (==) { Math.Lemmas.div_exact_r len1 blocksize }
+    == { Math.Lemmas.div_exact_r len1 blocksize }
     len1;
     };
 
   calc (==) {
     len0 + i_b1 * blocksize;
-    (==) { Math.Lemmas.div_exact_r len0 blocksize }
+    == { Math.Lemmas.div_exact_r len0 blocksize }
     n0 * blocksize + i_b1 * blocksize;
-    (==) { Math.Lemmas.distributivity_add_left n0 i_b1 blocksize }
+    == { Math.Lemmas.distributivity_add_left n0 i_b1 blocksize }
     (n0 + i_b1) * blocksize;
     };
 
@@ -284,23 +284,23 @@ let repeat_gen_blocks_multi_split #inp_t blocksize len0 mi hi n inp a f acc0 =
 
   calc (==) {
     repeat_gen_blocks_multi blocksize mi hi n0 t0 a f acc0;
-    (==) { }
+    == { }
     Loops.repeat_right mi (mi + n0) a repeat_bf_s0 acc0;
-    (==) { Classical.forall_intro_2 (aux_repeat_bf_s0 #inp_t blocksize len0 mi hi n inp a f);
+    == { Classical.forall_intro_2 (aux_repeat_bf_s0 #inp_t blocksize len0 mi hi n inp a f);
            repeat_right_extensionality n0 mi a a repeat_bf_s0 repeat_bf_t acc0 }
     Loops.repeat_right mi (mi + n0) a repeat_bf_t acc0;
     };
 
   calc (==) {
     repeat_gen_blocks_multi blocksize (mi + n0) hi n1 t1 a f acc1;
-    (==) { }
+    == { }
     Loops.repeat_right (mi + n0) (mi + n) a repeat_bf_s1 acc1;
-    (==) { Classical.forall_intro_2 (aux_repeat_bf_s1 #inp_t blocksize len0 mi hi n inp a f);
+    == { Classical.forall_intro_2 (aux_repeat_bf_s1 #inp_t blocksize len0 mi hi n inp a f);
            repeat_right_extensionality n1 (mi + n0) a a repeat_bf_s1 repeat_bf_t acc1 }
     Loops.repeat_right (mi + n0) (mi + n) a repeat_bf_t acc1;
-    (==) { Loops.repeat_right_plus mi (mi + n0) (mi + n) a repeat_bf_t acc0 }
+    == { Loops.repeat_right_plus mi (mi + n0) (mi + n) a repeat_bf_t acc0 }
     Loops.repeat_right mi (mi + n) a repeat_bf_t acc0;
-    (==) { }
+    == { }
     repeat_gen_blocks_multi blocksize mi hi n inp a f acc0;
   }
 
@@ -368,11 +368,11 @@ let slice_slice_last #inp_t blocksize len0 inp =
 
   calc (==) {
     len0 + n1 * blocksize;
-    (==) { len0_div_bs blocksize len len0 }
+    == { len0_div_bs blocksize len len0 }
     len0 + (n - n0) * blocksize;
-    (==) { Math.Lemmas.distributivity_sub_left n n0 blocksize }
+    == { Math.Lemmas.distributivity_sub_left n n0 blocksize }
     len0 + n * blocksize - n0 * blocksize;
-    (==) { Math.Lemmas.div_exact_r len0 blocksize }
+    == { Math.Lemmas.div_exact_r len0 blocksize }
     n * blocksize;
   };
 
@@ -410,17 +410,17 @@ let repeat_gen_blocks_split #inp_t #c blocksize len0 hi mi inp a f l acc0 =
 
   calc (==) {
     repeat_gen_blocks_multi blocksize (mi + n0) hi n1 blocks1 a f acc;
-    (==) { repeat_gen_blocks_multi_split_slice #inp_t blocksize len0 mi hi inp a f acc0 }
+    == { repeat_gen_blocks_multi_split_slice #inp_t blocksize len0 mi hi inp a f acc0 }
     repeat_gen_blocks_multi blocksize mi hi n (Seq.slice inp 0 (n * blocksize)) a f acc0;
     };
 
   calc (==) {
     repeat_gen_blocks blocksize (mi + n0) hi t1 a f l acc;
-    (==) { len0_div_bs blocksize len len0 }
+    == { len0_div_bs blocksize len len0 }
     l (mi + n) (len1 % blocksize) (Seq.slice t1 (n1 * blocksize) len1) acc1;
-    (==) { Math.Lemmas.lemma_mod_sub_distr len len0 blocksize }
+    == { Math.Lemmas.lemma_mod_sub_distr len len0 blocksize }
     l (mi + n) (len % blocksize) (Seq.slice t1 (n1 * blocksize) len1) acc1;
-    (==) { slice_slice_last #inp_t blocksize len0 inp }
+    == { slice_slice_last #inp_t blocksize len0 inp }
     l (mi + n) (len % blocksize) (Seq.slice inp (n * blocksize) len) acc1;
     }
 #pop-options
@@ -467,9 +467,9 @@ let lemma_repeat_blocks_via_multi #a #b #c blocksize inp f l acc0 =
   lemma_repeat_blocks #a #b #c blocksize inp f l acc0;
   calc (==) {
     Loops.repeati nb f_rep acc0;
-    (==) { Classical.forall_intro_2 aux; repeati_extensionality nb f_rep f_rep_b acc0 }
+    == { Classical.forall_intro_2 aux; repeati_extensionality nb f_rep f_rep_b acc0 }
     Loops.repeati nb f_rep_b acc0;
-    (==) { lemma_repeat_blocks_multi blocksize blocks f acc0 }
+    == { lemma_repeat_blocks_multi blocksize blocks f acc0 }
     repeat_blocks_multi blocksize blocks f acc0;
   }
 
@@ -486,11 +486,11 @@ let repeat_blocks_multi_is_repeat_gen_blocks_multi #a #b hi blocksize inp f acc0
 
   calc (==) {
     repeat_blocks_multi #a #b blocksize inp f acc0;
-    (==) { lemma_repeat_blocks_multi #a #b blocksize inp f acc0 }
+    == { lemma_repeat_blocks_multi #a #b blocksize inp f acc0 }
     Loops.repeati n f_rep acc0;
-    (==) { Loops.repeati_def n (repeat_blocks_f blocksize inp f n) acc0 }
+    == { Loops.repeati_def n (repeat_blocks_f blocksize inp f n) acc0 }
     Loops.repeat_right 0 n (Loops.fixed_a b) f_rep acc0;
-    (==) { Classical.forall_intro_2 aux;
+    == { Classical.forall_intro_2 aux;
            repeat_gen_right_extensionality n 0 (Loops.fixed_a b) (Loops.fixed_a b) f_rep f_gen acc0 }
     Loops.repeat_right 0 n (Loops.fixed_a b) f_gen acc0;
     }
@@ -508,7 +508,7 @@ let repeat_blocks_is_repeat_gen_blocks #a #b #c hi blocksize inp f l acc0 =
   lemma_repeat_blocks_via_multi #a #b #c blocksize inp f l acc0;
   calc (==) {
     repeat_blocks_multi blocksize blocks f acc0;
-    (==) { repeat_blocks_multi_is_repeat_gen_blocks_multi #a #b hi blocksize blocks f acc0 }
+    == { repeat_blocks_multi_is_repeat_gen_blocks_multi #a #b hi blocksize blocks f acc0 }
     repeat_gen_blocks_multi blocksize 0 hi nb blocks (Loops.fixed_a b) (Loops.fixed_i f) acc0;
     }
 
@@ -528,23 +528,23 @@ let repeat_blocks_multi_split #a #b blocksize len0 inp f acc0 =
 
   calc (==) {
     repeat_gen_blocks_multi blocksize 0 n n0 t0 (Loops.fixed_a b) (Loops.fixed_i f) acc0;
-    (==) { repeat_gen_blocks_multi_extensionality_zero blocksize 0 n0 n n0 t0
+    == { repeat_gen_blocks_multi_extensionality_zero blocksize 0 n0 n n0 t0
             (Loops.fixed_a b) (Loops.fixed_a b) (Loops.fixed_i f) (Loops.fixed_i f) acc0}
     repeat_gen_blocks_multi blocksize 0 n0 n0 t0 (Loops.fixed_a b) (Loops.fixed_i f) acc0;
-    (==) { repeat_blocks_multi_is_repeat_gen_blocks_multi #a #b n0 blocksize t0 f acc0 }
+    == { repeat_blocks_multi_is_repeat_gen_blocks_multi #a #b n0 blocksize t0 f acc0 }
     repeat_blocks_multi blocksize t0 f acc0;
   };
 
   calc (==) {
     repeat_blocks_multi blocksize inp f acc0;
-    (==) { repeat_blocks_multi_is_repeat_gen_blocks_multi #a #b n blocksize inp f acc0 }
+    == { repeat_blocks_multi_is_repeat_gen_blocks_multi #a #b n blocksize inp f acc0 }
     repeat_gen_blocks_multi blocksize 0 n n inp (Loops.fixed_a b) (Loops.fixed_i f) acc0;
-    (==) { repeat_gen_blocks_multi_split #a blocksize len0 0 n n inp (Loops.fixed_a b) (Loops.fixed_i f) acc0 }
+    == { repeat_gen_blocks_multi_split #a blocksize len0 0 n n inp (Loops.fixed_a b) (Loops.fixed_i f) acc0 }
     repeat_gen_blocks_multi blocksize n0 n n1 t1 (Loops.fixed_a b) (Loops.fixed_i f) acc1;
-    (==) { repeat_gen_blocks_multi_extensionality_zero blocksize n0 n n1 n1 t1
+    == { repeat_gen_blocks_multi_extensionality_zero blocksize n0 n n1 n1 t1
             (Loops.fixed_a b) (Loops.fixed_a b) (Loops.fixed_i f) (Loops.fixed_i f) acc1 }
     repeat_gen_blocks_multi blocksize 0 n1 n1 t1 (Loops.fixed_a b) (Loops.fixed_i f) acc1;
-    (==) { repeat_blocks_multi_is_repeat_gen_blocks_multi #a #b n1 blocksize t1 f acc1 }
+    == { repeat_blocks_multi_is_repeat_gen_blocks_multi #a #b n1 blocksize t1 f acc1 }
     repeat_blocks_multi blocksize t1 f acc1;
     }
 
@@ -564,25 +564,25 @@ let repeat_blocks_split #a #b #c blocksize len0 inp f l acc0 =
 
   calc (==) {
     repeat_gen_blocks_multi blocksize 0 n n0 t0 (Loops.fixed_a b) (Loops.fixed_i f) acc0;
-    (==) { repeat_gen_blocks_multi_extensionality_zero blocksize 0 n0 n n0 t0
+    == { repeat_gen_blocks_multi_extensionality_zero blocksize 0 n0 n n0 t0
             (Loops.fixed_a b) (Loops.fixed_a b) (Loops.fixed_i f) (Loops.fixed_i f) acc0}
     repeat_gen_blocks_multi blocksize 0 n0 n0 t0 (Loops.fixed_a b) (Loops.fixed_i f) acc0;
-    (==) { repeat_blocks_multi_is_repeat_gen_blocks_multi #a #b n0 blocksize t0 f acc0 }
+    == { repeat_blocks_multi_is_repeat_gen_blocks_multi #a #b n0 blocksize t0 f acc0 }
     repeat_blocks_multi blocksize t0 f acc0;
   };
 
   calc (==) {
     repeat_blocks blocksize inp f l acc0;
-    (==) { repeat_blocks_is_repeat_gen_blocks n blocksize inp f l acc0 }
+    == { repeat_blocks_is_repeat_gen_blocks n blocksize inp f l acc0 }
     repeat_gen_blocks blocksize 0 n inp (Loops.fixed_a b) (Loops.fixed_i f) (Loops.fixed_i l) acc0;
-    (==) { repeat_gen_blocks_split #a #c blocksize len0 n 0 inp
+    == { repeat_gen_blocks_split #a #c blocksize len0 n 0 inp
              (Loops.fixed_a b) (Loops.fixed_i f) (Loops.fixed_i l) acc0 }
     repeat_gen_blocks blocksize n0 n t1 (Loops.fixed_a b) (Loops.fixed_i f) (Loops.fixed_i l) acc1;
-    (==) { repeat_gen_blocks_extensionality_zero blocksize n0 n n1 n1 t1
+    == { repeat_gen_blocks_extensionality_zero blocksize n0 n n1 n1 t1
             (Loops.fixed_a b) (Loops.fixed_a b) (Loops.fixed_i f) (Loops.fixed_i l)
 	    (Loops.fixed_i f) (Loops.fixed_i l) acc1 }
     repeat_gen_blocks blocksize 0 n1 t1 (Loops.fixed_a b) (Loops.fixed_i f) (Loops.fixed_i l) acc1;
-    (==) { repeat_blocks_is_repeat_gen_blocks #a #b #c n1 blocksize t1 f l acc1 }
+    == { repeat_blocks_is_repeat_gen_blocks #a #b #c n1 blocksize t1 f l acc1 }
     repeat_blocks blocksize t1 f l acc1;
     }
 
@@ -613,16 +613,16 @@ let map_blocks_multi_extensionality #a blocksize max n inp f g =
 
   calc (==) {
     map_blocks_multi blocksize max n inp f;
-    (==) { lemma_map_blocks_multi blocksize max n inp f }
+    == { lemma_map_blocks_multi blocksize max n inp f }
     Loops.repeat_gen n a_map (map_blocks_f #a blocksize max inp f) acc0;
-    (==) { Loops.repeat_gen_def n a_map (map_blocks_f #a blocksize max inp f) acc0 }
+    == { Loops.repeat_gen_def n a_map (map_blocks_f #a blocksize max inp f) acc0 }
     Loops.repeat_right 0 n a_map (map_blocks_f #a blocksize max inp f) acc0;
-    (==) { repeat_right_extensionality n 0 a_map a_map
+    == { repeat_right_extensionality n 0 a_map a_map
       (map_blocks_f #a blocksize max inp f) (map_blocks_f #a blocksize max inp g) acc0 }
     Loops.repeat_right 0 n a_map (map_blocks_f #a blocksize max inp g) acc0;
-    (==) { Loops.repeat_gen_def n a_map (map_blocks_f #a blocksize max inp g) acc0 }
+    == { Loops.repeat_gen_def n a_map (map_blocks_f #a blocksize max inp g) acc0 }
     Loops.repeat_gen n a_map (map_blocks_f #a blocksize max inp g) acc0;
-    (==) { lemma_map_blocks_multi blocksize max n inp g }
+    == { lemma_map_blocks_multi blocksize max n inp g }
     map_blocks_multi blocksize max n inp g;
     }
 
@@ -705,11 +705,11 @@ let rec map_blocks_multi_acc_is_map_blocks_multi_ #a blocksize mi hi_f hi_g n in
 
     calc (==) {
       Loops.repeat_right mi (mi + n) a_f f_gen acc0;
-      (==) { Loops.unfold_repeat_right mi (mi + n) a_f f_gen acc0 (mi + n - 1) }
+      == { Loops.unfold_repeat_right mi (mi + n) a_f f_gen acc0 (mi + n - 1) }
       Seq.append lp1 (f (mi + n - 1) block);
-      (==) { map_blocks_multi_acc_is_map_blocks_multi_ #a blocksize mi hi_f hi_g (n - 1) inp f acc0 }
+      == { map_blocks_multi_acc_is_map_blocks_multi_ #a blocksize mi hi_f hi_g (n - 1) inp f acc0 }
       Seq.append (Seq.append acc0 rp1) (f (mi + n - 1) block);
-      (==) { Seq.Base.append_assoc acc0 rp1 (f (mi + n - 1) block) }
+      == { Seq.Base.append_assoc acc0 rp1 (f (mi + n - 1) block) }
       Seq.append acc0 (Seq.append rp1 (f (mi + n - 1) block));
       } end
 #pop-options
@@ -725,13 +725,13 @@ let map_blocks_multi_acc_is_map_blocks_multi #a blocksize mi hi n inp f acc0 =
 
   calc (==) {
     Seq.append acc0 (map_blocks_multi blocksize n n inp f_map_s);
-    (==) { lemma_map_blocks_multi blocksize n n inp f_map_s }
+    == { lemma_map_blocks_multi blocksize n n inp f_map_s }
     Seq.append acc0 (Loops.repeat_gen n a_map_s f_gen_s (Seq.empty #a));
-    (==) { Loops.repeat_gen_def n a_map_s f_gen_s (Seq.empty #a) }
+    == { Loops.repeat_gen_def n a_map_s f_gen_s (Seq.empty #a) }
     Seq.append acc0 (Loops.repeat_right 0 n a_map_s f_gen_s (Seq.empty #a));
-    (==) { map_blocks_multi_acc_is_map_blocks_multi_ #a blocksize mi hi n n inp f acc0 }
+    == { map_blocks_multi_acc_is_map_blocks_multi_ #a blocksize mi hi n n inp f acc0 }
     Loops.repeat_right mi (mi + n) a_map f_gen acc0;
-    (==) { }
+    == { }
     map_blocks_multi_acc #a blocksize mi hi n inp f acc0;
   }
 
@@ -755,11 +755,11 @@ let map_blocks_multi_acc_is_map_blocks_multi0 #a blocksize hi n inp f =
 
   calc (==) {
     map_blocks_multi_acc blocksize 0 hi n inp f Seq.empty;
-    (==) { map_blocks_multi_acc_is_map_blocks_multi #a blocksize 0 hi n inp f Seq.empty }
+    == { map_blocks_multi_acc_is_map_blocks_multi #a blocksize 0 hi n inp f Seq.empty }
     Seq.append Seq.empty (map_blocks_multi blocksize n n inp f_sh);
-    (==) { Seq.Base.append_empty_l (map_blocks_multi blocksize n n inp f_sh) }
+    == { Seq.Base.append_empty_l (map_blocks_multi blocksize n n inp f_sh) }
     map_blocks_multi blocksize n n inp f_sh;
-    (==) { map_blocks_multi_extensionality blocksize n n inp f_sh f }
+    == { map_blocks_multi_extensionality blocksize n n inp f_sh f }
     map_blocks_multi blocksize n n inp f;
     }
 
@@ -772,11 +772,11 @@ let map_blocks_acc_is_map_blocks0 #a blocksize hi inp f l =
 
   calc (==) {
     map_blocks_acc #a blocksize 0 hi inp f l Seq.empty;
-    (==) { map_blocks_acc_is_map_blocks blocksize 0 hi inp f l Seq.empty }
+    == { map_blocks_acc_is_map_blocks blocksize 0 hi inp f l Seq.empty }
     Seq.append Seq.empty (map_blocks #a blocksize inp f_sh l_sh);
-    (==) { Seq.Base.append_empty_l (map_blocks #a blocksize inp f_sh l_sh) }
+    == { Seq.Base.append_empty_l (map_blocks #a blocksize inp f_sh l_sh) }
     map_blocks #a blocksize inp f_sh l_sh;
-    (==) { map_blocks_extensionality #a blocksize inp f l f_sh l_sh }
+    == { map_blocks_extensionality #a blocksize inp f l f_sh l_sh }
     map_blocks #a blocksize inp f l;
     }
 
@@ -790,10 +790,10 @@ let map_blocks_is_empty #a blocksize hi inp f l =
   assert (rem == 0);
   calc (==) {
     map_blocks blocksize inp f l;
-    (==) { lemma_map_blocks blocksize inp f l }
+    == { lemma_map_blocks blocksize inp f l }
     map_blocks_multi #a blocksize nb nb blocks f;
-    (==) { lemma_map_blocks_multi blocksize nb nb blocks f }
+    == { lemma_map_blocks_multi blocksize nb nb blocks f }
     Loops.repeat_gen nb (map_blocks_a a blocksize nb) (map_blocks_f #a blocksize nb inp f) Seq.empty;
-    (==) { Loops.eq_repeat_gen0 nb (map_blocks_a a blocksize nb) (map_blocks_f #a blocksize nb inp f) Seq.empty }
+    == { Loops.eq_repeat_gen0 nb (map_blocks_a a blocksize nb) (map_blocks_f #a blocksize nb inp f) Seq.empty }
     Seq.empty;
     }

--- a/lib/Lib.UpdateMulti.Lemmas.fst
+++ b/lib/Lib.UpdateMulti.Lemmas.fst
@@ -174,11 +174,11 @@ let rec update_full_is_repeat_blocks #a block_length update update_last acc inpu
     S.lemma_len_append tail rest;
     calc (==) {
       S.length (tail `S.append` rest) / block_length;
-    (==) { }
+    == { }
       (S.length input - S.length head) / block_length;
-    (==) { }
+    == { }
       (S.length input + (- 1) * block_length) / block_length;
-    (==) { Math.Lemmas.division_addition_lemma (S.length input) block_length (-1) }
+    == { Math.Lemmas.division_addition_lemma (S.length input) block_length (-1) }
       n_blocks - 1;
     };
 
@@ -201,26 +201,26 @@ let rec update_full_is_repeat_blocks #a block_length update update_last acc inpu
       (mk_update_multi block_length update acc (head `S.append` tail));
     calc (==) {
       Lib.UpdateMulti.update_full block_length update update_last acc input;
-    (==) { }
+    == { }
       update_last (mk_update_multi block_length update (update acc head) tail) rest;
-    (==) { }
+    == { }
       Lib.UpdateMulti.update_full block_length update update_last (update acc head) (tail `S.append` rest);
-    (==) { update_full_is_repeat_blocks #a block_length update update_last (update acc head) (tail `S.append` rest) input' }
+    == { update_full_is_repeat_blocks #a block_length update update_last (update acc head) (tail `S.append` rest) input' }
       Lib.Sequence.repeat_blocks #uint8 block_length (tail `S.append` rest) repeat_f repeat_l (update acc head);
-    (==) { }
+    == { }
       Lib.Sequence.repeat_blocks #uint8 block_length (tail `S.append` rest) repeat_f repeat_l (repeat_f head acc);
-    (==) {
+    == {
       Lib.LoopCombinators.eq_repeati0 1 (Lib.Sequence.repeat_blocks_f block_length head repeat_f 1) acc;
       Lib.LoopCombinators.unfold_repeati 1 (Lib.Sequence.repeat_blocks_f block_length head repeat_f 1) acc 0
     }
       Lib.Sequence.repeat_blocks #uint8 block_length (tail `S.append` rest) repeat_f repeat_l
         (Lib.LoopCombinators.repeati 1 (Lib.Sequence.repeat_blocks_f block_length head repeat_f 1) acc);
 
-    (==) { Lib.Sequence.lemma_repeat_blocks_multi block_length head repeat_f acc }
+    == { Lib.Sequence.lemma_repeat_blocks_multi block_length head repeat_f acc }
       Lib.Sequence.repeat_blocks #uint8 block_length (tail `S.append` rest) repeat_f repeat_l
         (Lib.Sequence.repeat_blocks_multi block_length head repeat_f acc);
 
-    (==) { Lib.Sequence.Lemmas.repeat_blocks_split block_length block_length input repeat_f repeat_l acc }
+    == { Lib.Sequence.Lemmas.repeat_blocks_split block_length block_length input repeat_f repeat_l acc }
       Lib.Sequence.repeat_blocks #uint8 block_length input repeat_f repeat_l acc;
     }
   end
@@ -263,33 +263,33 @@ let rec update_multi_is_repeat_blocks_multi #a block_length update acc input =
     let f = repeat_blocks_f block_length (S.slice input split_index (S.length input)) repeat_f 1 in
     calc (==) {
       Lib.Sequence.repeat_blocks_multi #uint8 block_length input repeat_f acc;
-    (==) { Lib.Sequence.Lemmas.repeat_blocks_multi_split block_length split_index input repeat_f acc }
+    == { Lib.Sequence.Lemmas.repeat_blocks_multi_split block_length split_index input repeat_f acc }
       Lib.Sequence.repeat_blocks_multi #uint8 block_length (S.slice input split_index (S.length input)) repeat_f
         (Lib.Sequence.repeat_blocks_multi #uint8 block_length (S.slice input 0 split_index) repeat_f acc);
-    (==) { update_multi_is_repeat_blocks_multi block_length update acc (S.slice input 0 split_index) }
+    == { update_multi_is_repeat_blocks_multi block_length update acc (S.slice input 0 split_index) }
       Lib.Sequence.repeat_blocks_multi #uint8 block_length (S.slice input split_index (S.length input)) repeat_f
         acc0;
-    (==) { Lib.Sequence.lemma_repeat_blocks_multi block_length (S.slice input split_index (S.length input)) repeat_f
+    == { Lib.Sequence.lemma_repeat_blocks_multi block_length (S.slice input split_index (S.length input)) repeat_f
         acc0
     }
       Lib.LoopCombinators.repeati 1 (repeat_blocks_f block_length (S.slice input split_index (S.length input)) repeat_f 1) acc0;
-    (==) { Lib.LoopCombinators.unfold_repeati 1
+    == { Lib.LoopCombinators.unfold_repeati 1
       (repeat_blocks_f block_length (S.slice input split_index (S.length input)) repeat_f 1)
       acc0
       0
     }
       f 0 (Lib.LoopCombinators.repeati 0 f acc0);
-    (==) { Lib.LoopCombinators.eq_repeati0 0 f acc0 }
+    == { Lib.LoopCombinators.eq_repeati0 0 f acc0 }
       f 0 acc0;
-    (==) { }
+    == { }
       update acc0 (S.slice input split_index (S.length input));
-    (==) { update_multi_one block_length update acc0 (S.slice input split_index (S.length input)) }
+    == { update_multi_one block_length update acc0 (S.slice input split_index (S.length input)) }
       Lib.UpdateMulti.mk_update_multi block_length update acc0 (S.slice input split_index (S.length input));
-    (==) { Lib.UpdateMulti.update_multi_associative block_length update acc
+    == { Lib.UpdateMulti.update_multi_associative block_length update acc
       (S.slice input 0 split_index) (S.slice input split_index (S.length input)) }
       Lib.UpdateMulti.mk_update_multi block_length update acc (S.append
         (S.slice input 0 split_index) (S.slice input split_index (S.length input)));
-    (==) { assert (
+    == { assert (
         (S.append (S.slice input 0 split_index) (S.slice input split_index (S.length input))) `S.equal`
         input) }
       Lib.UpdateMulti.mk_update_multi block_length update acc input;

--- a/lib/Lib.UpdateMulti.fst
+++ b/lib/Lib.UpdateMulti.fst
@@ -44,23 +44,23 @@ let split_nb_lem (block_length: pos)
   assert(bl % block_length = 0);
   calc (<=) {
      bl;
-  (<=) { Math.Lemmas.lemma_mult_le_right block_length n (data_length / block_length) }
+  <= { Math.Lemmas.lemma_mult_le_right block_length n (data_length / block_length) }
     (data_length / block_length) * block_length;
-  (<=) {}
+  <= {}
     (data_length / block_length) * block_length + data_length % block_length;
-  (==) { Math.Lemmas.euclidean_division_definition data_length block_length }
+  == { Math.Lemmas.euclidean_division_definition data_length block_length }
     data_length;
   };
   let r = data_length - bl in
   calc (==) {
     r % block_length;
-  (==) { Math.Lemmas.modulo_distributivity data_length (- bl) block_length }
+  == { Math.Lemmas.modulo_distributivity data_length (- bl) block_length }
     (data_length % block_length + (- bl) % block_length) % block_length;
-  (==) { Math.Lemmas.paren_mul_right (-1) n block_length }
+  == { Math.Lemmas.paren_mul_right (-1) n block_length }
     (data_length % block_length + ((- n) * block_length) % block_length) % block_length;
-  (==) { Math.Lemmas.multiple_modulo_lemma (-n) block_length }
+  == { Math.Lemmas.multiple_modulo_lemma (-n) block_length }
     (data_length % block_length) % block_length;
-  (==) { Math.Lemmas.lemma_mod_add_distr 0 data_length block_length }
+  == { Math.Lemmas.lemma_mod_add_distr 0 data_length block_length }
     data_length % block_length;
   }
 #pop-options
@@ -330,15 +330,15 @@ let concat_blocks_modulo (block_len: pos) (s1 s2: S.seq uint8): Lemma
   let input2 = s2 in
   calc (==) {
     S.length input % block_len;
-  (==) { S.lemma_len_append input1 input2 }
+  == { S.lemma_len_append input1 input2 }
     (S.length input1 + S.length input2) % block_len;
-  (==) {
+  == {
     FStar.Math.Lemmas.modulo_distributivity (S.length input1) (S.length input2) (block_len)
   }
     (S.length input1 % block_len + S.length input2 % block_len) % block_len;
-  (==) { (* hyp *) }
+  == { (* hyp *) }
     0 % block_len;
-  (==) { FStar.Math.Lemmas.small_mod 0 block_len }
+  == { FStar.Math.Lemmas.small_mod 0 block_len }
     0;
   }
 #pop-options
@@ -375,11 +375,11 @@ let rec update_multi_associative #a (block_length: pos)
   if S.length input1 = 0 then
     calc (==) {
       mk_update_multi block_length update (mk_update_multi block_length update acc input1) input2;
-    (==) { update_multi_zero block_length update acc }
+    == { update_multi_zero block_length update acc }
       mk_update_multi block_length update acc input2;
-    (==) { S.lemma_eq_intro input2 (S.empty `S.append` input2) }
+    == { S.lemma_eq_intro input2 (S.empty `S.append` input2) }
       mk_update_multi block_length update acc (S.empty `S.append` input2);
-    (==) { S.lemma_eq_intro input1 S.empty }
+    == { S.lemma_eq_intro input1 S.empty }
       mk_update_multi block_length update acc (input1 `S.append` input2);
     }
   else

--- a/lib/Lib.Vec.Lemmas.fst
+++ b/lib/Lib.Vec.Lemmas.fst
@@ -16,13 +16,13 @@ let rec lemma_repeat_gen_vec w n a a_vec normalize_v f f_v acc_v0 =
 
     calc (==) {
       Loops.repeat_right 0 (w * n) a f (normalize_v 0 acc_v0);
-      (==) { Loops.repeat_right_plus 0 (w * (n - 1)) (w * n) a f (normalize_v 0 acc_v0) }
+      == { Loops.repeat_right_plus 0 (w * (n - 1)) (w * n) a f (normalize_v 0 acc_v0) }
       Loops.repeat_right (w * (n - 1)) (w * n) a f next_v;
-      (==) { lemma_repeat_gen_vec w (n - 1) a a_vec normalize_v f f_v acc_v0 }
+      == { lemma_repeat_gen_vec w (n - 1) a a_vec normalize_v f f_v acc_v0 }
       Loops.repeat_right (w * (n - 1)) (w * n) a f (normalize_v (n - 1) next_p);
-      (==) { }
+      == { }
       normalize_v n (f_v (n - 1) next_p);
-      (==) { Loops.unfold_repeat_right 0 n a_vec f_v acc_v0 (n - 1) }
+      == { Loops.unfold_repeat_right 0 n a_vec f_v acc_v0 (n - 1) }
       normalize_v n (Loops.repeat_right 0 n a_vec f_v acc_v0);
     } end
 
@@ -104,23 +104,23 @@ let repeat_gen_blocks_slice_k #inp_t w blocksize n hi_f inp a f i k acc =
   let blocksize_v = w * blocksize in
   calc (<=) {
     (i + 1) * blocksize_v;
-    (<=) { Math.Lemmas.lemma_mult_le_right blocksize_v (i + 1) n }
+    <= { Math.Lemmas.lemma_mult_le_right blocksize_v (i + 1) n }
     n * blocksize_v;
-    (==) { Math.Lemmas.paren_mul_right n w blocksize }
+    == { Math.Lemmas.paren_mul_right n w blocksize }
     length inp;
     };
 
   calc (==) {
     i * blocksize_v + (k - w * i) * blocksize;
-    (==) { Math.Lemmas.paren_mul_right i w blocksize }
+    == { Math.Lemmas.paren_mul_right i w blocksize }
     i * w * blocksize + (k - w * i) * blocksize;
-    (==) { Math.Lemmas.distributivity_add_left (i * w) (k - w * i) blocksize }
+    == { Math.Lemmas.distributivity_add_left (i * w) (k - w * i) blocksize }
     (i * w + (k - w * i)) * blocksize;
-    (==) { }
+    == { }
     (i * w + (k + (- w * i))) * blocksize;
-    (==) { Math.Lemmas.paren_add_right (i * w) k (- w * i) }
+    == { Math.Lemmas.paren_add_right (i * w) k (- w * i) }
     (i * w + k + (- w * i)) * blocksize;
-    (==) { Math.Lemmas.swap_mul i w } // JP: this was the important one that made the proof brittle
+    == { Math.Lemmas.swap_mul i w } // JP: this was the important one that made the proof brittle
     k * blocksize;
     };
 
@@ -194,9 +194,9 @@ let repeat_gen_blocks_multi_vec_step #inp_t w blocksize n hi_f inp a a_vec f f_v
   let acc0 = normalize_v i acc_v in
   calc (==) {
     repeat_gen_blocks_multi blocksize (w * i) hi_f w b_v a f acc0;
-    (==) { lemma_repeat_gen_blocks_multi blocksize (w * i) hi_f w b_v a f acc0 }
+    == { lemma_repeat_gen_blocks_multi blocksize (w * i) hi_f w b_v a f acc0 }
     Loops.repeat_right (w * i) (w * i + w) a f_rep_s acc0;
-    (==) { repeat_gen_blocks_slice #inp_t w blocksize n hi_f inp a f i acc0 }
+    == { repeat_gen_blocks_slice #inp_t w blocksize n hi_f inp a f i acc0 }
     Loops.repeat_right (w * i) (w * i + w) a f_rep acc0;
   };
 
@@ -215,15 +215,15 @@ let lemma_repeat_gen_blocks_multi_vec #inp_t w blocksize n hi_f inp a a_vec f f_
 
   calc (==) {
     normalize_v n (repeat_gen_blocks_multi blocksize_v 0 n n inp a_vec f_v acc_v0);
-    (==) { lemma_repeat_gen_blocks_multi blocksize_v 0 n n inp a_vec f_v acc_v0 }
+    == { lemma_repeat_gen_blocks_multi blocksize_v 0 n n inp a_vec f_v acc_v0 }
     normalize_v n (Loops.repeat_right 0 n a_vec f_rep_v acc_v0);
-    (==) {
+    == {
       Classical.forall_intro_2 (repeat_gen_blocks_multi_vec_step w blocksize n hi_f inp a a_vec f f_v normalize_v ());
       lemma_repeat_gen_vec w n a a_vec normalize_v f_rep f_rep_v acc_v0 }
     Loops.repeat_right 0 (w * n) a f_rep acc0;
-    (==) { lemma_repeat_gen_blocks_multi blocksize 0 (w * n) (w * n) inp a f acc0 }
+    == { lemma_repeat_gen_blocks_multi blocksize 0 (w * n) (w * n) inp a f acc0 }
     repeat_gen_blocks_multi blocksize 0 (w * n) (w * n) inp a f acc0;
-    (==) { repeat_gen_blocks_multi_extensionality_zero blocksize 0 (w * n) hi_f (w * n) inp a a f f acc0 }
+    == { repeat_gen_blocks_multi_extensionality_zero blocksize 0 (w * n) hi_f (w * n) inp a a f f acc0 }
     repeat_gen_blocks_multi blocksize 0 hi_f (w * n) inp a f acc0;
   }
 #pop-options
@@ -250,9 +250,9 @@ let lemma_repeat_gen_blocks_vec #inp_t #c w blocksize inp n a a_vec f l f_v l_v 
   let acc0 = normalize_v 0 acc_v0 in
   calc (==) {
     l_v n rem_v last_v acc_v;
-    (==) { assert (repeat_gen_blocks_vec_equiv_pre w blocksize n a a_vec f l l_v normalize_v rem_v last_v acc_v) }
+    == { assert (repeat_gen_blocks_vec_equiv_pre w blocksize n a a_vec f l l_v normalize_v rem_v last_v acc_v) }
     repeat_gen_blocks blocksize (w * n) (w * n + w) last_v a f l (normalize_v n acc_v);
-    (==) { lemma_repeat_gen_blocks_multi_vec w blocksize n (w * n + w) blocks_v a a_vec f f_v normalize_v acc_v0 }
+    == { lemma_repeat_gen_blocks_multi_vec w blocksize n (w * n + w) blocks_v a a_vec f f_v normalize_v acc_v0 }
     repeat_gen_blocks blocksize (w * n) (w * n + w) last_v a f l
       (repeat_gen_blocks_multi blocksize 0 (w * n + w) (w * n) blocks_v a f acc0);
   };
@@ -298,9 +298,9 @@ let lemma_repeat_blocks_multi_vec_equiv_pre #a #b #b_vec w blocksize n hi_f f f_
 
   calc (==) {
     repeat_blocks_multi blocksize b_v f (normalize_v acc_v);
-    (==) { repeat_blocks_multi_is_repeat_gen_blocks_multi w blocksize b_v f (normalize_v acc_v) }
+    == { repeat_blocks_multi_is_repeat_gen_blocks_multi w blocksize b_v f (normalize_v acc_v) }
     repeat_gen_blocks_multi blocksize 0 w w b_v (Loops.fixed_a b) (Loops.fixed_i f) (normalize_v acc_v);
-    (==) { repeat_gen_blocks_multi_extensionality_zero blocksize (w * i) hi_f w w b_v
+    == { repeat_gen_blocks_multi_extensionality_zero blocksize (w * i) hi_f w w b_v
            (Loops.fixed_a b) (Loops.fixed_a b) (Loops.fixed_i f) (Loops.fixed_i f) (normalize_v acc_v) }
     repeat_gen_blocks_multi blocksize (w * i) hi_f w b_v (Loops.fixed_a b) (Loops.fixed_i f) (normalize_v acc_v);
     }
@@ -316,14 +316,14 @@ let lemma_repeat_blocks_multi_vec #a #b #b_vec w blocksize inp f f_v normalize_v
 
   calc (==) {
     normalize_v (repeat_blocks_multi #a #b_vec blocksize_v inp f_v acc_v0);
-    (==) { repeat_blocks_multi_is_repeat_gen_blocks_multi nw blocksize_v inp f_v acc_v0 }
+    == { repeat_blocks_multi_is_repeat_gen_blocks_multi nw blocksize_v inp f_v acc_v0 }
     normalize_v (repeat_gen_blocks_multi blocksize_v 0 nw nw inp (Loops.fixed_a b_vec) (Loops.fixed_i f_v) acc_v0);
-    (==) {
+    == {
       Classical.forall_intro_3 (lemma_repeat_blocks_multi_vec_equiv_pre w blocksize nw (w * nw) f f_v normalize_v ());
       lemma_repeat_gen_blocks_multi_vec w blocksize nw (w * nw) inp (Loops.fixed_a b) (Loops.fixed_a b_vec)
 	(Loops.fixed_i f) (Loops.fixed_i f_v) (Loops.fixed_i normalize_v) acc_v0 }
     repeat_gen_blocks_multi blocksize 0 (nw * w) (nw * w) inp (Loops.fixed_a b) (Loops.fixed_i f) acc0;
-    (==) { repeat_blocks_multi_is_repeat_gen_blocks_multi (nw * w) blocksize inp f acc0 }
+    == { repeat_blocks_multi_is_repeat_gen_blocks_multi (nw * w) blocksize inp f acc0 }
     repeat_blocks_multi blocksize inp f acc0;
     }
 
@@ -360,13 +360,13 @@ let lemma_repeat_blocks_vec_equiv_pre #a #b #b_vec #c w blocksize n f l l_v norm
 
   calc (==) {
     Loops.fixed_i l_v n rem b_v acc_v;
-    (==) { }
+    == { }
     l_v rem b_v acc_v;
-    (==) { assert (repeat_blocks_vec_equiv_pre w blocksize f l l_v normalize_v rem b_v acc_v) }
+    == { assert (repeat_blocks_vec_equiv_pre w blocksize f l l_v normalize_v rem b_v acc_v) }
     repeat_blocks blocksize b_v f l acc0;
-    (==) { repeat_blocks_is_repeat_gen_blocks nb_rem blocksize b_v f l acc0 }
+    == { repeat_blocks_is_repeat_gen_blocks nb_rem blocksize b_v f l acc0 }
     repeat_gen_blocks blocksize 0 nb_rem b_v (Loops.fixed_a b) (Loops.fixed_i f) (Loops.fixed_i l) acc0;
-    (==) { repeat_gen_blocks_extensionality_zero blocksize (w * n) (w * n + w) nb_rem nb_rem b_v
+    == { repeat_gen_blocks_extensionality_zero blocksize (w * n) (w * n + w) nb_rem nb_rem b_v
            (Loops.fixed_a b) (Loops.fixed_a b)
 	   (Loops.fixed_i f) (Loops.fixed_i l)
 	   (Loops.fixed_i f) (Loops.fixed_i l) acc0 }
@@ -380,15 +380,15 @@ let lemma_repeat_blocks_vec #a #b #b_vec #c w blocksize inp f l f_v l_v normaliz
 
   calc (==) {
     repeat_blocks blocksize_v inp f_v l_v acc_v0;
-    (==) { repeat_blocks_is_repeat_gen_blocks nb_v blocksize_v inp f_v l_v acc_v0 }
+    == { repeat_blocks_is_repeat_gen_blocks nb_v blocksize_v inp f_v l_v acc_v0 }
     repeat_gen_blocks blocksize_v 0 nb_v inp (Loops.fixed_a b_vec) (Loops.fixed_i f_v) (Loops.fixed_i l_v) acc_v0;
-    (==) { Classical.forall_intro_3 (lemma_repeat_blocks_multi_vec_equiv_pre w blocksize nb_v (w * nb_v + w) f f_v normalize_v ());
+    == { Classical.forall_intro_3 (lemma_repeat_blocks_multi_vec_equiv_pre w blocksize nb_v (w * nb_v + w) f f_v normalize_v ());
            Classical.forall_intro_3 (lemma_repeat_blocks_vec_equiv_pre #a #b #b_vec #c w blocksize nb_v f l l_v normalize_v ());
            lemma_repeat_gen_blocks_vec w blocksize inp nb_v
              (Loops.fixed_a b) (Loops.fixed_a b_vec) (Loops.fixed_i f) (Loops.fixed_i l)
              (Loops.fixed_i f_v) (Loops.fixed_i l_v) (Loops.fixed_i normalize_v) acc_v0 }
     repeat_gen_blocks blocksize 0 (w * nb_v + w) inp (Loops.fixed_a b) (Loops.fixed_i f) (Loops.fixed_i l) (normalize_v acc_v0);
-    (==) { repeat_blocks_is_repeat_gen_blocks (w * nb_v + w) blocksize inp f l (normalize_v acc_v0) }
+    == { repeat_blocks_is_repeat_gen_blocks (w * nb_v + w) blocksize inp f l (normalize_v acc_v0) }
     repeat_blocks blocksize inp f l (normalize_v acc_v0);
   }
 
@@ -400,11 +400,11 @@ let lemma_repeat_blocks_vec #a #b #b_vec #c w blocksize inp f l f_v l_v normaliz
 let lemma_f_map_ind w blocksize n i k =
   calc (<) {
     w * i + k / blocksize;
-    (<) { div_mul_lt blocksize k w }
+    < { div_mul_lt blocksize k w }
     w * i + w;
-    (==) { Math.Lemmas.distributivity_add_right w i 1 }
+    == { Math.Lemmas.distributivity_add_right w i 1 }
     w * (i + 1);
-    (<=) { Math.Lemmas.lemma_mult_le_left w (i + 1) n }
+    <= { Math.Lemmas.lemma_mult_le_left w (i + 1) n }
     w * n;
     }
 
@@ -477,9 +477,9 @@ let lemma_map_blocks_multi_vec_equiv_pre_k #a w blocksize n hi_f f f_v i b_v pre
 
     calc (==) {
       Seq.index (map_blocks_multi blocksize w w b_v f_sh) k;
-      (==) { index_map_blocks_multi blocksize w w b_v f_sh k }
+      == { index_map_blocks_multi blocksize w w b_v f_sh k }
       Seq.index (f_sh j block) (k % blocksize);
-      (==) { assert (map_blocks_multi_vec_equiv_pre_k w blocksize n hi_f f f_v i b_v k) }
+      == { assert (map_blocks_multi_vec_equiv_pre_k w blocksize n hi_f f f_v i b_v k) }
       Seq.index (f_v i b_v) k;
     } in
 
@@ -490,11 +490,11 @@ let lemma_map_blocks_multi_vec_equiv_pre_k #a w blocksize n hi_f f f_v i b_v pre
   in
   calc (==) {
     map_blocks_multi_acc blocksize (w * i) hi_f w b_v f acc_v;
-    (==) { map_blocks_multi_acc_is_map_blocks_multi blocksize (w * i) hi_f w b_v f acc_v }
+    == { map_blocks_multi_acc_is_map_blocks_multi blocksize (w * i) hi_f w b_v f acc_v }
     Seq.append acc_v (map_blocks_multi blocksize w w b_v f_sh);
-    (==) { Classical.forall_intro aux; Seq.lemma_eq_intro (f_v i b_v) (map_blocks_multi blocksize w w b_v f_sh) }
+    == { Classical.forall_intro aux; Seq.lemma_eq_intro (f_v i b_v) (map_blocks_multi blocksize w w b_v f_sh) }
     Seq.append acc_v (f_v i b_v);
-    (==) { Seq.lemma_eq_intro (Seq.append acc_v (f_v i b_v)) (repeat_gen_blocks_map_f #a (w * blocksize) n f_v i b_v acc_v) }
+    == { Seq.lemma_eq_intro (Seq.append acc_v (f_v i b_v)) (repeat_gen_blocks_map_f #a (w * blocksize) n f_v i b_v acc_v) }
     repeat_gen_blocks_map_f #a (w * blocksize) n f_v i b_v acc_v;
     }
 #pop-options
@@ -535,13 +535,13 @@ let lemma_map_blocks_multi_vec #a w blocksize n inp f f_v =
 
   calc (==) {
     map_blocks_multi blocksize_v n n inp f_v;
-    (==) { map_blocks_multi_acc_is_map_blocks_multi0 blocksize_v n n inp f_v }
+    == { map_blocks_multi_acc_is_map_blocks_multi0 blocksize_v n n inp f_v }
     map_blocks_multi_acc blocksize_v 0 n n inp f_v Seq.empty;
-    (==) { map_blocks_multi_acc_is_repeat_gen_blocks_multi blocksize_v 0 n n inp f_v Seq.empty }
+    == { map_blocks_multi_acc_is_repeat_gen_blocks_multi blocksize_v 0 n n inp f_v Seq.empty }
     repeat_gen_blocks_multi blocksize_v 0 n n inp
      (map_blocks_a a blocksize_v n)
      (repeat_gen_blocks_map_f blocksize_v n f_v) Seq.empty;
-    (==) { Classical.forall_intro_3 (lemma_map_blocks_multi_vec_equiv_pre #a w blocksize n (w * n) f f_v ());
+    == { Classical.forall_intro_3 (lemma_map_blocks_multi_vec_equiv_pre #a w blocksize n (w * n) f f_v ());
            lemma_repeat_gen_blocks_multi_vec w blocksize n (w * n) inp
              (map_blocks_a a blocksize (w * n)) (map_blocks_a a blocksize_v n)
              (repeat_gen_blocks_map_f blocksize (w * n) f)
@@ -550,9 +550,9 @@ let lemma_map_blocks_multi_vec #a w blocksize n inp f f_v =
     repeat_gen_blocks_multi blocksize 0 (w * n) (w * n) inp
      (map_blocks_a a blocksize (w * n))
      (repeat_gen_blocks_map_f blocksize (w * n) f) Seq.empty;
-    (==) { map_blocks_multi_acc_is_repeat_gen_blocks_multi blocksize 0 (w * n) (w * n) inp f Seq.empty }
+    == { map_blocks_multi_acc_is_repeat_gen_blocks_multi blocksize 0 (w * n) (w * n) inp f Seq.empty }
     map_blocks_multi_acc blocksize 0 (w * n) (w * n) inp f Seq.empty;
-    (==) { map_blocks_multi_acc_is_map_blocks_multi0 blocksize (w * n) (w * n) inp f }
+    == { map_blocks_multi_acc_is_map_blocks_multi0 blocksize (w * n) (w * n) inp f }
     map_blocks_multi blocksize (w * n) (w * n) inp f;
   }
 
@@ -613,9 +613,9 @@ let lemma_map_blocks_vec_equiv_pre_k_aux #a w blocksize n f l l_v rem b_v pre k 
     let block = get_block_s #a #rem blocksize b_v k in
     calc (==) {
       Seq.index (map_blocks blocksize b_v f_sh l_sh) k;
-      (==) { index_map_blocks blocksize b_v f_sh l_sh k }
+      == { index_map_blocks blocksize b_v f_sh l_sh k }
       Seq.index (f j block) (k % blocksize);
-      (==) { assert (map_blocks_vec_equiv_pre_k w blocksize n f l l_v rem b_v k) }
+      == { assert (map_blocks_vec_equiv_pre_k w blocksize n f l l_v rem b_v k) }
       Seq.index (l_v n rem b_v) k;
     }  end
   else begin
@@ -623,11 +623,11 @@ let lemma_map_blocks_vec_equiv_pre_k_aux #a w blocksize n f l l_v rem b_v pre k 
     mod_div_lt blocksize k rem;
     calc (==) {
       Seq.index (map_blocks blocksize b_v f_sh l_sh) k;
-      (==) { index_map_blocks blocksize b_v f_sh l_sh k }
+      == { index_map_blocks blocksize b_v f_sh l_sh k }
       Seq.index (l_sh (rem / blocksize) (rem % blocksize) block_l) (k % blocksize);
-      (==) { div_interval blocksize (rem / blocksize) k }
+      == { div_interval blocksize (rem / blocksize) k }
       Seq.index (l j (rem % blocksize) block_l) (k % blocksize);
-      (==) { assert (map_blocks_vec_equiv_pre_k w blocksize n f l l_v rem b_v k) }
+      == { assert (map_blocks_vec_equiv_pre_k w blocksize n f l l_v rem b_v k) }
       Seq.index (l_v n rem b_v) k;
     } end
 
@@ -655,24 +655,24 @@ let lemma_map_blocks_vec_equiv_pre_k #a w blocksize n f l l_v rem b_v pre acc_v 
   if rem = 0 then begin
     calc (==) {
       map_blocks_acc blocksize (w * n) (w * n + w) b_v f l acc_v;
-      (==) { map_blocks_acc_is_map_blocks blocksize (w * n) (w * n + w) b_v f l acc_v}
+      == { map_blocks_acc_is_map_blocks blocksize (w * n) (w * n + w) b_v f l acc_v}
       Seq.append acc_v (map_blocks blocksize b_v f_sh l_sh);
-      (==) { map_blocks_is_empty blocksize nb b_v f_sh l_sh }
+      == { map_blocks_is_empty blocksize nb b_v f_sh l_sh }
       Seq.append acc_v Seq.empty;
-      (==) { Seq.Base.append_empty_r acc_v }
+      == { Seq.Base.append_empty_r acc_v }
       acc_v;
-      (==) { }
+      == { }
       repeat_gen_blocks_map_l (w * blocksize) n l_v n rem b_v acc_v;
       } end
   else begin
     calc (==) {
       map_blocks_acc blocksize (w * n) (w * n + w) b_v f l acc_v;
-      (==) { map_blocks_acc_is_map_blocks blocksize (w * n) (w * n + w) b_v f l acc_v}
+      == { map_blocks_acc_is_map_blocks blocksize (w * n) (w * n + w) b_v f l acc_v}
       Seq.append acc_v (map_blocks blocksize b_v f_sh l_sh);
-      (==) { Classical.forall_intro (lemma_map_blocks_vec_equiv_pre_k_aux #a w blocksize n f l l_v rem b_v ());
+      == { Classical.forall_intro (lemma_map_blocks_vec_equiv_pre_k_aux #a w blocksize n f l l_v rem b_v ());
              Seq.lemma_eq_intro (l_v n rem b_v) (map_blocks blocksize b_v f_sh l_sh) }
       Seq.append acc_v (l_v n rem b_v);
-      (==) { }
+      == { }
       repeat_gen_blocks_map_l (w * blocksize) n l_v n rem b_v acc_v;
       } end
 
@@ -713,14 +713,14 @@ let lemma_map_blocks_vec #a w blocksize inp n f l f_v l_v =
 
   calc (==) {
     map_blocks_acc blocksize_v 0 n inp f_v l_v Seq.empty;
-    (==) { map_blocks_acc_is_repeat_gen_blocks blocksize_v 0 n inp f_v l_v Seq.empty }
+    == { map_blocks_acc_is_repeat_gen_blocks blocksize_v 0 n inp f_v l_v Seq.empty }
     repeat_gen_blocks blocksize_v 0 n inp
       (map_blocks_a a blocksize_v n)
       (repeat_gen_blocks_map_f blocksize_v n f_v)
       (repeat_gen_blocks_map_l blocksize_v n l_v)
       Seq.empty;
 
-    (==) {
+    == {
       Classical.forall_intro_3 (lemma_map_blocks_multi_vec_equiv_pre #a w blocksize n (w * n + w) f f_v ());
       Classical.forall_intro_3 (lemma_map_blocks_vec_equiv_pre #a w blocksize n f l l_v ());
       lemma_repeat_gen_blocks_vec w blocksize inp n
@@ -738,7 +738,7 @@ let lemma_map_blocks_vec #a w blocksize inp n f l f_v l_v =
       (repeat_gen_blocks_map_l blocksize (w * n + w) l)
       Seq.empty;
 
-    (==) { map_blocks_acc_is_repeat_gen_blocks blocksize 0 (w * n + w) inp f l Seq.empty }
+    == { map_blocks_acc_is_repeat_gen_blocks blocksize 0 (w * n + w) inp f l Seq.empty }
     map_blocks_acc blocksize 0 (w * n + w) inp f l Seq.empty;
   };
 

--- a/providers/evercrypt/fst/EverCrypt.AEAD.fst
+++ b/providers/evercrypt/fst/EverCrypt.AEAD.fst
@@ -258,7 +258,7 @@ fun s iv iv_len ad ad_len plain plain_len cipher tag ->
           assert (Seq.equal (B.as_seq h0 hkeys_b) hkeys);
           calc (==) {
             Vale.Def.Types_s.le_bytes_to_seq_quad32 (Vale.Def.Words.Seq_s.seq_uint8_to_seq_nat8 hkeys);
-            (==) { Vale.Arch.Types.le_bytes_to_seq_quad32_to_bytes hkeys_quad }
+            == { Vale.Arch.Types.le_bytes_to_seq_quad32_to_bytes hkeys_quad }
             hkeys_quad;
           }
 
@@ -487,7 +487,7 @@ fun s iv iv_len ad ad_len cipher cipher_len tag dst ->
               assert (Seq.equal (B.as_seq h0 hkeys_b) hkeys);
               calc (==) {
               Vale.Def.Types_s.le_bytes_to_seq_quad32 (Vale.Def.Words.Seq_s.seq_uint8_to_seq_nat8 hkeys);
-              (==) { Vale.Arch.Types.le_bytes_to_seq_quad32_to_bytes hkeys_quad }
+              == { Vale.Arch.Types.le_bytes_to_seq_quad32_to_bytes hkeys_quad }
               hkeys_quad;
               }
 

--- a/providers/evercrypt/fst/EverCrypt.Hash.fst
+++ b/providers/evercrypt/fst/EverCrypt.Hash.fst
@@ -551,7 +551,7 @@ val modulo_sub_lemma (a : int) (b : nat) (c : pos) :
   (requires (b < c /\ (a - b) % c = 0))
   (ensures (b = a % c))
 let modulo_sub_lemma a b c =
-  calc== {
+  calc (==) {
     (a - b) % c;
   == { Math.Lemmas.lemma_mod_add_distr (-b) a c }
     ((a % c) - b) % c;

--- a/providers/evercrypt/fst/EverCrypt.Hash.fst
+++ b/providers/evercrypt/fst/EverCrypt.Hash.fst
@@ -551,9 +551,9 @@ val modulo_sub_lemma (a : int) (b : nat) (c : pos) :
   (requires (b < c /\ (a - b) % c = 0))
   (ensures (b = a % c))
 let modulo_sub_lemma a b c =
-  calc(==) {
+  calc== {
     (a - b) % c;
-  (==) { Math.Lemmas.lemma_mod_add_distr (-b) a c }
+  == { Math.Lemmas.lemma_mod_add_distr (-b) a c }
     ((a % c) - b) % c;
   };
   assert(- c < (a % c) - b);

--- a/specs/Spec.RSAPSS.fst
+++ b/specs/Spec.RSAPSS.fst
@@ -230,13 +230,13 @@ let os2ip_lemma emBits em =
 
     calc (<=) {
       pow2 ((emLen - 1) * 8) + pow2 ((emLen - 1) * 8) * v em.[0];
-      (==) { Math.Lemmas.distributivity_add_right (pow2 (8 * (emLen - 1))) 1 (v em.[0]) }
+      == { Math.Lemmas.distributivity_add_right (pow2 (8 * (emLen - 1))) 1 (v em.[0]) }
       pow2 (8 * (emLen - 1)) * (1 + v em.[0]);
-      (<=) { Math.Lemmas.lemma_mult_le_left (pow2 (8 * emLen - 1)) (v em.[0] + 1) (pow2 (emBits % 8)) }
+      <= { Math.Lemmas.lemma_mult_le_left (pow2 (8 * emLen - 1)) (v em.[0] + 1) (pow2 (emBits % 8)) }
       pow2 (8 * (emLen - 1)) * pow2 (emBits % 8);
-      (==) { Math.Lemmas.pow2_plus (8 * (emLen - 1)) (emBits % 8) }
+      == { Math.Lemmas.pow2_plus (8 * (emLen - 1)) (emBits % 8) }
       pow2 (8 * ((emBits - 1) / 8) + emBits % 8);
-      (<=) { aux emBits; Math.Lemmas.pow2_le_compat emBits ((emBits - 1) - (emBits - 1) % 8 + emBits % 8) }
+      <= { aux emBits; Math.Lemmas.pow2_le_compat emBits ((emBits - 1) - (emBits - 1) % 8 + emBits % 8) }
       pow2 emBits;
     };
    assert (nat_from_bytes_be em < pow2 emBits) end

--- a/specs/frodo/Spec.Frodo.Encode.fst
+++ b/specs/frodo/Spec.Frodo.Encode.fst
@@ -31,9 +31,9 @@ let ec logq b k =
 
   calc (<) {
     v k * pow2 (logq - b);
-    (<) { Math.Lemmas.lemma_mult_lt_right (pow2 (logq - b)) (v k) (pow2 b) }
+    < { Math.Lemmas.lemma_mult_lt_right (pow2 (logq - b)) (v k) (pow2 b) }
     pow2 b * pow2 (logq - b);
-    (==) { Math.Lemmas.pow2_plus b (logq - b) }
+    == { Math.Lemmas.pow2_plus b (logq - b) }
     pow2 logq;
     };
 
@@ -58,13 +58,13 @@ let dc logq b c =
 
   calc (==) {
     v res1;
-    (==) { }
+    == { }
     (((v c + pow2 (logq - b - 1) % modulus U16) % modulus U16) / pow2 (logq - b)) % modulus U16;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r (v c) (pow2 (logq - b - 1)) (modulus U16) }
+    == { Math.Lemmas.lemma_mod_plus_distr_r (v c) (pow2 (logq - b - 1)) (modulus U16) }
     (((v c + pow2 (logq - b - 1)) % modulus U16) / pow2 (logq - b)) % modulus U16;
-    (==) { Math.Lemmas.pow2_modulo_division_lemma_1 (v c + pow2 (logq - b - 1)) (logq - b) 16 }
+    == { Math.Lemmas.pow2_modulo_division_lemma_1 (v c + pow2 (logq - b - 1)) (logq - b) 16 }
     (((v c + pow2 (logq - b - 1)) / pow2 (logq - b)) % pow2 (16 - logq + b)) % modulus U16;
-    (==) { Math.Lemmas.pow2_modulo_modulo_lemma_2 ((v c + pow2 (logq - b - 1)) / pow2 (logq - b)) 16 (16 - logq + b) }
+    == { Math.Lemmas.pow2_modulo_modulo_lemma_2 ((v c + pow2 (logq - b - 1)) / pow2 (logq - b)) 16 (16 - logq + b) }
     ((v c + pow2 (logq - b - 1)) / pow2 (logq - b)) % pow2 (16 - logq + b);
     };
 
@@ -73,9 +73,9 @@ let dc logq b c =
 
   calc (==) {
     v res;
-    (==) { modulo_pow2_u16 res1 b }
+    == { modulo_pow2_u16 res1 b }
     v res1 % pow2 b;
-    (==) { Math.Lemmas.pow2_modulo_modulo_lemma_1 ((v c + pow2 (logq - b - 1)) / pow2 (logq - b)) b (16 - logq + b) }
+    == { Math.Lemmas.pow2_modulo_modulo_lemma_1 ((v c + pow2 (logq - b - 1)) / pow2 (logq - b)) b (16 - logq + b) }
     ((v c + pow2 (logq - b - 1)) / pow2 (logq - b)) % pow2 b;
     };
   res
@@ -99,9 +99,9 @@ let ec1 logq b x k =
 
   calc (==) {
     v rk;
-    (==) { modulo_pow2_u64 (x >>. size (b * k)) b }
+    == { modulo_pow2_u64 (x >>. size (b * k)) b }
     v (x >>. size (b * k)) % pow2 b;
-    (==) { }
+    == { }
     v x / pow2 (b * k) % pow2 b;
     };
 

--- a/specs/frodo/Spec.Frodo.Lemmas.fst
+++ b/specs/frodo/Spec.Frodo.Lemmas.fst
@@ -65,20 +65,20 @@ val lemma_frodo_sample2:
 let lemma_frodo_sample2 sign e =
   calc (==) {
     v ((lognot sign +. u16 1) ^. e);
-    (==) { logxor_spec (lognot sign +. u16 1) e }
+    == { logxor_spec (lognot sign +. u16 1) e }
     logxor_v #U16 (v (lognot sign +. u16 1)) (v e);
-    (==) { lognot_plus_one sign }
+    == { lognot_plus_one sign }
     logxor_v #U16 ((modulus U16 - v sign) % modulus U16) (v e);
-    (==) { UInt.logxor_commutative #16 ((modulus U16 - v sign) % modulus U16) (v e) }
+    == { UInt.logxor_commutative #16 ((modulus U16 - v sign) % modulus U16) (v e) }
     logxor_v #U16 (v e) ((modulus U16 - v sign) % modulus U16);
     };
 
   if v sign = 0 then begin
     calc (==) {
       logxor_v #U16 (v e) ((modulus U16 - v sign) % modulus U16);
-      (==) { Math.Lemmas.multiple_modulo_lemma 1 (modulus U16) }
+      == { Math.Lemmas.multiple_modulo_lemma 1 (modulus U16) }
       logxor_v #U16 (v e) 0;
-      (==) { UInt.logxor_lemma_1 #16 (v e) }
+      == { UInt.logxor_lemma_1 #16 (v e) }
       v e;
       };
     assert (v (((lognot sign +. u16 1) ^. e) +. sign) == v e);
@@ -88,11 +88,11 @@ let lemma_frodo_sample2 sign e =
   else begin
     calc (==) {
       logxor_v #U16 (v e) ((modulus U16 - v sign) % modulus U16);
-      (==) { Math.Lemmas.small_mod (modulus U16 - v sign) (modulus U16) }
+      == { Math.Lemmas.small_mod (modulus U16 - v sign) (modulus U16) }
       logxor_v #U16 (v e) (UInt.ones 16);
-      (==) { UInt.logxor_lemma_2 #16 (v e) }
+      == { UInt.logxor_lemma_2 #16 (v e) }
       lognot_v #U16 (v e);
-      (==) { UInt.lemma_lognot_value_mod #16 (v e) }
+      == { UInt.lemma_lognot_value_mod #16 (v e) }
       modulus U16 - v e - 1;
       };
     assert (v (((lognot sign +. u16 1) ^. e) +. sign) == (modulus U16 - v e) % modulus U16);

--- a/specs/frodo/Spec.Matrix.fst
+++ b/specs/frodo/Spec.Matrix.fst
@@ -24,11 +24,11 @@ val index_lt:
 let index_lt n1 n2 i j =
   calc (<=) {
     i * n2 + j;
-    (<=) { Math.Lemmas.lemma_mult_le_right n2 i (n1 - 1) }
+    <= { Math.Lemmas.lemma_mult_le_right n2 i (n1 - 1) }
     (n1 - 1) * n2 + j;
-    (==) { Math.Lemmas.distributivity_sub_left n1 1 n2 }
+    == { Math.Lemmas.distributivity_sub_left n1 1 n2 }
     n1 * n2 - n2 + j;
-    (<=) { }
+    <= { }
     n1 * n2 - 1;
     }
 
@@ -50,26 +50,26 @@ let index_neq #n1 #n2 i j i' j' =
   if i' < i then
     calc (<) {
       i' * n2 + j';
-      (<) { }
+      < { }
       i' * n2 + n2;
-      (==) { Math.Lemmas.distributivity_add_left i' 1 n2 }
+      == { Math.Lemmas.distributivity_add_left i' 1 n2 }
       (i' + 1) * n2;
-      (<=) { Math.Lemmas.lemma_mult_le_right n2 (i' + 1) i }
+      <= { Math.Lemmas.lemma_mult_le_right n2 (i' + 1) i }
       i * n2;
-      (<=) { }
+      <= { }
       i * n2 + j;
       }
   else if i = i' then ()
   else
     calc (<) {
       i * n2 + j;
-      (<) { }
+      < { }
       i * n2 + n2;
-      (==) { Math.Lemmas.distributivity_add_left i 1 n2 }
+      == { Math.Lemmas.distributivity_add_left i 1 n2 }
       (i + 1) * n2;
-      (<=) { Math.Lemmas.lemma_mult_le_right n2 (i + 1) i' }
+      <= { Math.Lemmas.lemma_mult_le_right n2 (i + 1) i' }
       i' * n2;
-      (<=) { }
+      <= { }
       i' * n2 + j';
       }
 

--- a/specs/lemmas/Spec.Ed25519.Lemmas.fst
+++ b/specs/lemmas/Spec.Ed25519.Lemmas.fst
@@ -133,15 +133,15 @@ let lemma_aff_double_aux x y =
 
   calc (==) {
     1 -% d *% (x *% x) *% (y *% y);
-    (==) { }
+    == { }
     1 -% (y *% y -% x *% x -% 1);
-    (==) { }
+    == { }
     (1 - (y *% y -% x *% x - 1) % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_sub_distr 1 (y *% y -% x *% x - 1) prime }
+    == { Math.Lemmas.lemma_mod_sub_distr 1 (y *% y -% x *% x - 1) prime }
     (2 - (y *% y - x *% x) % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_sub_distr 2 (y *% y - x *% x) prime }
+    == { Math.Lemmas.lemma_mod_sub_distr 2 (y *% y - x *% x) prime }
     (2 - (y *% y - x *% x)) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l (2 - y *% y) (x *% x) prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_l (2 - y *% y) (x *% x) prime }
     2 -% y *% y +% x *% x;
     }
 
@@ -163,33 +163,33 @@ let aff_point_at_infinity_lemma p =
 
   calc (==) {
     k1;
-    (==) { }
+    == { }
     x1 *% one +% y1 *% zero;
-    (==) { Math.Lemmas.small_mod x1 prime }
+    == { Math.Lemmas.small_mod x1 prime }
     x1;
     };
 
   calc (==) {
     k2;
-    (==) { }
+    == { }
     1 +% d *% (x1 *% zero) *% (y1 *% one);
-    (==) { }
+    == { }
     1;
     };
 
   calc (==) {
     k3;
-    (==) { }
+    == { }
     y1 *% one +% x1 *% zero;
-    (==) { Math.Lemmas.small_mod y1 prime }
+    == { Math.Lemmas.small_mod y1 prime }
     y1;
     };
 
   calc (==) {
     k4;
-    (==) { }
+    == { }
     1 -% d *% (x1 *% zero) *% (y1 *% one);
-    (==) { }
+    == { }
     1;
     };
 
@@ -214,31 +214,31 @@ let aff_point_double_lemma p =
 
   calc (==) {
     k1;
-    (==) { }
+    == { }
     x *% y +% y *% x;
-    (==) { assert (x *% y +% y *% x == 2 *% x *% y) by (ed25519_semiring ()) }
+    == { assert (x *% y +% y *% x == 2 *% x *% y) by (ed25519_semiring ()) }
     2 *% x *% y;
-    (==) { }
+    == { }
     k5;
     };
 
   calc (==) {
     k2;
-    (==) { }
+    == { }
     1 +% d *% (x *% x) *% (y *% y);
-    (==) { }
+    == { }
     y *% y -% x *% x;
-    (==) { }
+    == { }
     k6;
     };
 
   calc (==) {
     k4;
-    (==) { }
+    == { }
     1 -% d *% (x *% x) *% (y *% y);
-    (==) { lemma_aff_double_aux x y }
+    == { lemma_aff_double_aux x y }
     2 -% y *% y +% x *% x;
-    (==) { }
+    == { }
     k8;
     }
 
@@ -247,11 +247,11 @@ val lemma_neg_sqr: x:elem -> Lemma ((-x) % prime *% ((-x) % prime) == x *% x)
 let lemma_neg_sqr x =
   calc (==) {
     (- x) % prime * ((- x) % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (- x) ((- x) % prime) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (- x) ((- x) % prime) prime }
     (- x) * ((- x) % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (- x) (- x) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (- x) (- x) prime }
     (- x) * (- x) % prime;
-    (==) { Math.Lemmas.neg_mul_left x (- x); Math.Lemmas.neg_mul_right x x }
+    == { Math.Lemmas.neg_mul_left x (- x); Math.Lemmas.neg_mul_right x x }
     (x * x) % prime;
   }
 
@@ -295,9 +295,9 @@ let ext_dx1x2y1y2 p q =
   assert (x2 == _X2 /% _Z2 /\ y2 == _Y2 /% _Z2);
   calc (==) {
     d *% (x1 *% x2) *% (y1 *% y2);
-    (==) { fdiv_to_one_denominator _X1 _X2 _Z1 _Z2 }
+    == { fdiv_to_one_denominator _X1 _X2 _Z1 _Z2 }
     d *% (_X1 *% _X2 *% finv (_Z1 *% _Z2)) *% (y1 *% y2);
-    (==) { fdiv_to_one_denominator _Y1 _Y2 _Z1 _Z2 }
+    == { fdiv_to_one_denominator _Y1 _Y2 _Z1 _Z2 }
     d *% (_X1 *% _X2 *% finv (_Z1 *% _Z2)) *% (_Y1 *% _Y2 *% finv (_Z1 *% _Z2));
   };
   assert (
@@ -323,15 +323,15 @@ let ext_dx1x2y1y2_mulz1z2 p q =
 
   calc (==) {
     _Z1 *% _Z2 *% (d *% (x1 *% x2) *% (y1 *% y2));
-    (==) { ext_dx1x2y1y2 p q }
+    == { ext_dx1x2y1y2 p q }
     _Z1 *% _Z2 *% (d *% (_X1 *% _X2) *% (_Y1 *% _Y2) *% finv (_Z1 *% _Z2) *% finv (_Z1 *% _Z2));
-    (==) {
+    == {
       assert (
 	_Z1 *% _Z2 *% (d *% (_X1 *% _X2) *% (_Y1 *% _Y2) *% finv (_Z1 *% _Z2) *% finv (_Z1 *% _Z2)) ==
 	d *% (_X1 *% _X2) *% (_Y1 *% _Y2) *% finv (_Z1 *% _Z2) *% (finv (_Z1 *% _Z2) *% (_Z1 *% _Z2)))
        by (ed25519_semiring ()) }
     d *% (_X1 *% _X2) *% (_Y1 *% _Y2) *% finv (_Z1 *% _Z2) *% (finv (_Z1 *% _Z2) *% (_Z1 *% _Z2));
-    (==) { fmul_nonzero_lemma _Z1 _Z2; fdiv_one_lemma1 (d *% (_X1 *% _X2) *% (_Y1 *% _Y2) *% finv (_Z1 *% _Z2)) (_Z1 *% _Z2) }
+    == { fmul_nonzero_lemma _Z1 _Z2; fdiv_one_lemma1 (d *% (_X1 *% _X2) *% (_Y1 *% _Y2) *% finv (_Z1 *% _Z2)) (_Z1 *% _Z2) }
     d *% (_X1 *% _X2) *% (_Y1 *% _Y2) *% finv (_Z1 *% _Z2);
     }
 
@@ -355,11 +355,11 @@ let ext_x1x2_plus_y1y2 p q =
 
   calc (==) {
     x1 *% x2 +% y1 *% y2;
-    (==) { }
+    == { }
     _X1 *% finv _Z1 *% (_X2 *% finv _Z2) +% _Y1 *% finv _Z1 *% (_Y2 *% finv _Z2);
-    (==) { fdiv_to_one_denominator _X1 _X2 _Z1 _Z2; fdiv_to_one_denominator _Y1 _Y2 _Z1 _Z2 }
+    == { fdiv_to_one_denominator _X1 _X2 _Z1 _Z2; fdiv_to_one_denominator _Y1 _Y2 _Z1 _Z2 }
     _X1 *% _X2 *% finv (_Z1 *% _Z2) +% _Y1 *% _Y2 *% finv (_Z1 *% _Z2);
-    (==) { LM.lemma_mod_distributivity_add_left #prime (_X1 *% _X2) (_Y1 *% _Y2) (finv (_Z1 *% _Z2)) }
+    == { LM.lemma_mod_distributivity_add_left #prime (_X1 *% _X2) (_Y1 *% _Y2) (finv (_Z1 *% _Z2)) }
     (_X1 *% _X2 +% _Y1 *% _Y2) *% finv (_Z1 *% _Z2);
     }
 
@@ -383,11 +383,11 @@ let ext_x1y2_plus_y1x2 p q =
 
   calc (==) {
     x1 *% y2 +% y1 *% x2;
-    (==) { }
+    == { }
     _X1 *% finv _Z1 *% (_Y2 *% finv _Z2) +% _Y1 *% finv _Z1 *% (_X2 *% finv _Z2);
-    (==) { fdiv_to_one_denominator _X1 _Y2 _Z1 _Z2; fdiv_to_one_denominator _Y1 _X2 _Z1 _Z2 }
+    == { fdiv_to_one_denominator _X1 _Y2 _Z1 _Z2; fdiv_to_one_denominator _Y1 _X2 _Z1 _Z2 }
     _X1 *% _Y2 *% finv (_Z1 *% _Z2) +% _Y1 *% _X2 *% finv (_Z1 *% _Z2);
-    (==) { LM.lemma_mod_distributivity_add_left #prime (_X1 *% _Y2) (_Y1 *% _X2) (finv (_Z1 *% _Z2)) }
+    == { LM.lemma_mod_distributivity_add_left #prime (_X1 *% _Y2) (_Y1 *% _X2) (finv (_Z1 *% _Z2)) }
     (_X1 *% _Y2 +% _Y1 *% _X2) *% finv (_Z1 *% _Z2);
     }
 
@@ -406,11 +406,11 @@ let ext_yy_minus_xx p =
 
   calc (==) {
     y *% y -% x *% x;
-    (==) { }
+    == { }
     _Y *% finv _Z *% (_Y *% finv _Z) -% _X *% finv _Z *% (_X *% finv _Z);
-    (==) { fdiv_to_one_denominator _X _X _Z _Z; fdiv_to_one_denominator _Y _Y _Z _Z }
+    == { fdiv_to_one_denominator _X _X _Z _Z; fdiv_to_one_denominator _Y _Y _Z _Z }
     _Y *% _Y *% finv (_Z *% _Z) -% _X *% _X *% finv (_Z *% _Z);
-    (==) { LM.lemma_mod_distributivity_sub_left #prime (_Y *% _Y) (_X *% _X) (finv (_Z *% _Z)) }
+    == { LM.lemma_mod_distributivity_sub_left #prime (_Y *% _Y) (_X *% _X) (finv (_Z *% _Z)) }
     (_Y *% _Y -% _X *% _X) *% finv (_Z *% _Z);
     }
 
@@ -429,13 +429,13 @@ let ext_2_minus_yy_plus_xx p =
 
   calc (==) {
     2 -% y *% y +% x *% x;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l (2 - y *% y) (x *% x) prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_l (2 - y *% y) (x *% x) prime }
     (2 - y *% y + x *% x) % prime;
-    (==) { }
+    == { }
     (2 - (y *% y - x *% x)) % prime;
-    (==) { Math.Lemmas.lemma_mod_sub_distr 2 (y *% y - x *% x) prime }
+    == { Math.Lemmas.lemma_mod_sub_distr 2 (y *% y - x *% x) prime }
     (2 - (y *% y -% x *% x)) % prime;
-    (==) { ext_yy_minus_xx p }
+    == { ext_yy_minus_xx p }
     2 -% (_Y *% _Y -% _X *% _X) *% finv (_Z *% _Z);
     }
 
@@ -454,15 +454,15 @@ let ext_2_minus_yy_plus_xx_mul_zz p =
 
   calc (==) {
     (2 -% y *% y +% x *% x) *% (_Z *% _Z);
-    (==) { ext_2_minus_yy_plus_xx p }
+    == { ext_2_minus_yy_plus_xx p }
     (2 -% (_Y *% _Y -% _X *% _X) *% finv (_Z *% _Z)) *% (_Z *% _Z);
-    (==) { LM.lemma_mod_distributivity_sub_left #prime 2 ((_Y *% _Y -% _X *% _X) *% finv (_Z *% _Z)) (_Z *% _Z) }
+    == { LM.lemma_mod_distributivity_sub_left #prime 2 ((_Y *% _Y -% _X *% _X) *% finv (_Z *% _Z)) (_Z *% _Z) }
     2 *% (_Z *% _Z) -% (_Y *% _Y -% _X *% _X) *% finv (_Z *% _Z) *% (_Z *% _Z);
-    (==) { LM.lemma_mul_mod_assoc #prime (_Y *% _Y -% _X *% _X) (finv (_Z *% _Z)) (_Z *% _Z) }
+    == { LM.lemma_mul_mod_assoc #prime (_Y *% _Y -% _X *% _X) (finv (_Z *% _Z)) (_Z *% _Z) }
     2 *% (_Z *% _Z) -% (_Y *% _Y -% _X *% _X) *% (finv (_Z *% _Z) *% (_Z *% _Z));
-    (==) { LM.lemma_mul_mod_comm #prime (finv (_Z *% _Z)) (_Z *% _Z) }
+    == { LM.lemma_mul_mod_comm #prime (finv (_Z *% _Z)) (_Z *% _Z) }
     2 *% (_Z *% _Z) -% (_Y *% _Y -% _X *% _X) *% ((_Z *% _Z) *% finv (_Z *% _Z));
-    (==) { fmul_nonzero_lemma _Z _Z; fdiv_one_lemma1 (_Y *% _Y -% _X *% _X) (_Z *% _Z) }
+    == { fmul_nonzero_lemma _Z _Z; fdiv_one_lemma1 (_Y *% _Y -% _X *% _X) (_Z *% _Z) }
     2 *% (_Z *% _Z) -% (_Y *% _Y -% _X *% _X);
     }
 
@@ -484,22 +484,22 @@ let ext_denominator_lemma1 p q =
   let p1 = 1 +% d *% (x1 *% x2) *% (y1 *% y2) in
   calc (==) {
     _Z1 *% _Z2 *% p1;
-    (==) { LM.lemma_mod_distributivity_add_right #prime (_Z1 *% _Z2) one (d *% (x1 *% x2) *% (y1 *% y2)) }
+    == { LM.lemma_mod_distributivity_add_right #prime (_Z1 *% _Z2) one (d *% (x1 *% x2) *% (y1 *% y2)) }
     _Z1 *% _Z2 *% one +% _Z1 *% _Z2 *% (d *% (x1 *% x2) *% (y1 *% y2));
-    (==) { Math.Lemmas.small_mod (_Z1 *% _Z2) prime }
+    == { Math.Lemmas.small_mod (_Z1 *% _Z2) prime }
     _Z1 *% _Z2 +% _Z1 *% _Z2 *% (d *% (x1 *% x2) *% (y1 *% y2));
-    (==) { ext_dx1x2y1y2_mulz1z2 p q }
+    == { ext_dx1x2y1y2_mulz1z2 p q }
     _Z1 *% _Z2 +% d *% (_X1 *% _X2) *% (_Y1 *% _Y2) *% finv (_Z1 *% _Z2);
     };
 
   let p2 = 1 -% d *% (x1 *% x2) *% (y1 *% y2) in
   calc (==) {
     _Z1 *% _Z2 *% p2;
-    (==) { LM.lemma_mod_distributivity_sub_right #prime (_Z1 *% _Z2) one (d *% (x1 *% x2) *% (y1 *% y2)) }
+    == { LM.lemma_mod_distributivity_sub_right #prime (_Z1 *% _Z2) one (d *% (x1 *% x2) *% (y1 *% y2)) }
     _Z1 *% _Z2 *% one -% _Z1 *% _Z2 *% (d *% (x1 *% x2) *% (y1 *% y2));
-    (==) { Math.Lemmas.small_mod (_Z1 *% _Z2) prime }
+    == { Math.Lemmas.small_mod (_Z1 *% _Z2) prime }
     _Z1 *% _Z2 -% _Z1 *% _Z2 *% (d *% (x1 *% x2) *% (y1 *% y2));
-    (==) { ext_dx1x2y1y2_mulz1z2 p q }
+    == { ext_dx1x2y1y2_mulz1z2 p q }
     _Z1 *% _Z2 -% d *% (_X1 *% _X2) *% (_Y1 *% _Y2) *% finv (_Z1 *% _Z2);
     };
 
@@ -526,22 +526,22 @@ let ext_denominator_lemma2 p =
   let p2 = 1 -% d *% (x *% x) *% (y *% y) in
   calc (==) {
     p2 *% (_Z *% _Z);
-    (==) { lemma_aff_double_aux x y }
+    == { lemma_aff_double_aux x y }
     (2 -% y *% y +% x *% x) *% (_Z *% _Z);
-    (==) { ext_2_minus_yy_plus_xx_mul_zz p }
+    == { ext_2_minus_yy_plus_xx_mul_zz p }
     2 *% (_Z *% _Z) -% (_Y *% _Y -% _X *% _X);
     };
 
   let p1 = 1 +% d *% (x *% x) *% (y *% y) in
   calc (==) {
     p1 *% (_Z *% _Z);
-    (==) { }
+    == { }
     (y *% y -% x *% x) *% (_Z *% _Z);
-    (==) { ext_yy_minus_xx p }
+    == { ext_yy_minus_xx p }
     (_Y *% _Y -% _X *% _X) *% finv (_Z *% _Z) *% (_Z *% _Z);
-    (==) { LM.lemma_mul_mod_assoc #prime (_Y *% _Y -% _X *% _X) (finv (_Z *% _Z)) (_Z *% _Z) }
+    == { LM.lemma_mul_mod_assoc #prime (_Y *% _Y -% _X *% _X) (finv (_Z *% _Z)) (_Z *% _Z) }
     (_Y *% _Y -% _X *% _X) *% (finv (_Z *% _Z) *% (_Z *% _Z));
-    (==) { fmul_nonzero_lemma _Z _Z; fdiv_one_lemma1 (_Y *% _Y -% _X *% _X) (_Z *% _Z) }
+    == { fmul_nonzero_lemma _Z _Z; fdiv_one_lemma1 (_Y *% _Y -% _X *% _X) (_Z *% _Z) }
     (_Y *% _Y -% _X *% _X);
     };
 
@@ -578,29 +578,29 @@ let point_add_expand_eh_lemma p q =
 
   calc (==) { //a
     (_Y1 -% _X1) *% (_Y2 -% _X2);
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (_Y1 - _X1) (_Y2 -% _X2) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (_Y1 - _X1) (_Y2 -% _X2) prime }
     (_Y1 - _X1) * (_Y2 -% _X2) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (_Y1 - _X1) (_Y2 - _X2) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (_Y1 - _X1) (_Y2 - _X2) prime }
     (_Y1 - _X1) * (_Y2 - _X2) % prime;
-    (==) { Math.Lemmas.distributivity_sub_right (_Y1 - _X1) _Y2 _X2 }
+    == { Math.Lemmas.distributivity_sub_right (_Y1 - _X1) _Y2 _X2 }
     ((_Y1 - _X1) * _Y2 - (_Y1 - _X1) * _X2) % prime;
-    (==) { Math.Lemmas.distributivity_sub_left _Y1 _X1 _Y2 }
+    == { Math.Lemmas.distributivity_sub_left _Y1 _X1 _Y2 }
     (_Y1 * _Y2 - _X1 * _Y2 - (_Y1 - _X1) * _X2) % prime;
-    (==) { Math.Lemmas.distributivity_sub_left _Y1 _X1 _X2 }
+    == { Math.Lemmas.distributivity_sub_left _Y1 _X1 _X2 }
     (_Y1 * _Y2 - _X1 * _Y2 - _Y1 * _X2 + _X1 * _X2) % prime;
     };
 
   calc (==) { //b
     (_Y1 +% _X1) *% (_Y2 +% _X2);
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (_Y1 + _X1) (_Y2 +% _X2) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (_Y1 + _X1) (_Y2 +% _X2) prime }
     (_Y1 + _X1) * (_Y2 +% _X2) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r (_Y1 + _X1) (_Y2 + _X2) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r (_Y1 + _X1) (_Y2 + _X2) prime }
     (_Y1 + _X1) * (_Y2 + _X2) % prime;
-    (==) { Math.Lemmas.distributivity_add_right (_Y1 + _X1) _Y2 _X2 }
+    == { Math.Lemmas.distributivity_add_right (_Y1 + _X1) _Y2 _X2 }
     ((_Y1 + _X1) * _Y2 + (_Y1 + _X1) * _X2) % prime;
-    (==) { Math.Lemmas.distributivity_add_left _Y1 _X1 _Y2 }
+    == { Math.Lemmas.distributivity_add_left _Y1 _X1 _Y2 }
     (_Y1 * _Y2 + _X1 * _Y2 + (_Y1 + _X1) * _X2) % prime;
-    (==) { Math.Lemmas.distributivity_add_left _Y1 _X1 _X2 }
+    == { Math.Lemmas.distributivity_add_left _Y1 _X1 _X2 }
     (_Y1 * _Y2 + _X1 * _Y2 + _Y1 * _X2 + _X1 * _X2) % prime;
     };
 
@@ -608,45 +608,45 @@ let point_add_expand_eh_lemma p q =
   let p2 = _Y1 * _Y2 - _X1 * _Y2 - _Y1 * _X2 + _X1 * _X2 in
   calc (==) { //e = b -% a;
     (_Y1 +% _X1) *% (_Y2 +% _X2) -% (_Y1 -% _X1) *% (_Y2 -% _X2);
-    (==) { }
+    == { }
     (p1 % prime - p2 % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_sub_distr (p1 % prime) p2 prime }
+    == { Math.Lemmas.lemma_mod_sub_distr (p1 % prime) p2 prime }
     (p1 % prime - p2) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l p1 (- p2) prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_l p1 (- p2) prime }
     (p1 - p2) % prime;
-    (==) { }
+    == { }
     (_Y1 * _Y2 + _X1 * _Y2 + _Y1 * _X2 + _X1 * _X2 - _Y1 * _Y2 + _X1 * _Y2 + _Y1 * _X2 - _X1 * _X2) % prime;
-    (==) { }
+    == { }
     (_X1 * _Y2 + _Y1 * _X2 + _X1 * _Y2 + _Y1 * _X2) % prime;
-    (==) { }
+    == { }
     (2 * (_X1 * _Y2) + 2 * (_Y1 * _X2)) % prime;
-    (==) { Math.Lemmas.distributivity_add_right 2 (_X1 * _Y2) (_Y1 * _X2) }
+    == { Math.Lemmas.distributivity_add_right 2 (_X1 * _Y2) (_Y1 * _X2) }
     2 * (_X1 * _Y2 + _Y1 * _X2) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r 2 (_X1 * _Y2 + _Y1 * _X2) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r 2 (_X1 * _Y2 + _Y1 * _X2) prime }
     2 * ((_X1 * _Y2 + _Y1 * _X2) % prime) % prime;
-    (==) { Math.Lemmas.modulo_distributivity (_X1 * _Y2) (_Y1 * _X2) prime }
+    == { Math.Lemmas.modulo_distributivity (_X1 * _Y2) (_Y1 * _X2) prime }
     2 *% (_X1 *% _Y2 +% _Y1 *% _X2);
     };
 
   calc (==) { //h = b +% a;
     (_Y1 +% _X1) *% (_Y2 +% _X2) +% (_Y1 -% _X1) *% (_Y2 -% _X2);
-    (==) { }
+    == { }
     (p1 % prime + p2 % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r (p1 % prime) p2 prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_r (p1 % prime) p2 prime }
     (p1 % prime + p2) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l p1 p2 prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_l p1 p2 prime }
     (p1 + p2) % prime;
-    (==) { }
+    == { }
     (_Y1 * _Y2 + _X1 * _Y2 + _Y1 * _X2 + _X1 * _X2 + _Y1 * _Y2 - _X1 * _Y2 - _Y1 * _X2 + _X1 * _X2) % prime;
-    (==) { }
+    == { }
     (_Y1 * _Y2 + _X1 * _X2 + _Y1 * _Y2 + _X1 * _X2) % prime;
-    (==) { }
+    == { }
     (2 * (_Y1 * _Y2) + 2 * (_X1 * _X2)) % prime;
-    (==) { Math.Lemmas.distributivity_add_right 2 (_Y1 * _Y2) (_X1 * _X2) }
+    == { Math.Lemmas.distributivity_add_right 2 (_Y1 * _Y2) (_X1 * _X2) }
     2 * (_X1 * _X2 + _Y1 * _Y2) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r 2 (_X1 * _X2 + _Y1 * _Y2) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r 2 (_X1 * _X2 + _Y1 * _Y2) prime }
     2 * ((_X1 * _X2 + _Y1 * _Y2) % prime) % prime;
-    (==) { Math.Lemmas.modulo_distributivity (_X1 * _X2) (_Y1 * _Y2) prime }
+    == { Math.Lemmas.modulo_distributivity (_X1 * _X2) (_Y1 * _Y2) prime }
     2 *% (_X1 *% _X2 +% _Y1 *% _Y2);
     }
 
@@ -676,25 +676,25 @@ let point_add_expand_gf_lemma p q =
 
   calc (==) { //c
     d2 *% _T1 *% _T2;
-    (==) {
+    == {
       assert (
 	2 *% d *% (_X1 *% _Y1 *% finv _Z1) *% (_X2 *% _Y2 *% finv _Z2) ==
 	2 *% (d *% (_X1 *% _X2) *% (_Y1 *% _Y2) *% (finv _Z1 *% finv _Z2))) by (ed25519_semiring ()) }
     2 *% (d *% (_X1 *% _X2) *% (_Y1 *% _Y2) *% (finv _Z1 *% finv _Z2));
-    (==) { prime_lemma(); LM.lemma_inv_mod_both #prime _Z1 _Z2 }
+    == { prime_lemma(); LM.lemma_inv_mod_both #prime _Z1 _Z2 }
     2 *% (d *% (_X1 *% _X2) *% (_Y1 *% _Y2) *% finv (_Z1 *% _Z2));
-    (==) { }
+    == { }
     2 *% k;
     };
 
 
   calc (==) { //f == d1 -% c
     2 *% _Z1 *% _Z2 -% d2 *% _T1 *% _T2;
-    (==) { }
+    == { }
     2 *% _Z1 *% _Z2 -% 2 *% k;
-    (==) { LM.lemma_mul_mod_assoc #prime 2 _Z1 _Z2 }
+    == { LM.lemma_mul_mod_assoc #prime 2 _Z1 _Z2 }
     2 *% (_Z1 *% _Z2) -% 2 *% k;
-    (==) { LM.lemma_mod_distributivity_sub_right #prime 2 (_Z1 *% _Z2) k }
+    == { LM.lemma_mod_distributivity_sub_right #prime 2 (_Z1 *% _Z2) k }
     2 *% (_Z1 *% _Z2 -% k);
     };
 
@@ -702,11 +702,11 @@ let point_add_expand_gf_lemma p q =
 
   calc (==) { //g == d1 +% c
     2 *% _Z1 *% _Z2 +% d2 *% _T1 *% _T2;
-    (==) { }
+    == { }
     2 *% _Z1 *% _Z2 +% 2 *% k;
-    (==) { LM.lemma_mul_mod_assoc #prime 2 _Z1 _Z2 }
+    == { LM.lemma_mul_mod_assoc #prime 2 _Z1 _Z2 }
     2 *% (_Z1 *% _Z2) +% 2 *% k;
-    (==) { LM.lemma_mod_distributivity_add_right #prime 2 (_Z1 *% _Z2) k }
+    == { LM.lemma_mod_distributivity_add_right #prime 2 (_Z1 *% _Z2) k }
     2 *% (_Z1 *% _Z2 +% k);
     };
 
@@ -769,23 +769,23 @@ let fghe_relation f g h e =
 
   calc (==) {
     _Y3 /% _Z3;
-    (==) { }
+    == { }
     g *% h /% (f *% g);
-    (==) { LM.lemma_mul_mod_comm #prime g h; LM.lemma_mul_mod_comm #prime f g }
+    == { LM.lemma_mul_mod_comm #prime g h; LM.lemma_mul_mod_comm #prime f g }
     h *% g *% finv (g *% f);
-    (==) { fdiv_cancel_lemma h f g }
+    == { fdiv_cancel_lemma h f g }
     h /% f;
     };
 
   calc (==) {
     _X3 *% _Y3 /% _Z3;
-    (==) { LM.lemma_mul_mod_assoc #prime _X3 _Y3 (finv _Z3) }
+    == { LM.lemma_mul_mod_assoc #prime _X3 _Y3 (finv _Z3) }
     _X3 *% (_Y3 /% _Z3);
-    (==) { }
+    == { }
     e *% f *% (h /% f);
-    (==) { assert (e *% f *% (h *% finv f) == e *% h *% (f *% finv f)) by (ed25519_semiring ()) }
+    == { assert (e *% f *% (h *% finv f) == e *% h *% (f *% finv f)) by (ed25519_semiring ()) }
     e *% h *% (f *% finv f);
-    (==) { fdiv_one_lemma1 (e *% h) f }
+    == { fdiv_one_lemma1 (e *% h) f }
     e *% h;
     };
 
@@ -835,37 +835,37 @@ let to_aff_point_add_lemma p q =
 
   calc (==) { //_X3 /% _Z3
     e /% g;
-    (==) { }
+    == { }
     2 *% (_X1 *% _Y2 +% _Y1 *% _X2) /% (2 *% (_Z1 *% _Z2 +% k));
-    (==) { fdiv_cancel_lemma (_X1 *% _Y2 +% _Y1 *% _X2) (_Z1 *% _Z2 +% k) 2 }
+    == { fdiv_cancel_lemma (_X1 *% _Y2 +% _Y1 *% _X2) (_Z1 *% _Z2 +% k) 2 }
     (_X1 *% _Y2 +% _Y1 *% _X2) /% (_Z1 *% _Z2 +% k);
-    (==) { finv2_nonzero_lemma _Z1 _Z2; fdiv_cancel_lemma (_X1 *% _Y2 +% _Y1 *% _X2) (_Z1 *% _Z2 +% k) (finv (_Z1 *% _Z2)) }
+    == { finv2_nonzero_lemma _Z1 _Z2; fdiv_cancel_lemma (_X1 *% _Y2 +% _Y1 *% _X2) (_Z1 *% _Z2 +% k) (finv (_Z1 *% _Z2)) }
     (_X1 *% _Y2 +% _Y1 *% _X2) *% finv (_Z1 *% _Z2) /% ((_Z1 *% _Z2 +% k) *% finv (_Z1 *% _Z2));
-    (==) { ext_x1y2_plus_y1x2 p q }
+    == { ext_x1y2_plus_y1x2 p q }
     k1 /% ((_Z1 *% _Z2 +% k) *% finv (_Z1 *% _Z2));
-    (==) { LM.lemma_mod_distributivity_add_left #prime (_Z1 *% _Z2) k (finv (_Z1 *% _Z2)) }
+    == { LM.lemma_mod_distributivity_add_left #prime (_Z1 *% _Z2) k (finv (_Z1 *% _Z2)) }
     k1 /% (_Z1 *% _Z2 *% finv (_Z1 *% _Z2) +% k *% finv (_Z1 *% _Z2));
-    (==) { fmul_nonzero_lemma _Z1 _Z2; fdiv_lemma (_Z1 *% _Z2) }
+    == { fmul_nonzero_lemma _Z1 _Z2; fdiv_lemma (_Z1 *% _Z2) }
     k1 /% (1 +% k *% finv (_Z1 *% _Z2));
-    (==) { ext_dx1x2y1y2 p q }
+    == { ext_dx1x2y1y2 p q }
     k1 /% k2;
     };
 
   calc (==) { //_Y3 /% _Z3
     h /% f;
-    (==) { }
+    == { }
     2 *% (_X1 *% _X2 +% _Y1 *% _Y2) /% (2 *% (_Z1 *% _Z2 -% k));
-    (==) { fdiv_cancel_lemma (_X1 *% _X2 +% _Y1 *% _Y2) (_Z1 *% _Z2 -% k) 2 }
+    == { fdiv_cancel_lemma (_X1 *% _X2 +% _Y1 *% _Y2) (_Z1 *% _Z2 -% k) 2 }
     (_X1 *% _X2 +% _Y1 *% _Y2) /% (_Z1 *% _Z2 -% k);
-    (==) { finv2_nonzero_lemma _Z1 _Z2; fdiv_cancel_lemma (_X1 *% _X2 +% _Y1 *% _Y2) (_Z1 *% _Z2 -% k) (finv (_Z1 *% _Z2)) }
+    == { finv2_nonzero_lemma _Z1 _Z2; fdiv_cancel_lemma (_X1 *% _X2 +% _Y1 *% _Y2) (_Z1 *% _Z2 -% k) (finv (_Z1 *% _Z2)) }
     (_X1 *% _X2 +% _Y1 *% _Y2) *% finv (_Z1 *% _Z2) /% ((_Z1 *% _Z2 -% k) *% finv (_Z1 *% _Z2));
-    (==) { ext_x1x2_plus_y1y2 p q }
+    == { ext_x1x2_plus_y1y2 p q }
     k3 /% ((_Z1 *% _Z2 -% k) *% finv (_Z1 *% _Z2));
-    (==) { LM.lemma_mod_distributivity_sub_left #prime (_Z1 *% _Z2) k (finv (_Z1 *% _Z2)) }
+    == { LM.lemma_mod_distributivity_sub_left #prime (_Z1 *% _Z2) k (finv (_Z1 *% _Z2)) }
     k3 /% (_Z1 *% _Z2 *% finv (_Z1 *% _Z2) -% k *% finv (_Z1 *% _Z2));
-    (==) { fmul_nonzero_lemma _Z1 _Z2; fdiv_lemma (_Z1 *% _Z2) }
+    == { fmul_nonzero_lemma _Z1 _Z2; fdiv_lemma (_Z1 *% _Z2) }
     k3 /% (1 -% k *% finv (_Z1 *% _Z2));
-    (==) { ext_dx1x2y1y2 p q }
+    == { ext_dx1x2y1y2 p q }
     k3 /% k4;
     };
   assert (k1 /% k2 == _X3 /% _Z3 /\ k3 /% k4 == _Y3 /% _Z3);
@@ -896,25 +896,25 @@ let point_double_expand_eh_lemma p =
 
   calc (==) {
     h -% ((_X +% _Y) *% (_X +% _Y));
-    (==) { }
+    == { }
     (_X *% _X +% _Y *% _Y - (_X *% _X +% _Y *% _X +% (_X *% _Y +% _Y *% _Y))) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_l (_X *% _X + _Y *% _Y) (- (_X *% _X +% _Y *% _X +% (_X *% _Y +% _Y *% _Y))) prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_l (_X *% _X + _Y *% _Y) (- (_X *% _X +% _Y *% _X +% (_X *% _Y +% _Y *% _Y))) prime }
     (_X *% _X + _Y *% _Y - (_X *% _X +% _Y *% _X +% (_X *% _Y +% _Y *% _Y))) % prime;
-    (==) { Math.Lemmas.modulo_distributivity (_X *% _X + _Y *% _X) (_X *% _Y + _Y *% _Y) prime }
+    == { Math.Lemmas.modulo_distributivity (_X *% _X + _Y *% _X) (_X *% _Y + _Y *% _Y) prime }
     (_X *% _X + _Y *% _Y - (_X *% _X + _Y *% _X + (_X *% _Y + _Y *% _Y)) % prime) % prime;
-    (==) { Math.Lemmas.lemma_mod_sub_distr (_X *% _X + _Y *% _Y) (_X *% _X + _Y *% _X + (_X *% _Y + _Y *% _Y)) prime }
+    == { Math.Lemmas.lemma_mod_sub_distr (_X *% _X + _Y *% _Y) (_X *% _X + _Y *% _X + (_X *% _Y + _Y *% _Y)) prime }
     (_X *% _X + _Y *% _Y - (_X *% _X + _Y *% _X + (_X *% _Y + _Y *% _Y))) % prime;
-    (==) { }
+    == { }
     (_X *% _X + _Y *% _Y - _X *% _X - _Y *% _X - _X *% _Y - _Y *% _Y) % prime;
-    (==) { }
+    == { }
     (- _Y *% _X - _X *% _Y) % prime;
-    (==) { }
+    == { }
     (- 2 * (_X *% _Y)) % prime;
-    (==) { }
+    == { }
     ((- 1) * 2 * (_X *% _Y)) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (- 1) (2 * (_X *% _Y)) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (- 1) (2 * (_X *% _Y)) prime }
     ((- 1) % prime * (2 * (_X *% _Y))) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r ((- 1) % prime) (2 * (_X *% _Y)) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r ((- 1) % prime) (2 * (_X *% _Y)) prime }
     (- 1) % prime *% (2 *% (_X *% _Y));
     };
   assert (e == (- 1) % prime *% (2 *% (_X *% _Y)))
@@ -944,23 +944,23 @@ let point_double_expand_gf_lemma p =
 
   calc (==) { //g
     _X *% _X -% _Y *% _Y;
-    (==) { }
+    == { }
     (-1) * (_Y *% _Y - _X *% _X) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (- 1) (_Y *% _Y - _X *% _X) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (- 1) (_Y *% _Y - _X *% _X) prime }
     (-1) % prime * (_Y *% _Y - _X *% _X) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_r ((- 1) % prime) (_Y *% _Y - _X *% _X) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_r ((- 1) % prime) (_Y *% _Y - _X *% _X) prime }
     (-1) % prime *% (_Y *% _Y -% _X *% _X);
     };
 
   calc (==) { //f
     2 *% (_Z *% _Z) +% (_X *% _X -% _Y *% _Y);
-    (==) { }
+    == { }
     (2 *% (_Z *% _Z) + (_X *% _X -% _Y *% _Y)) % prime;
-    (==) { Math.Lemmas.lemma_mod_plus_distr_r (2 *% (_Z *% _Z)) (_X *% _X - _Y *% _Y) prime }
+    == { Math.Lemmas.lemma_mod_plus_distr_r (2 *% (_Z *% _Z)) (_X *% _X - _Y *% _Y) prime }
     (2 *% (_Z *% _Z) + (_X *% _X - _Y *% _Y)) % prime;
-    (==) { }
+    == { }
     (2 *% (_Z *% _Z) - (_Y *% _Y - _X *% _X)) % prime;
-    (==) { Math.Lemmas.lemma_mod_sub_distr (2 *% (_Z *% _Z)) (_Y *% _Y - _X *% _X) prime }
+    == { Math.Lemmas.lemma_mod_sub_distr (2 *% (_Z *% _Z)) (_Y *% _Y - _X *% _X) prime }
     (2 *% (_Z *% _Z) -% (_Y *% _Y -% _X *% _X));
     }
 
@@ -1032,35 +1032,35 @@ let to_aff_point_double_lemma p =
 
   calc (==) { //_X3 /% _Z3
     e /% g;
-    (==) { }
+    == { }
     (- 1) % prime *% (2 *% (_X *% _Y)) /% ((-1) % prime *% (_Y *% _Y -% _X *% _X));
-    (==) { fdiv_cancel_lemma (2 *% (_X *% _Y)) (_Y *% _Y -% _X *% _X) ((- 1) % prime) }
+    == { fdiv_cancel_lemma (2 *% (_X *% _Y)) (_Y *% _Y -% _X *% _X) ((- 1) % prime) }
     2 *% (_X *% _Y) /% (_Y *% _Y -% _X *% _X);
-    (==) { finv2_nonzero_lemma _Z _Z; fdiv_cancel_lemma (2 *% (_X *% _Y)) (_Y *% _Y -% _X *% _X) (finv (_Z *% _Z)) }
+    == { finv2_nonzero_lemma _Z _Z; fdiv_cancel_lemma (2 *% (_X *% _Y)) (_Y *% _Y -% _X *% _X) (finv (_Z *% _Z)) }
     2 *% (_X *% _Y) *% finv (_Z *% _Z) /% (finv (_Z *% _Z) *% (_Y *% _Y -% _X *% _X));
-    (==) { ext_yy_minus_xx p }
+    == { ext_yy_minus_xx p }
     2 *% (_X *% _Y) *% finv (_Z *% _Z) /% k2;
-    (==) { LM.lemma_mul_mod_assoc #prime 2 (_X *% _Y) (finv (_Z *% _Z)); fdiv_to_one_denominator _X _Y _Z _Z }
+    == { LM.lemma_mul_mod_assoc #prime 2 (_X *% _Y) (finv (_Z *% _Z)); fdiv_to_one_denominator _X _Y _Z _Z }
     2 *% (x *% y) /% k2;
-    (==) { LM.lemma_mul_mod_assoc #prime 2 x y }
+    == { LM.lemma_mul_mod_assoc #prime 2 x y }
     k1 /% k2;
     };
 
   calc (==) { //_Y3 /% _Z3
     h /% f;
-    (==) { }
+    == { }
     (_X *% _X +% _Y *% _Y) /% (2 *% (_Z *% _Z) -% (_Y *% _Y -% _X *% _X));
-    (==) { ext_2_minus_yy_plus_xx_mul_zz p }
+    == { ext_2_minus_yy_plus_xx_mul_zz p }
     (_X *% _X +% _Y *% _Y) /% (k4 *% (_Z *% _Z));
-    (==) { finv2_nonzero_lemma _Z _Z; fdiv_cancel_lemma (_X *% _X +% _Y *% _Y) (k4 *% (_Z *% _Z)) (finv (_Z *% _Z)) }
+    == { finv2_nonzero_lemma _Z _Z; fdiv_cancel_lemma (_X *% _X +% _Y *% _Y) (k4 *% (_Z *% _Z)) (finv (_Z *% _Z)) }
     (_X *% _X +% _Y *% _Y) *% finv (_Z *% _Z) /% (k4 *% (_Z *% _Z) *% finv (_Z *% _Z));
-    (==) { LM.lemma_mul_mod_assoc #prime k4 (_Z *% _Z) (finv (_Z *% _Z)) }
+    == { LM.lemma_mul_mod_assoc #prime k4 (_Z *% _Z) (finv (_Z *% _Z)) }
     (_X *% _X +% _Y *% _Y) *% finv (_Z *% _Z) /% (k4 *% ((_Z *% _Z) *% finv (_Z *% _Z)));
-    (==) { fmul_nonzero_lemma _Z _Z; fdiv_one_lemma1 k4 (_Z *% _Z) }
+    == { fmul_nonzero_lemma _Z _Z; fdiv_one_lemma1 k4 (_Z *% _Z) }
     (_X *% _X +% _Y *% _Y) *% finv (_Z *% _Z) /% k4;
-    (==) { LM.lemma_mod_distributivity_add_left #prime (_X *% _X) (_Y *% _Y) (finv (_Z *% _Z)) }
+    == { LM.lemma_mod_distributivity_add_left #prime (_X *% _X) (_Y *% _Y) (finv (_Z *% _Z)) }
     (_X *% _X *% finv (_Z *% _Z) +% _Y *% _Y *% finv (_Z *% _Z)) /% k4;
-    (==) { fdiv_to_one_denominator _X _X _Z _Z; fdiv_to_one_denominator _Y _Y _Z _Z }
+    == { fdiv_to_one_denominator _X _X _Z _Z; fdiv_to_one_denominator _Y _Y _Z _Z }
     k3 /% k4;
     };
   assert (k1 /% k2 == _X3 /% _Z3 /\ k3 /% k4 == _Y3 /% _Z3);
@@ -1079,11 +1079,11 @@ let to_aff_point_negate p =
   assert (y *% y -% x *% x == 1 +% d *% (x *% x) *% (y *% y));
   calc (==) {
     (-_X) % prime * finv _Z % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (-_X) (finv _Z) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (-_X) (finv _Z) prime }
     (-_X) * finv _Z % prime;
-    (==) { Math.Lemmas.neg_mul_left _X (finv _Z) }
+    == { Math.Lemmas.neg_mul_left _X (finv _Z) }
     (- (_X * finv _Z)) % prime;
-    (==) { Math.Lemmas.lemma_mod_sub_distr 0 (_X * finv _Z) prime }
+    == { Math.Lemmas.lemma_mod_sub_distr 0 (_X * finv _Z) prime }
     (- (_X *% finv _Z)) % prime;
     };
   lemma_neg_sqr (_X *% finv _Z);
@@ -1091,19 +1091,19 @@ let to_aff_point_negate p =
 
   calc (==) {
     ((-_X) % prime * _Y) % prime * finv _Z % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (-_X) _Y prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (-_X) _Y prime }
     ((-_X) * _Y) % prime * finv _Z % prime;
-    (==) { Math.Lemmas.neg_mul_left _X _Y }
+    == { Math.Lemmas.neg_mul_left _X _Y }
     (-(_X * _Y)) % prime * finv _Z % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (-(_X * _Y)) (finv _Z) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (-(_X * _Y)) (finv _Z) prime }
     (-(_X * _Y)) * finv _Z % prime;
-    (==) { Math.Lemmas.neg_mul_left (_X * _Y) (finv _Z) }
+    == { Math.Lemmas.neg_mul_left (_X * _Y) (finv _Z) }
     (-(_X * _Y * finv _Z)) % prime;
-    (==) { Math.Lemmas.lemma_mod_sub_distr 0 (_X * _Y * finv _Z) prime }
+    == { Math.Lemmas.lemma_mod_sub_distr 0 (_X * _Y * finv _Z) prime }
     (-(_X * _Y * finv _Z % prime)) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (_X * _Y) (finv _Z) prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (_X * _Y) (finv _Z) prime }
     (-(_X *% _Y *% finv _Z)) % prime;
-    (==) { }
+    == { }
     (-_T) % prime;
     };
   assert (is_ext p');
@@ -1116,11 +1116,11 @@ val fmul_both_lemma: a:elem -> b:elem -> c:elem -> Lemma
 let fmul_both_lemma a b c =
   calc (==) {
     (a * c) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l a c prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l a c prime }
     ((a % prime) * c) % prime;
-    (==) {  }
+    == {  }
     ((b % prime) * c) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l b c prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l b c prime }
     (b * c) % prime;
   }
 
@@ -1178,11 +1178,11 @@ let recover_x_lemma_aux y =
   let x2 = (y2 -% one) *% finv (d *% y2 +% one) in
   calc (==) {
     x2 *% (d *% y2 +% one);
-    (==) { }
+    == { }
     (y2 -% one) *% p *% (d *% y2 +% one);
-    (==) { Lib.NatMod.lemma_mul_mod_assoc #prime (y2 -% one) p (d *% y2 +% one) }
+    == { Lib.NatMod.lemma_mul_mod_assoc #prime (y2 -% one) p (d *% y2 +% one) }
     (y2 -% one) *% (p *% (d *% y2 +% one));
-    (==) { denominator_lemma1 y; fdiv_one_lemma1 (y2 -% one) (d *% y2 +% one) }
+    == { denominator_lemma1 y; fdiv_one_lemma1 (y2 -% one) (d *% y2 +% one) }
     y2 -% one;
     };
   assert (x2 *% (d *% y2 +% one) == y2 -% one);
@@ -1220,11 +1220,11 @@ let recover_x_lemma y sign =
 	  let x1 = (prime - x) % prime in
 	  calc (==) {
 	    x1 *% x1;
-	    (==) { }
+	    == { }
 	    (prime - x) % prime * ((prime - x) % prime) % prime;
-	    (==) { Math.Lemmas.modulo_addition_lemma (-x) prime 1 }
+	    == { Math.Lemmas.modulo_addition_lemma (-x) prime 1 }
 	    (- x) % prime * ((- x) % prime) % prime;
-	    (==) { lemma_neg_sqr x }
+	    == { lemma_neg_sqr x }
 	    (x * x) % prime;
 	    };
 	  assert (x1 *% x1 = x2);
@@ -1264,11 +1264,11 @@ let point_equal_lemma_aux1 a b c d e f =
   assert (a *% b *% f <> c *% d *% f);
   calc (==) {
     a *% b *% f;
-    (==) { lemma_fmul_assoc1 a b f }
+    == { lemma_fmul_assoc1 a b f }
     a *% f *% b;
-    (==) { fdiv_lemma1 a d e f }
+    == { fdiv_lemma1 a d e f }
     e *% d *% b;
-    (==) { lemma_fmul_assoc1 e d b }
+    == { lemma_fmul_assoc1 e d b }
     e *% b *% d;
     };
   lemma_fmul_assoc1 c d f;
@@ -1284,11 +1284,11 @@ let point_equal_lemma_aux2 a b c d e f =
   assert (a *% b *% f == c *% d *% f);
   calc (==) {
     a *% b *% f;
-    (==) { lemma_fmul_assoc1 a b f }
+    == { lemma_fmul_assoc1 a b f }
     a *% f *% b;
-    (==) { fdiv_lemma1 a d e f }
+    == { fdiv_lemma1 a d e f }
     e *% d *% b;
-    (==) { lemma_fmul_assoc1 e d b }
+    == { lemma_fmul_assoc1 e d b }
     e *% b *% d;
     };
   lemma_fmul_assoc1 c d f;

--- a/specs/lemmas/Spec.Hash.Lemmas.fst
+++ b/specs/lemmas/Spec.Hash.Lemmas.fst
@@ -91,17 +91,17 @@ let lemma_blocki_aux2 (a:blake_alg) (s1 s2:bytes) (nb1 nb2:nat) (i:nat{i < nb2})
     let a' = to_blake_alg a in
     calc (==) {
           Spec.Blake2.get_blocki a' s (i + nb1);
-          (==) { }
+          == { }
           S.slice s ((i + nb1) * block_length a) ((i + nb1 + 1) * block_length a);
-          (==) { }
+          == { }
           S.slice s (i * block_length a + nb1 * block_length a) ((i + 1) * block_length a + nb1 * block_length a);
-          (==) { }
+          == { }
           S.slice s (i * block_length a + S.length s1) ((i + 1) * block_length a + S.length s1);
-          (==) { S.slice_slice s (S.length s1) (S.length s) (i * block_length a) ((i+1) * block_length a) }
+          == { S.slice_slice s (S.length s1) (S.length s) (i * block_length a) ((i+1) * block_length a) }
           S.slice (S.slice s (S.length s1) (S.length s)) (i * block_length a) ((i+1) * block_length a);
-          (==) { S.append_slices s1 s2; assert (s2 `S.equal` S.slice s (S.length s1) (S.length s)) }
+          == { S.append_slices s1 s2; assert (s2 `S.equal` S.slice s (S.length s1) (S.length s)) }
           S.slice s2 (i * block_length a) ((i+1) * block_length a);
-          (==) { }
+          == { }
           Spec.Blake2.get_blocki a' s2 i;
         }
 
@@ -127,25 +127,25 @@ let lemma_update_aux2 (a:blake_alg) (s1 s2:bytes) (nb1 nb2:nat) (prevlen1 prevle
     // Proving totlen1 == totlen2 for the last calc step below
     calc (==) {
       totlen2;
-      (==) { }
+      == { }
       prevlen2 + (i + 1) * block_length a;
-      (==) { }
+      == { }
       prevlen1 + S.length s1 + (i + 1) * block_length a;
-      (==) { }
+      == { }
       prevlen1 + nb1 * block_length a + (i + 1) * block_length a;
-      (==) { Math.Lemmas.distributivity_add_left (i + 1) nb1 (block_length a) }
+      == { Math.Lemmas.distributivity_add_left (i + 1) nb1 (block_length a) }
       prevlen1 + (i + 1 + nb1) * block_length a;
-      (==) { }
+      == { }
       totlen1;
     };
 
     calc (==) {
       f1 (i + nb1) acc;
-      (==) { }
+      == { }
       blake2_update_block a' false false totlen1 (get_blocki a' s (i + nb1)) acc;
-      (==) { lemma_blocki_aux2 a s1 s2 nb1 nb2 i }
+      == { lemma_blocki_aux2 a s1 s2 nb1 nb2 i }
       blake2_update_block a' false false totlen1 (get_blocki a' s2 i) acc;
-      (==) { }
+      == { }
       f2 i acc;
 
     }
@@ -189,17 +189,17 @@ let update_multi_associative_blake (a: blake_alg)
     let fix = fixed_a (words_state a) in
     calc (==) {
       update_multi a h prevlen1 input;
-      (==) { }
+      == { }
       repeati #(words_state a) nb f h;
-      (==) { repeati_def nb f h }
+      == { repeati_def nb f h }
       repeat_right 0 nb fix f h;
-      (==) { repeat_right_plus 0 nb1 nb fix f h; repeati_def nb1 f h }
+      == { repeat_right_plus 0 nb1 nb fix f h; repeati_def nb1 f h }
       repeat_right nb1 nb fix f (repeati nb1 f h);
-      (==) { Classical.forall_intro_2 aux1; repeati_extensionality nb1 f f1 h }
+      == { Classical.forall_intro_2 aux1; repeati_extensionality nb1 f f1 h }
       repeat_right nb1 nb fix f (update_multi a h prevlen1 input1);
-      (==) { Classical.forall_intro_2 aux2; repeat_gen_right_extensionality nb2 nb1 fix fix f2 f (update_multi a h prevlen1 input1) }
+      == { Classical.forall_intro_2 aux2; repeat_gen_right_extensionality nb2 nb1 fix fix f2 f (update_multi a h prevlen1 input1) }
       repeat_right 0 nb2 fix f2 (update_multi a h prevlen1 input1);
-      (==) { repeati_def nb2 f2 (update_multi a h prevlen1 input1) }
+      == { repeati_def nb2 f2 (update_multi a h prevlen1 input1) }
       update_multi a (update_multi a h prevlen1 input1) prevlen2 input2;
     }
 

--- a/specs/lemmas/Spec.K256.Lemmas.fst
+++ b/specs/lemmas/Spec.K256.Lemmas.fst
@@ -65,11 +65,11 @@ let to_aff_point_negate_lemma p =
 
   calc (==) { // (-py) % prime /% pz;
     ((- py) % prime * pz_inv) % prime;
-    (==) { Math.Lemmas.lemma_mod_mul_distr_l (- py) pz_inv prime }
+    == { Math.Lemmas.lemma_mod_mul_distr_l (- py) pz_inv prime }
     (- py * pz_inv) % prime;
-    (==) { Math.Lemmas.neg_mul_left py pz_inv }
+    == { Math.Lemmas.neg_mul_left py pz_inv }
     (- (py * pz_inv)) % prime;
-    (==) { Math.Lemmas.lemma_mod_sub_distr 0 (py * pz_inv) prime }
+    == { Math.Lemmas.lemma_mod_sub_distr 0 (py * pz_inv) prime }
     (- (py * pz_inv) % prime) % prime; // (- py /% pz) % prime;
   }
 

--- a/specs/lemmas/Spec.MD.Incremental.fst
+++ b/specs/lemmas/Spec.MD.Incremental.fst
@@ -27,13 +27,13 @@ let md_is_hash_incremental
      let padding = pad a (S.length input) in
      calc (==) {
        update_last a (update_multi a s () blocks) (S.length blocks) rest;
-       (==) { }
+       == { }
        update_multi a (update_multi a s () blocks) () S.(rest @| padding);
-       (==) { update_multi_associative a s blocks S.(rest @| padding) }
+       == { update_multi_associative a s blocks S.(rest @| padding) }
        update_multi a s () S.(blocks @| (rest @| padding));
-       (==) { S.append_assoc blocks rest padding }
+       == { S.append_assoc blocks rest padding }
        update_multi a s () S.((blocks @| rest) @| padding);
-       (==) { }
+       == { }
        update_multi a s () S.(input @| padding);
      }
 #pop-options

--- a/specs/lemmas/Spec.SHA3.Incremental.fst
+++ b/specs/lemmas/Spec.SHA3.Incremental.fst
@@ -26,17 +26,17 @@ let update_is_update_multi (a:keccak_alg) (inp:bytes{S.length inp == block_lengt
     assert (bs == rateInBytes);
     calc (==) {
       update_multi a s () inp;
-      (==) { }
+      == { }
       Lib.Sequence.repeat_blocks_multi #_ #(words_state a) rateInBytes inp f s;
-      (==) { Lib.Sequence.lemma_repeat_blocks_multi #_ #(words_state a) bs inp f s }
+      == { Lib.Sequence.lemma_repeat_blocks_multi #_ #(words_state a) bs inp f s }
       (let len = S.length inp in
        let nb = len / bs in
       Loops.repeati #(words_state a) nb (Lib.Sequence.repeat_blocks_f bs inp f nb) s);
-      (==) {
+      == {
         Loops.unfold_repeati 1 f' s 0;
         Loops.eq_repeati0 1 f' s }
       f' 0 s;
-      (==) { assert (Seq.slice inp (0 * bs) (0 * bs + bs) `S.equal` inp) }
+      == { assert (Seq.slice inp (0 * bs) (0 * bs + bs) `S.equal` inp) }
       f inp s;
     }
 
@@ -56,20 +56,20 @@ val sha3_is_incremental1
 let sha3_is_incremental1 a input out_length =
   calc (==) {
        hash_incremental a input out_length;
-       (==) { }
+       == { }
        (let s = init a in
         let bs, l = split_blocks a input in
         let s = update_multi a s () bs in
         let s = update_last a s () l in
         finish a s out_length);
-       (==) { }
+       == { }
        (let s = Lib.Sequence.create 25 (u64 0) in
         let rateInBytes = rate a/8 in
         let bs, l = UpdateMulti.split_at_last_lazy rateInBytes input in
         let s = update_multi a s () bs in
         let s = update_last a s () l in
         finish a s out_length);
-       (==) { } (
+       == { } (
        let s = Lib.Sequence.create 25 (u64 0) in
        let rateInBytes = rate a / 8 in
        let delimitedSuffix = suffix a in
@@ -84,7 +84,7 @@ let sha3_is_incremental1 a input out_length =
          let s = Spec.SHA3.absorb_last delimitedSuffix rateInBytes (S.length l) l s in
        finish a s out_length
        );
-       (==) { (
+       == { (
          let s = Lib.Sequence.create 25 (u64 0) in
          let rateInBytes = rate a / 8 in
          let delimitedSuffix = suffix a in
@@ -108,7 +108,7 @@ let sha3_is_incremental1 a input out_length =
          let s = Spec.SHA3.absorb_last delimitedSuffix rateInBytes (S.length l) l s in
        finish a s out_length
        );
-       (==) { (
+       == { (
          let s = Lib.Sequence.create 25 (u64 0) in
          let rateInBytes = rate a / 8 in
          let delimitedSuffix = suffix a in
@@ -189,15 +189,15 @@ let sha3_is_incremental2
   let f = Spec.SHA3.absorb_inner rateInBytes in
   calc (==) {
     hash' a input out_length;
-    (==) { } (
+    == { } (
       let s = Spec.SHA3.absorb s rateInBytes (S.length input) input delimitedSuffix in
       Spec.SHA3.squeeze s rateInBytes (hash_length' a out_length)
       );
-   (==) { Lib.Sequence.lemma_repeat_blocks (block_length a) input f (Spec.SHA3.absorb_last delimitedSuffix rateInBytes) s } (
+   == { Lib.Sequence.lemma_repeat_blocks (block_length a) input f (Spec.SHA3.absorb_last delimitedSuffix rateInBytes) s } (
       let s = Loops.repeati #(words_state a) nb (Lib.Sequence.repeat_blocks_f (block_length a) input f nb) s in
       let s = Spec.SHA3.absorb_last delimitedSuffix rateInBytes (S.length l) l s in
       Spec.SHA3.squeeze s rateInBytes (hash_length' a out_length));
-   (==) {
+   == {
      Lib.Sequence.Lemmas.repeati_extensionality #(words_state a) nb
        (Lib.Sequence.repeat_blocks_f (block_length a) input f nb)
        (Lib.Sequence.repeat_blocks_f (block_length a) bs f nb)
@@ -206,7 +206,7 @@ let sha3_is_incremental2
       let s = Loops.repeati #(words_state a) nb (Lib.Sequence.repeat_blocks_f (block_length a) bs f nb) s in
       let s = Spec.SHA3.absorb_last delimitedSuffix rateInBytes (S.length l) l s in
       Spec.SHA3.squeeze s rateInBytes (hash_length' a out_length));
-   (==) { Lib.Sequence.lemma_repeat_blocks_multi #_ #(words_state a) (block_length a) bs f s } (
+   == { Lib.Sequence.lemma_repeat_blocks_multi #_ #(words_state a) (block_length a) bs f s } (
       let s = Lib.Sequence.repeat_blocks_multi #_ #(words_state a) (block_length a) bs f s in
       let s = Spec.SHA3.absorb_last delimitedSuffix rateInBytes (S.length l) l s in
       Spec.SHA3.squeeze s rateInBytes (hash_length' a out_length));

--- a/vale/code/arch/Vale.Arch.Types.fst
+++ b/vale/code/arch/Vale.Arch.Types.fst
@@ -393,9 +393,9 @@ let le_seq_quad32_to_bytes_to_seq_quad32 s =
   le_seq_quad32_to_bytes_reveal ();
   calc (==) {
     le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 s);
-    (==) { }
+    == { }
     seq_nat32_to_seq_nat8_LE (seq_four_to_seq_LE (seq_to_seq_four_LE (seq_nat8_to_seq_nat32_LE s)));
-    (==) { }
+    == { }
     s;
   }
 
@@ -708,39 +708,39 @@ let append_distributes_le_seq_quad32_to_bytes s1 s2 =
   le_seq_quad32_to_bytes_reveal ();
   calc (==) {
     le_seq_quad32_to_bytes (s1 @| s2);
-    (==) { }
+    == { }
     seq_nat32_to_seq_nat8_LE (seq_four_to_seq_LE (s1 @| s2));
-    (==) { append_distributes_seq_four_to_seq_LE s1 s2 }
+    == { append_distributes_seq_four_to_seq_LE s1 s2 }
     seq_nat32_to_seq_nat8_LE (seq_four_to_seq_LE s1 @| seq_four_to_seq_LE s2);
-    (==) { append_distributes_seq_map (nat_to_four 8) (seq_four_to_seq_LE s1) (seq_four_to_seq_LE s2) }
+    == { append_distributes_seq_map (nat_to_four 8) (seq_four_to_seq_LE s1) (seq_four_to_seq_LE s2) }
     seq_four_to_seq_LE (
       seq_map (nat_to_four 8) (seq_four_to_seq_LE s1) @|
       seq_map (nat_to_four 8) (seq_four_to_seq_LE s2));
-    (==) { append_distributes_seq_four_to_seq_LE
+    == { append_distributes_seq_four_to_seq_LE
          (seq_map (nat_to_four 8) (seq_four_to_seq_LE s1))
          (seq_map (nat_to_four 8) (seq_four_to_seq_LE s2)) }
       seq_four_to_seq_LE (seq_map (nat_to_four 8) (seq_four_to_seq_LE s1)) @|
       seq_four_to_seq_LE (seq_map (nat_to_four 8) (seq_four_to_seq_LE s2));
-    (==) { }
+    == { }
     le_seq_quad32_to_bytes s1 @| le_seq_quad32_to_bytes s2;
   }
 
 let append_distributes_be_seq_quad32_to_bytes s1 s2 =
   calc (==) {
     seq_nat32_to_seq_nat8_BE (seq_four_to_seq_BE (s1 @| s2));
-    (==) { }
+    == { }
     seq_nat32_to_seq_nat8_BE (seq_four_to_seq_BE (s1 @| s2));
-    (==) { append_distributes_seq_four_to_seq_BE s1 s2 }
+    == { append_distributes_seq_four_to_seq_BE s1 s2 }
     seq_nat32_to_seq_nat8_BE (seq_four_to_seq_BE s1 @| seq_four_to_seq_BE s2);
-    (==) { append_distributes_seq_map (nat_to_four 8) (seq_four_to_seq_BE s1) (seq_four_to_seq_BE s2) }
+    == { append_distributes_seq_map (nat_to_four 8) (seq_four_to_seq_BE s1) (seq_four_to_seq_BE s2) }
     seq_four_to_seq_BE (
       seq_map (nat_to_four 8) (seq_four_to_seq_BE s1) @|
       seq_map (nat_to_four 8) (seq_four_to_seq_BE s2));
-    (==) { append_distributes_seq_four_to_seq_BE
+    == { append_distributes_seq_four_to_seq_BE
          (seq_map (nat_to_four 8) (seq_four_to_seq_BE s1))
          (seq_map (nat_to_four 8) (seq_four_to_seq_BE s2)) }
       seq_four_to_seq_BE (seq_map (nat_to_four 8) (seq_four_to_seq_BE s1)) @|
       seq_four_to_seq_BE (seq_map (nat_to_four 8) (seq_four_to_seq_BE s2));
-    (==) { }
+    == { }
     seq_nat32_to_seq_nat8_BE (seq_four_to_seq_BE s1) @| seq_nat32_to_seq_nat8_BE (seq_four_to_seq_BE s2);
   }

--- a/vale/code/arch/x64/interop/Vale.Wrapper.X64.AES.fst
+++ b/vale/code/arch/x64/interop/Vale.Wrapper.X64.AES.fst
@@ -37,9 +37,9 @@ let aes128_key_expansion_stdcall input_b output_b =
        assert (Seq.equal (UV.as_seq h1 ub) (key_to_round_keys_LE AES_128 key));
        calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h1 output_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 output_b h1 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 output_b h1 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h1 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h1 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h1 ub) }
         UV.as_seq h1 ub;
       };
       le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h1 output_b))
@@ -68,9 +68,9 @@ let aes256_key_expansion_stdcall input_b output_b =
        assert (Seq.equal (UV.as_seq h1 ub) (key_to_round_keys_LE AES_256 key));
        calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h1 output_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 output_b h1 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 output_b h1 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h1 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h1 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h1 ub) }
         UV.as_seq h1 ub;
       };
       le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h1 output_b))

--- a/vale/code/arch/x64/interop/Vale.Wrapper.X64.GCM_IV.fst
+++ b/vale/code/arch/x64/interop/Vale.Wrapper.X64.GCM_IV.fst
@@ -149,19 +149,19 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
  // if B.length b > B.length b_start then (
    calc (==) {
      sf;
-     (==) { DV.length_eq b_start_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_start h;
+     == { DV.length_eq b_start_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_start h;
           le_bytes_to_seq_quad32_to_bytes (UV.as_seq h b_start_u) }
      wrap_slice (le_seq_quad32_to_bytes (Seq.append
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
        (UV.as_seq h b_extra_u)))
      (B.length b);
-     (==) { DV.length_eq b_extra_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_extra h;
+     == { DV.length_eq b_extra_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_extra h;
        le_bytes_to_seq_quad32_to_bytes (UV.as_seq h b_extra_u) }
      wrap_slice (le_seq_quad32_to_bytes (Seq.append
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))))
      (B.length b);
-     (==) { append_distributes_le_seq_quad32_to_bytes
+     == { append_distributes_le_seq_quad32_to_bytes
         (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
         (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
         }
@@ -169,13 +169,13 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
        (le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start))))
        (le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))))
      (B.length b);
-     (==) { le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start));
+     == { le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start));
             le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)) }
      wrap_slice (Seq.append
        (seq_uint8_to_seq_nat8 (B.as_seq h b_start))
        (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
      (B.length b);
-     (==) { Seq.lemma_eq_intro b_f
+     == { Seq.lemma_eq_intro b_f
        (wrap_slice (Seq.append
          (seq_uint8_to_seq_nat8 (B.as_seq h b_start))
          (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
@@ -198,20 +198,20 @@ let lemma_slice_sub (b:uint8_p) (b_sub:uint8_p) (b_extra:uint8_p) (h:HS.mem) : L
   ) =
   calc (==) {
     Seq.slice (Seq.append (B.as_seq h b_sub) (B.as_seq h b_extra)) 0 (B.length b);
-    (==) { Seq.lemma_eq_intro
+    == { Seq.lemma_eq_intro
      (Seq.slice (Seq.append (B.as_seq h b_sub) (B.as_seq h b_extra)) 0 (B.length b))
      (Seq.append (B.as_seq h b_sub) (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16)))
     }
     Seq.append (B.as_seq h b_sub) (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16));
-    (==) { }
+    == { }
     Seq.append
       (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
       (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16));
-    (==) { }
+    == { }
     Seq.append
       (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
       (Seq.slice (B.as_seq h b) (B.length b_sub) (B.length b));
-    (==) { Seq.lemma_eq_intro (B.as_seq h b)
+    == { Seq.lemma_eq_intro (B.as_seq h b)
       (Seq.append
         (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
         (Seq.slice (B.as_seq h b) (B.length b_sub) (B.length b)))
@@ -274,9 +274,9 @@ let compute_iv a key full_iv_b num_bytes j0_b extra_b hkeys_b =
 
     calc (==) {
       le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 hkeys_b));
-      (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 hkeys_b h0 }
+      == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 hkeys_b h0 }
       le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h0 ub))));
-      (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
+      == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
       UV.as_seq h0 ub;
     };
 
@@ -300,9 +300,9 @@ let compute_iv a key full_iv_b num_bytes j0_b extra_b hkeys_b =
       UV.length_eq ub;
       calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h1 hkeys_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 hkeys_b h1 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 hkeys_b h1 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h1 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h1 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h1 ub) }
         UV.as_seq h1 ub;
       }
 

--- a/vale/code/arch/x64/interop/Vale.Wrapper.X64.GCMdecryptOpt.fst
+++ b/vale/code/arch/x64/interop/Vale.Wrapper.X64.GCMdecryptOpt.fst
@@ -249,7 +249,7 @@ let gcm128_decrypt_opt' key iv auth_b auth_bytes auth_num keys_b iv_b hkeys_b ab
 
   calc (<=) {
     256 * ((16 * UInt64.v len128_num) / 16);
-    (==) {  FStar.Math.Lemmas.cancel_mul_div (UInt64.v len128_num) 16 }
+    == {  FStar.Math.Lemmas.cancel_mul_div (UInt64.v len128_num) 16 }
     256 * (UInt64.v len128_num);
     ( <= ) { assert_norm (256 <= 4096); FStar.Math.Lemmas.lemma_mult_le_right (UInt64.v len128_num) 256 4096 }
     4096 * (UInt64.v len128_num);
@@ -457,15 +457,15 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
     let bs = UV.as_seq h b_u in
     calc (==) {
       Seq.length split_bs;
-      (==) { }
+      == { }
       Seq.length (UV.as_seq h b1_u) + Seq.length (UV.as_seq h b2_u);
-      (==) { UV.length_eq b1_u; UV.length_eq b2_u }
+      == { UV.length_eq b1_u; UV.length_eq b2_u }
       DV.length b1_d / 16 + DV.length b2_d / 16;
-      (==) { DV.length_eq b1_d; DV.length_eq b2_d; math_aux (B.length b1); math_aux (B.length b2) }
+      == { DV.length_eq b1_d; DV.length_eq b2_d; math_aux (B.length b1); math_aux (B.length b2) }
       B.length b1 / 16 + B.length b2 / 16;
-      (==) { }
+      == { }
       B.length b / 16;
-      (==) { DV.length_eq b_d; UV.length_eq b_u; math_aux (B.length b) }
+      == { DV.length_eq b_d; UV.length_eq b_u; math_aux (B.length b) }
       Seq.length bs;
     };
     assert (Seq.length bs == Seq.length split_bs);
@@ -475,13 +475,13 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
         lemma_same_seq_dv h b;
         calc (==) {
           Seq.index bs i;
-          (==) { UV.as_seq_sel h b_u i }
+          == { UV.as_seq_sel h b_u i }
           UV.sel h b_u i;
-          (==) { UV.get_sel h b_u i }
+          == { UV.get_sel h b_u i }
           Vale.Interop.Views.get128 (Seq.slice (DV.as_seq h b_d) (i * 16) (i * 16 + 16));
-          (==) { lemma_same_seq_dv h b }
+          == { lemma_same_seq_dv h b }
           Vale.Interop.Views.get128 (Seq.slice (B.as_seq h b) (i * 16) (i * 16 + 16));
-          (==) { assert (Seq.equal (B.as_seq h b) (Seq.append (B.as_seq h b1) (B.as_seq h b2))) }
+          == { assert (Seq.equal (B.as_seq h b) (Seq.append (B.as_seq h b1) (B.as_seq h b2))) }
           Vale.Interop.Views.get128 (Seq.slice (Seq.append (B.as_seq h b1) (B.as_seq h b2)) (i * 16) (i * 16 + 16));
         };
         if i < Seq.length (UV.as_seq h b1_u) then (
@@ -489,13 +489,13 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
           UV.length_eq b1_u;
           calc (==) {
             Vale.Interop.Views.get128 (Seq.slice (Seq.append (B.as_seq h b1) (B.as_seq h b2)) (i * 16) (i * 16 + 16));
-            (==) { }
+            == { }
             Vale.Interop.Views.get128 (Seq.slice (B.as_seq h b1) (i * 16) (i * 16 + 16));
-            (==) { UV.get_sel h b1_u i }
+            == { UV.get_sel h b1_u i }
             UV.sel h b1_u i;
-            (==) { UV.as_seq_sel h b1_u i }
+            == { UV.as_seq_sel h b1_u i }
             Seq.index (UV.as_seq h b1_u) i;
-            (==) { }
+            == { }
             Seq.index split_bs i;
           }
         ) else (
@@ -504,13 +504,13 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
           let j = i - UV.length b1_u in
           calc (==) {
             Vale.Interop.Views.get128 (Seq.slice (Seq.append (B.as_seq h b1) (B.as_seq h b2)) (i * 16) (i * 16 + 16));
-            (==) { }
+            == { }
             Vale.Interop.Views.get128 (Seq.slice (B.as_seq h b2) (j * 16) (j * 16 + 16));
-            (==) { UV.get_sel h b2_u j }
+            == { UV.get_sel h b2_u j }
             UV.sel h b2_u j;
-            (==) { UV.as_seq_sel h b2_u j }
+            == { UV.as_seq_sel h b2_u j }
             Seq.index (UV.as_seq h b2_u) j;
-            (==) { }
+            == { }
             Seq.index split_bs i;
           }
        )
@@ -540,9 +540,9 @@ let gcm128_decrypt_opt_alloca key iv cipher_b cipher_len auth_b auth_bytes iv_b
          (key_to_round_keys_LE AES_128 (Ghost.reveal key)));
       calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 keys_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 keys_b h0 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 keys_b h0 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h0 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
         UV.as_seq h0 ub;
       }
 
@@ -559,9 +559,9 @@ let gcm128_decrypt_opt_alloca key iv cipher_b cipher_len auth_b auth_bytes iv_b
       let ub = UV.mk_buffer db Vale.Interop.Views.up_view128 in
       calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 hkeys_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 hkeys_b h0 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 hkeys_b h0 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h0 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
         UV.as_seq h0 ub;
       }
 
@@ -573,11 +573,11 @@ let gcm128_decrypt_opt_alloca key iv cipher_b cipher_len auth_b auth_bytes iv_b
   calc (==) {
     compute_iv_BE (aes_encrypt_LE AES_128 (Ghost.reveal key) (Mkfour 0 0 0 0))
                   (Ghost.reveal iv);
-    (==) { }
+    == { }
     le_bytes_to_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 iv_b));
-    (==) { gcm_simplify2 iv_b h0 }
+    == { gcm_simplify2 iv_b h0 }
     le_bytes_to_quad32 (le_quad32_to_bytes (low_buffer_read TUInt8 TUInt128 h0 iv_b 0));
-    (==) { le_bytes_to_quad32_to_bytes (low_buffer_read TUInt8 TUInt128 h0 iv_b 0) }
+    == { le_bytes_to_quad32_to_bytes (low_buffer_read TUInt8 TUInt128 h0 iv_b 0) }
     low_buffer_read TUInt8 TUInt128 h0 iv_b 0;
   };
 
@@ -799,19 +799,19 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
  // if B.length b > B.length b_start then (
    calc (==) {
      sf;
-     (==) { DV.length_eq b_start_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_start h;
+     == { DV.length_eq b_start_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_start h;
           le_bytes_to_seq_quad32_to_bytes (UV.as_seq h b_start_u) }
      wrap_slice (le_seq_quad32_to_bytes (Seq.append
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
        (UV.as_seq h b_extra_u)))
      (B.length b);
-     (==) { DV.length_eq b_extra_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_extra h;
+     == { DV.length_eq b_extra_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_extra h;
        le_bytes_to_seq_quad32_to_bytes (UV.as_seq h b_extra_u) }
      wrap_slice (le_seq_quad32_to_bytes (Seq.append
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))))
      (B.length b);
-     (==) { append_distributes_le_seq_quad32_to_bytes
+     == { append_distributes_le_seq_quad32_to_bytes
         (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
         (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
         }
@@ -819,13 +819,13 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
        (le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start))))
        (le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))))
      (B.length b);
-     (==) { le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start));
+     == { le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start));
             le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)) }
      wrap_slice (Seq.append
        (seq_uint8_to_seq_nat8 (B.as_seq h b_start))
        (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
      (B.length b);
-     (==) { Seq.lemma_eq_intro b_f
+     == { Seq.lemma_eq_intro b_f
        (wrap_slice (Seq.append
          (seq_uint8_to_seq_nat8 (B.as_seq h b_start))
          (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
@@ -836,12 +836,12 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
  // ) else (
  //   calc (==) {
  //     sf;
- //     (==) { }
+ //     == { }
  //     wrap_slice (le_seq_quad32_to_bytes (UV.as_seq h b_start_u)) (B.length b);
- //     (==) {    DV.length_eq (get_downview b_start);
+ //     == {    DV.length_eq (get_downview b_start);
  //               gcm_simplify1 b_start h (B.length b) }
  //     seq_uint8_to_seq_nat8 (B.as_seq h b_start);
- //     (==) { }
+ //     == { }
  //     b_f;
  //   }
  // )
@@ -860,20 +860,20 @@ let lemma_slice_sub (b:uint8_p) (b_sub:uint8_p) (b_extra:uint8_p) (h:HS.mem) : L
   ) =
   calc (==) {
     Seq.slice (Seq.append (B.as_seq h b_sub) (B.as_seq h b_extra)) 0 (B.length b);
-    (==) { Seq.lemma_eq_intro
+    == { Seq.lemma_eq_intro
      (Seq.slice (Seq.append (B.as_seq h b_sub) (B.as_seq h b_extra)) 0 (B.length b))
      (Seq.append (B.as_seq h b_sub) (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16)))
     }
     Seq.append (B.as_seq h b_sub) (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16));
-    (==) { }
+    == { }
     Seq.append
       (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
       (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16));
-    (==) { }
+    == { }
     Seq.append
       (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
       (Seq.slice (B.as_seq h b) (B.length b_sub) (B.length b));
-    (==) { Seq.lemma_eq_intro (B.as_seq h b)
+    == { Seq.lemma_eq_intro (B.as_seq h b)
       (Seq.append
         (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
         (Seq.slice (B.as_seq h b) (B.length b_sub) (B.length b)))

--- a/vale/code/arch/x64/interop/Vale.Wrapper.X64.GCMdecryptOpt256.fst
+++ b/vale/code/arch/x64/interop/Vale.Wrapper.X64.GCMdecryptOpt256.fst
@@ -249,7 +249,7 @@ let gcm256_decrypt_opt' key iv auth_b auth_bytes auth_num keys_b iv_b hkeys_b ab
 
   calc (<=) {
     256 * ((16 * UInt64.v len128_num) / 16);
-    (==) {  FStar.Math.Lemmas.cancel_mul_div (UInt64.v len128_num) 16 }
+    == {  FStar.Math.Lemmas.cancel_mul_div (UInt64.v len128_num) 16 }
     256 * (UInt64.v len128_num);
     ( <= ) { assert_norm (256 <= 4096); FStar.Math.Lemmas.lemma_mult_le_right (UInt64.v len128_num) 256 4096 }
     4096 * (UInt64.v len128_num);
@@ -454,15 +454,15 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
     let bs = UV.as_seq h b_u in
     calc (==) {
       Seq.length split_bs;
-      (==) { }
+      == { }
       Seq.length (UV.as_seq h b1_u) + Seq.length (UV.as_seq h b2_u);
-      (==) { UV.length_eq b1_u; UV.length_eq b2_u }
+      == { UV.length_eq b1_u; UV.length_eq b2_u }
       DV.length b1_d / 16 + DV.length b2_d / 16;
-      (==) { DV.length_eq b1_d; DV.length_eq b2_d; math_aux (B.length b1); math_aux (B.length b2) }
+      == { DV.length_eq b1_d; DV.length_eq b2_d; math_aux (B.length b1); math_aux (B.length b2) }
       B.length b1 / 16 + B.length b2 / 16;
-      (==) { }
+      == { }
       B.length b / 16;
-      (==) { DV.length_eq b_d; UV.length_eq b_u; math_aux (B.length b) }
+      == { DV.length_eq b_d; UV.length_eq b_u; math_aux (B.length b) }
       Seq.length bs;
     };
     assert (Seq.length bs == Seq.length split_bs);
@@ -472,13 +472,13 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
         lemma_same_seq_dv h b;
         calc (==) {
           Seq.index bs i;
-          (==) { UV.as_seq_sel h b_u i }
+          == { UV.as_seq_sel h b_u i }
           UV.sel h b_u i;
-          (==) { UV.get_sel h b_u i }
+          == { UV.get_sel h b_u i }
           Vale.Interop.Views.get128 (Seq.slice (DV.as_seq h b_d) (i * 16) (i * 16 + 16));
-          (==) { lemma_same_seq_dv h b }
+          == { lemma_same_seq_dv h b }
           Vale.Interop.Views.get128 (Seq.slice (B.as_seq h b) (i * 16) (i * 16 + 16));
-          (==) { assert (Seq.equal (B.as_seq h b) (Seq.append (B.as_seq h b1) (B.as_seq h b2))) }
+          == { assert (Seq.equal (B.as_seq h b) (Seq.append (B.as_seq h b1) (B.as_seq h b2))) }
           Vale.Interop.Views.get128 (Seq.slice (Seq.append (B.as_seq h b1) (B.as_seq h b2)) (i * 16) (i * 16 + 16));
         };
         if i < Seq.length (UV.as_seq h b1_u) then (
@@ -486,13 +486,13 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
           UV.length_eq b1_u;
           calc (==) {
             Vale.Interop.Views.get128 (Seq.slice (Seq.append (B.as_seq h b1) (B.as_seq h b2)) (i * 16) (i * 16 + 16));
-            (==) { }
+            == { }
             Vale.Interop.Views.get128 (Seq.slice (B.as_seq h b1) (i * 16) (i * 16 + 16));
-            (==) { UV.get_sel h b1_u i }
+            == { UV.get_sel h b1_u i }
             UV.sel h b1_u i;
-            (==) { UV.as_seq_sel h b1_u i }
+            == { UV.as_seq_sel h b1_u i }
             Seq.index (UV.as_seq h b1_u) i;
-            (==) { }
+            == { }
             Seq.index split_bs i;
           }
         ) else (
@@ -501,13 +501,13 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
           let j = i - UV.length b1_u in
           calc (==) {
             Vale.Interop.Views.get128 (Seq.slice (Seq.append (B.as_seq h b1) (B.as_seq h b2)) (i * 16) (i * 16 + 16));
-            (==) { }
+            == { }
             Vale.Interop.Views.get128 (Seq.slice (B.as_seq h b2) (j * 16) (j * 16 + 16));
-            (==) { UV.get_sel h b2_u j }
+            == { UV.get_sel h b2_u j }
             UV.sel h b2_u j;
-            (==) { UV.as_seq_sel h b2_u j }
+            == { UV.as_seq_sel h b2_u j }
             Seq.index (UV.as_seq h b2_u) j;
-            (==) { }
+            == { }
             Seq.index split_bs i;
           }
        )
@@ -537,9 +537,9 @@ let gcm256_decrypt_opt_alloca key iv cipher_b cipher_len auth_b auth_bytes iv_b
          (key_to_round_keys_LE AES_256 (Ghost.reveal key)));
       calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 keys_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 keys_b h0 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 keys_b h0 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h0 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
         UV.as_seq h0 ub;
       }
 
@@ -556,9 +556,9 @@ let gcm256_decrypt_opt_alloca key iv cipher_b cipher_len auth_b auth_bytes iv_b
       let ub = UV.mk_buffer db Vale.Interop.Views.up_view128 in
       calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 hkeys_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 hkeys_b h0 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 hkeys_b h0 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h0 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
         UV.as_seq h0 ub;
       }
 
@@ -570,11 +570,11 @@ let gcm256_decrypt_opt_alloca key iv cipher_b cipher_len auth_b auth_bytes iv_b
   calc (==) {
     compute_iv_BE (aes_encrypt_LE AES_256 (Ghost.reveal key) (Mkfour 0 0 0 0))
                   (Ghost.reveal iv);
-    (==) { }
+    == { }
     le_bytes_to_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 iv_b));
-    (==) { gcm_simplify2 iv_b h0 }
+    == { gcm_simplify2 iv_b h0 }
     le_bytes_to_quad32 (le_quad32_to_bytes (low_buffer_read TUInt8 TUInt128 h0 iv_b 0));
-    (==) { le_bytes_to_quad32_to_bytes (low_buffer_read TUInt8 TUInt128 h0 iv_b 0) }
+    == { le_bytes_to_quad32_to_bytes (low_buffer_read TUInt8 TUInt128 h0 iv_b 0) }
     low_buffer_read TUInt8 TUInt128 h0 iv_b 0;
   };
 
@@ -796,19 +796,19 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
  // if B.length b > B.length b_start then (
    calc (==) {
      sf;
-     (==) { DV.length_eq b_start_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_start h;
+     == { DV.length_eq b_start_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_start h;
           le_bytes_to_seq_quad32_to_bytes (UV.as_seq h b_start_u) }
      wrap_slice (le_seq_quad32_to_bytes (Seq.append
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
        (UV.as_seq h b_extra_u)))
      (B.length b);
-     (==) { DV.length_eq b_extra_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_extra h;
+     == { DV.length_eq b_extra_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_extra h;
        le_bytes_to_seq_quad32_to_bytes (UV.as_seq h b_extra_u) }
      wrap_slice (le_seq_quad32_to_bytes (Seq.append
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))))
      (B.length b);
-     (==) { append_distributes_le_seq_quad32_to_bytes
+     == { append_distributes_le_seq_quad32_to_bytes
         (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
         (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
         }
@@ -816,13 +816,13 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
        (le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start))))
        (le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))))
      (B.length b);
-     (==) { le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start));
+     == { le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start));
             le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)) }
      wrap_slice (Seq.append
        (seq_uint8_to_seq_nat8 (B.as_seq h b_start))
        (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
      (B.length b);
-     (==) { Seq.lemma_eq_intro b_f
+     == { Seq.lemma_eq_intro b_f
        (wrap_slice (Seq.append
          (seq_uint8_to_seq_nat8 (B.as_seq h b_start))
          (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
@@ -833,12 +833,12 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
  // ) else (
  //   calc (==) {
  //     sf;
- //     (==) { }
+ //     == { }
  //     wrap_slice (le_seq_quad32_to_bytes (UV.as_seq h b_start_u)) (B.length b);
- //     (==) {    DV.length_eq (get_downview b_start);
+ //     == {    DV.length_eq (get_downview b_start);
  //               gcm_simplify1 b_start h (B.length b) }
  //     seq_uint8_to_seq_nat8 (B.as_seq h b_start);
- //     (==) { }
+ //     == { }
  //     b_f;
  //   }
  // )
@@ -857,20 +857,20 @@ let lemma_slice_sub (b:uint8_p) (b_sub:uint8_p) (b_extra:uint8_p) (h:HS.mem) : L
   ) =
   calc (==) {
     Seq.slice (Seq.append (B.as_seq h b_sub) (B.as_seq h b_extra)) 0 (B.length b);
-    (==) { Seq.lemma_eq_intro
+    == { Seq.lemma_eq_intro
      (Seq.slice (Seq.append (B.as_seq h b_sub) (B.as_seq h b_extra)) 0 (B.length b))
      (Seq.append (B.as_seq h b_sub) (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16)))
     }
     Seq.append (B.as_seq h b_sub) (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16));
-    (==) { }
+    == { }
     Seq.append
       (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
       (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16));
-    (==) { }
+    == { }
     Seq.append
       (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
       (Seq.slice (B.as_seq h b) (B.length b_sub) (B.length b));
-    (==) { Seq.lemma_eq_intro (B.as_seq h b)
+    == { Seq.lemma_eq_intro (B.as_seq h b)
       (Seq.append
         (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
         (Seq.slice (B.as_seq h b) (B.length b_sub) (B.length b)))

--- a/vale/code/arch/x64/interop/Vale.Wrapper.X64.GCMencryptOpt.fst
+++ b/vale/code/arch/x64/interop/Vale.Wrapper.X64.GCMencryptOpt.fst
@@ -252,7 +252,7 @@ let gcm128_encrypt_opt' key iv auth_b auth_bytes auth_num keys_b iv_b hkeys_b ab
 
   calc (<=) {
     256 * ((16 * UInt64.v len128_num) / 16);
-    (==) {  FStar.Math.Lemmas.cancel_mul_div (UInt64.v len128_num) 16 }
+    == {  FStar.Math.Lemmas.cancel_mul_div (UInt64.v len128_num) 16 }
     256 * (UInt64.v len128_num);
     ( <= ) { assert_norm (256 <= 4096); FStar.Math.Lemmas.lemma_mult_le_right (UInt64.v len128_num) 256 4096 }
     4096 * (UInt64.v len128_num);
@@ -458,15 +458,15 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
     let bs = UV.as_seq h b_u in
     calc (==) {
       Seq.length split_bs;
-      (==) { }
+      == { }
       Seq.length (UV.as_seq h b1_u) + Seq.length (UV.as_seq h b2_u);
-      (==) { UV.length_eq b1_u; UV.length_eq b2_u }
+      == { UV.length_eq b1_u; UV.length_eq b2_u }
       DV.length b1_d / 16 + DV.length b2_d / 16;
-      (==) { DV.length_eq b1_d; DV.length_eq b2_d; math_aux (B.length b1); math_aux (B.length b2) }
+      == { DV.length_eq b1_d; DV.length_eq b2_d; math_aux (B.length b1); math_aux (B.length b2) }
       B.length b1 / 16 + B.length b2 / 16;
-      (==) { }
+      == { }
       B.length b / 16;
-      (==) { DV.length_eq b_d; UV.length_eq b_u; math_aux (B.length b) }
+      == { DV.length_eq b_d; UV.length_eq b_u; math_aux (B.length b) }
       Seq.length bs;
     };
     assert (Seq.length bs == Seq.length split_bs);
@@ -476,13 +476,13 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
         lemma_same_seq_dv h b;
         calc (==) {
           Seq.index bs i;
-          (==) { UV.as_seq_sel h b_u i }
+          == { UV.as_seq_sel h b_u i }
           UV.sel h b_u i;
-          (==) { UV.get_sel h b_u i }
+          == { UV.get_sel h b_u i }
           Vale.Interop.Views.get128 (Seq.slice (DV.as_seq h b_d) (i * 16) (i * 16 + 16));
-          (==) { lemma_same_seq_dv h b }
+          == { lemma_same_seq_dv h b }
           Vale.Interop.Views.get128 (Seq.slice (B.as_seq h b) (i * 16) (i * 16 + 16));
-          (==) { assert (Seq.equal (B.as_seq h b) (Seq.append (B.as_seq h b1) (B.as_seq h b2))) }
+          == { assert (Seq.equal (B.as_seq h b) (Seq.append (B.as_seq h b1) (B.as_seq h b2))) }
           Vale.Interop.Views.get128 (Seq.slice (Seq.append (B.as_seq h b1) (B.as_seq h b2)) (i * 16) (i * 16 + 16));
         };
         if i < Seq.length (UV.as_seq h b1_u) then (
@@ -490,13 +490,13 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
           UV.length_eq b1_u;
           calc (==) {
             Vale.Interop.Views.get128 (Seq.slice (Seq.append (B.as_seq h b1) (B.as_seq h b2)) (i * 16) (i * 16 + 16));
-            (==) { }
+            == { }
             Vale.Interop.Views.get128 (Seq.slice (B.as_seq h b1) (i * 16) (i * 16 + 16));
-            (==) { UV.get_sel h b1_u i }
+            == { UV.get_sel h b1_u i }
             UV.sel h b1_u i;
-            (==) { UV.as_seq_sel h b1_u i }
+            == { UV.as_seq_sel h b1_u i }
             Seq.index (UV.as_seq h b1_u) i;
-            (==) { }
+            == { }
             Seq.index split_bs i;
           }
         ) else (
@@ -505,13 +505,13 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
           let j = i - UV.length b1_u in
           calc (==) {
             Vale.Interop.Views.get128 (Seq.slice (Seq.append (B.as_seq h b1) (B.as_seq h b2)) (i * 16) (i * 16 + 16));
-            (==) { }
+            == { }
             Vale.Interop.Views.get128 (Seq.slice (B.as_seq h b2) (j * 16) (j * 16 + 16));
-            (==) { UV.get_sel h b2_u j }
+            == { UV.get_sel h b2_u j }
             UV.sel h b2_u j;
-            (==) { UV.as_seq_sel h b2_u j }
+            == { UV.as_seq_sel h b2_u j }
             Seq.index (UV.as_seq h b2_u) j;
-            (==) { }
+            == { }
             Seq.index split_bs i;
           }
        )
@@ -541,9 +541,9 @@ let gcm128_encrypt_opt_alloca key iv plain_b plain_len auth_b auth_bytes iv_b
          (key_to_round_keys_LE AES_128 (Ghost.reveal key)));
       calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 keys_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 keys_b h0 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 keys_b h0 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h0 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
         UV.as_seq h0 ub;
       }
 
@@ -560,9 +560,9 @@ let gcm128_encrypt_opt_alloca key iv plain_b plain_len auth_b auth_bytes iv_b
       let ub = UV.mk_buffer db Vale.Interop.Views.up_view128 in
       calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 hkeys_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 hkeys_b h0 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 hkeys_b h0 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h0 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
         UV.as_seq h0 ub;
       }
 
@@ -574,11 +574,11 @@ let gcm128_encrypt_opt_alloca key iv plain_b plain_len auth_b auth_bytes iv_b
   calc (==) {
     compute_iv_BE (aes_encrypt_LE AES_128 (Ghost.reveal key) (Mkfour 0 0 0 0))
                   (Ghost.reveal iv);
-    (==) { }
+    == { }
     le_bytes_to_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 iv_b));
-    (==) { gcm_simplify2 iv_b h0 }
+    == { gcm_simplify2 iv_b h0 }
     le_bytes_to_quad32 (le_quad32_to_bytes (low_buffer_read TUInt8 TUInt128 h0 iv_b 0));
-    (==) { le_bytes_to_quad32_to_bytes (low_buffer_read TUInt8 TUInt128 h0 iv_b 0) }
+    == { le_bytes_to_quad32_to_bytes (low_buffer_read TUInt8 TUInt128 h0 iv_b 0) }
     low_buffer_read TUInt8 TUInt128 h0 iv_b 0;
   };
 
@@ -796,19 +796,19 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
  // if B.length b > B.length b_start then (
    calc (==) {
      sf;
-     (==) { DV.length_eq b_start_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_start h;
+     == { DV.length_eq b_start_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_start h;
           le_bytes_to_seq_quad32_to_bytes (UV.as_seq h b_start_u) }
      wrap_slice (le_seq_quad32_to_bytes (Seq.append
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
        (UV.as_seq h b_extra_u)))
      (B.length b);
-     (==) { DV.length_eq b_extra_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_extra h;
+     == { DV.length_eq b_extra_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_extra h;
        le_bytes_to_seq_quad32_to_bytes (UV.as_seq h b_extra_u) }
      wrap_slice (le_seq_quad32_to_bytes (Seq.append
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))))
      (B.length b);
-     (==) { append_distributes_le_seq_quad32_to_bytes
+     == { append_distributes_le_seq_quad32_to_bytes
         (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
         (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
         }
@@ -816,13 +816,13 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
        (le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start))))
        (le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))))
      (B.length b);
-     (==) { le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start));
+     == { le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start));
             le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)) }
      wrap_slice (Seq.append
        (seq_uint8_to_seq_nat8 (B.as_seq h b_start))
        (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
      (B.length b);
-     (==) { Seq.lemma_eq_intro b_f
+     == { Seq.lemma_eq_intro b_f
        (wrap_slice (Seq.append
          (seq_uint8_to_seq_nat8 (B.as_seq h b_start))
          (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
@@ -833,12 +833,12 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
  // ) else (
  //   calc (==) {
  //     sf;
- //     (==) { }
+ //     == { }
  //     wrap_slice (le_seq_quad32_to_bytes (UV.as_seq h b_start_u)) (B.length b);
- //     (==) {    DV.length_eq (get_downview b_start);
+ //     == {    DV.length_eq (get_downview b_start);
  //               gcm_simplify1 b_start h (B.length b) }
  //     seq_uint8_to_seq_nat8 (B.as_seq h b_start);
- //     (==) { }
+ //     == { }
  //     b_f;
  //   }
  // )
@@ -857,20 +857,20 @@ let lemma_slice_sub (b:uint8_p) (b_sub:uint8_p) (b_extra:uint8_p) (h:HS.mem) : L
   ) =
   calc (==) {
     Seq.slice (Seq.append (B.as_seq h b_sub) (B.as_seq h b_extra)) 0 (B.length b);
-    (==) { Seq.lemma_eq_intro
+    == { Seq.lemma_eq_intro
      (Seq.slice (Seq.append (B.as_seq h b_sub) (B.as_seq h b_extra)) 0 (B.length b))
      (Seq.append (B.as_seq h b_sub) (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16)))
     }
     Seq.append (B.as_seq h b_sub) (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16));
-    (==) { }
+    == { }
     Seq.append
       (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
       (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16));
-    (==) { }
+    == { }
     Seq.append
       (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
       (Seq.slice (B.as_seq h b) (B.length b_sub) (B.length b));
-    (==) { Seq.lemma_eq_intro (B.as_seq h b)
+    == { Seq.lemma_eq_intro (B.as_seq h b)
       (Seq.append
         (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
         (Seq.slice (B.as_seq h b) (B.length b_sub) (B.length b)))

--- a/vale/code/arch/x64/interop/Vale.Wrapper.X64.GCMencryptOpt256.fst
+++ b/vale/code/arch/x64/interop/Vale.Wrapper.X64.GCMencryptOpt256.fst
@@ -251,7 +251,7 @@ let gcm256_encrypt_opt' key iv auth_b auth_bytes auth_num keys_b iv_b hkeys_b ab
 
   calc (<=) {
     256 * ((16 * UInt64.v len128_num) / 16);
-    (==) {  FStar.Math.Lemmas.cancel_mul_div (UInt64.v len128_num) 16 }
+    == {  FStar.Math.Lemmas.cancel_mul_div (UInt64.v len128_num) 16 }
     256 * (UInt64.v len128_num);
     ( <= ) { assert_norm (256 <= 4096); FStar.Math.Lemmas.lemma_mult_le_right (UInt64.v len128_num) 256 4096 }
     4096 * (UInt64.v len128_num);
@@ -457,15 +457,15 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
     let bs = UV.as_seq h b_u in
     calc (==) {
       Seq.length split_bs;
-      (==) { }
+      == { }
       Seq.length (UV.as_seq h b1_u) + Seq.length (UV.as_seq h b2_u);
-      (==) { UV.length_eq b1_u; UV.length_eq b2_u }
+      == { UV.length_eq b1_u; UV.length_eq b2_u }
       DV.length b1_d / 16 + DV.length b2_d / 16;
-      (==) { DV.length_eq b1_d; DV.length_eq b2_d; math_aux (B.length b1); math_aux (B.length b2) }
+      == { DV.length_eq b1_d; DV.length_eq b2_d; math_aux (B.length b1); math_aux (B.length b2) }
       B.length b1 / 16 + B.length b2 / 16;
-      (==) { }
+      == { }
       B.length b / 16;
-      (==) { DV.length_eq b_d; UV.length_eq b_u; math_aux (B.length b) }
+      == { DV.length_eq b_d; UV.length_eq b_u; math_aux (B.length b) }
       Seq.length bs;
     };
     assert (Seq.length bs == Seq.length split_bs);
@@ -475,13 +475,13 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
         lemma_same_seq_dv h b;
         calc (==) {
           Seq.index bs i;
-          (==) { UV.as_seq_sel h b_u i }
+          == { UV.as_seq_sel h b_u i }
           UV.sel h b_u i;
-          (==) { UV.get_sel h b_u i }
+          == { UV.get_sel h b_u i }
           Vale.Interop.Views.get128 (Seq.slice (DV.as_seq h b_d) (i * 16) (i * 16 + 16));
-          (==) { lemma_same_seq_dv h b }
+          == { lemma_same_seq_dv h b }
           Vale.Interop.Views.get128 (Seq.slice (B.as_seq h b) (i * 16) (i * 16 + 16));
-          (==) { assert (Seq.equal (B.as_seq h b) (Seq.append (B.as_seq h b1) (B.as_seq h b2))) }
+          == { assert (Seq.equal (B.as_seq h b) (Seq.append (B.as_seq h b1) (B.as_seq h b2))) }
           Vale.Interop.Views.get128 (Seq.slice (Seq.append (B.as_seq h b1) (B.as_seq h b2)) (i * 16) (i * 16 + 16));
         };
         if i < Seq.length (UV.as_seq h b1_u) then (
@@ -489,13 +489,13 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
           UV.length_eq b1_u;
           calc (==) {
             Vale.Interop.Views.get128 (Seq.slice (Seq.append (B.as_seq h b1) (B.as_seq h b2)) (i * 16) (i * 16 + 16));
-            (==) { }
+            == { }
             Vale.Interop.Views.get128 (Seq.slice (B.as_seq h b1) (i * 16) (i * 16 + 16));
-            (==) { UV.get_sel h b1_u i }
+            == { UV.get_sel h b1_u i }
             UV.sel h b1_u i;
-            (==) { UV.as_seq_sel h b1_u i }
+            == { UV.as_seq_sel h b1_u i }
             Seq.index (UV.as_seq h b1_u) i;
-            (==) { }
+            == { }
             Seq.index split_bs i;
           }
         ) else (
@@ -504,13 +504,13 @@ let lemma_uv_split (h:HS.mem) (b:uint8_p) (n:UInt32.t) : Lemma
           let j = i - UV.length b1_u in
           calc (==) {
             Vale.Interop.Views.get128 (Seq.slice (Seq.append (B.as_seq h b1) (B.as_seq h b2)) (i * 16) (i * 16 + 16));
-            (==) { }
+            == { }
             Vale.Interop.Views.get128 (Seq.slice (B.as_seq h b2) (j * 16) (j * 16 + 16));
-            (==) { UV.get_sel h b2_u j }
+            == { UV.get_sel h b2_u j }
             UV.sel h b2_u j;
-            (==) { UV.as_seq_sel h b2_u j }
+            == { UV.as_seq_sel h b2_u j }
             Seq.index (UV.as_seq h b2_u) j;
-            (==) { }
+            == { }
             Seq.index split_bs i;
           }
        )
@@ -533,11 +533,11 @@ let gcm256_encrypt_opt_alloca key iv plain_b plain_len auth_b auth_bytes iv_b
   calc (==) {
     compute_iv_BE (aes_encrypt_LE AES_256 (Ghost.reveal key) (Mkfour 0 0 0 0))
                   (Ghost.reveal iv);
-    (==) { }
+    == { }
     le_bytes_to_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 iv_b));
-    (==) { gcm_simplify2 iv_b h0 }
+    == { gcm_simplify2 iv_b h0 }
     le_bytes_to_quad32 (le_quad32_to_bytes (low_buffer_read TUInt8 TUInt128 h0 iv_b 0));
-    (==) { le_bytes_to_quad32_to_bytes (low_buffer_read TUInt8 TUInt128 h0 iv_b 0) }
+    == { le_bytes_to_quad32_to_bytes (low_buffer_read TUInt8 TUInt128 h0 iv_b 0) }
     low_buffer_read TUInt8 TUInt128 h0 iv_b 0;
   };
 
@@ -555,9 +555,9 @@ let gcm256_encrypt_opt_alloca key iv plain_b plain_len auth_b auth_bytes iv_b
          (key_to_round_keys_LE AES_256 (Ghost.reveal key)));
       calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 keys_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 keys_b h0 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 keys_b h0 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h0 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
         UV.as_seq h0 ub;
       }
 
@@ -574,9 +574,9 @@ let gcm256_encrypt_opt_alloca key iv plain_b plain_len auth_b auth_bytes iv_b
       let ub = UV.mk_buffer db Vale.Interop.Views.up_view128 in
       calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 hkeys_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 hkeys_b h0 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 hkeys_b h0 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h0 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
         UV.as_seq h0 ub;
       }
 
@@ -796,19 +796,19 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
  // if B.length b > B.length b_start then (
    calc (==) {
      sf;
-     (==) { DV.length_eq b_start_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_start h;
+     == { DV.length_eq b_start_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_start h;
           le_bytes_to_seq_quad32_to_bytes (UV.as_seq h b_start_u) }
      wrap_slice (le_seq_quad32_to_bytes (Seq.append
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
        (UV.as_seq h b_extra_u)))
      (B.length b);
-     (==) { DV.length_eq b_extra_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_extra h;
+     == { DV.length_eq b_extra_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_extra h;
        le_bytes_to_seq_quad32_to_bytes (UV.as_seq h b_extra_u) }
      wrap_slice (le_seq_quad32_to_bytes (Seq.append
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))))
      (B.length b);
-     (==) { append_distributes_le_seq_quad32_to_bytes
+     == { append_distributes_le_seq_quad32_to_bytes
         (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
         (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
         }
@@ -816,13 +816,13 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
        (le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start))))
        (le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))))
      (B.length b);
-     (==) { le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start));
+     == { le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start));
             le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)) }
      wrap_slice (Seq.append
        (seq_uint8_to_seq_nat8 (B.as_seq h b_start))
        (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
      (B.length b);
-     (==) { Seq.lemma_eq_intro b_f
+     == { Seq.lemma_eq_intro b_f
        (wrap_slice (Seq.append
          (seq_uint8_to_seq_nat8 (B.as_seq h b_start))
          (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
@@ -833,12 +833,12 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
  // ) else (
  //   calc (==) {
  //     sf;
- //     (==) { }
+ //     == { }
  //     wrap_slice (le_seq_quad32_to_bytes (UV.as_seq h b_start_u)) (B.length b);
- //     (==) {    DV.length_eq (get_downview b_start);
+ //     == {    DV.length_eq (get_downview b_start);
  //               gcm_simplify1 b_start h (B.length b) }
  //     seq_uint8_to_seq_nat8 (B.as_seq h b_start);
- //     (==) { }
+ //     == { }
  //     b_f;
  //   }
  // )
@@ -857,20 +857,20 @@ let lemma_slice_sub (b:uint8_p) (b_sub:uint8_p) (b_extra:uint8_p) (h:HS.mem) : L
   ) =
   calc (==) {
     Seq.slice (Seq.append (B.as_seq h b_sub) (B.as_seq h b_extra)) 0 (B.length b);
-    (==) { Seq.lemma_eq_intro
+    == { Seq.lemma_eq_intro
      (Seq.slice (Seq.append (B.as_seq h b_sub) (B.as_seq h b_extra)) 0 (B.length b))
      (Seq.append (B.as_seq h b_sub) (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16)))
     }
     Seq.append (B.as_seq h b_sub) (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16));
-    (==) { }
+    == { }
     Seq.append
       (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
       (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16));
-    (==) { }
+    == { }
     Seq.append
       (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
       (Seq.slice (B.as_seq h b) (B.length b_sub) (B.length b));
-    (==) { Seq.lemma_eq_intro (B.as_seq h b)
+    == { Seq.lemma_eq_intro (B.as_seq h b)
       (Seq.append
         (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
         (Seq.slice (B.as_seq h b) (B.length b_sub) (B.length b)))

--- a/vale/code/arch/x64/interop/Vale.Wrapper.X64.GCTR.fst
+++ b/vale/code/arch/x64/interop/Vale.Wrapper.X64.GCTR.fst
@@ -197,9 +197,9 @@ let gctr128_bytes_stdcall' key in_b num_bytes out_b inout_b keys_b ctr_b num_blo
          (key_to_round_keys_LE AES_128 (Ghost.reveal key)));
       calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 keys_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 keys_b h0 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 keys_b h0 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h0 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
         UV.as_seq h0 ub;
       }
 
@@ -250,9 +250,9 @@ let gctr256_bytes_stdcall' key in_b num_bytes out_b inout_b keys_b ctr_b num_blo
          (key_to_round_keys_LE AES_256 (Ghost.reveal key)));
       calc (==) {
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h0 keys_b));
-        (==) { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 keys_b h0 }
+        == { lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 keys_b h0 }
         le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (seq_nat8_to_seq_uint8 (le_seq_quad32_to_bytes (UV.as_seq h0 ub))));
-        (==) { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
+        == { le_bytes_to_seq_quad32_to_bytes (UV.as_seq h0 ub) }
         UV.as_seq h0 ub;
       }
 
@@ -309,19 +309,19 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
  // if B.length b > B.length b_start then (
    calc (==) {
      sf;
-     (==) { DV.length_eq b_start_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_start h;
+     == { DV.length_eq b_start_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_start h;
           le_bytes_to_seq_quad32_to_bytes (UV.as_seq h b_start_u) }
      wrap_slice (le_seq_quad32_to_bytes (Seq.append
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
        (UV.as_seq h b_extra_u)))
      (B.length b);
-     (==) { DV.length_eq b_extra_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_extra h;
+     == { DV.length_eq b_extra_d; lemma_seq_nat8_le_seq_quad32_to_bytes_uint32 b_extra h;
        le_bytes_to_seq_quad32_to_bytes (UV.as_seq h b_extra_u) }
      wrap_slice (le_seq_quad32_to_bytes (Seq.append
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
        (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))))
      (B.length b);
-     (==) { append_distributes_le_seq_quad32_to_bytes
+     == { append_distributes_le_seq_quad32_to_bytes
         (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start)))
         (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
         }
@@ -329,13 +329,13 @@ let lemma_slice_uv_extra (b:uint8_p) (b_start:uint8_p) (b_extra:uint8_p) (h:HS.m
        (le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start))))
        (le_seq_quad32_to_bytes (le_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))))
      (B.length b);
-     (==) { le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start));
+     == { le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_start));
             le_seq_quad32_to_bytes_to_seq_quad32 (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)) }
      wrap_slice (Seq.append
        (seq_uint8_to_seq_nat8 (B.as_seq h b_start))
        (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
      (B.length b);
-     (==) { Seq.lemma_eq_intro b_f
+     == { Seq.lemma_eq_intro b_f
        (wrap_slice (Seq.append
          (seq_uint8_to_seq_nat8 (B.as_seq h b_start))
          (seq_uint8_to_seq_nat8 (B.as_seq h b_extra)))
@@ -357,20 +357,20 @@ let lemma_slice_sub (b:uint8_p) (b_sub:uint8_p) (b_extra:uint8_p) (h:HS.mem) : L
   ) =
   calc (==) {
     Seq.slice (Seq.append (B.as_seq h b_sub) (B.as_seq h b_extra)) 0 (B.length b);
-    (==) { Seq.lemma_eq_intro
+    == { Seq.lemma_eq_intro
      (Seq.slice (Seq.append (B.as_seq h b_sub) (B.as_seq h b_extra)) 0 (B.length b))
      (Seq.append (B.as_seq h b_sub) (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16)))
     }
     Seq.append (B.as_seq h b_sub) (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16));
-    (==) { }
+    == { }
     Seq.append
       (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
       (Seq.slice (B.as_seq h b_extra) 0 (B.length b % 16));
-    (==) { }
+    == { }
     Seq.append
       (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
       (Seq.slice (B.as_seq h b) (B.length b_sub) (B.length b));
-    (==) { Seq.lemma_eq_intro (B.as_seq h b)
+    == { Seq.lemma_eq_intro (B.as_seq h b)
       (Seq.append
         (Seq.slice (B.as_seq h b) 0 (B.length b_sub))
         (Seq.slice (B.as_seq h b) (B.length b_sub) (B.length b)))

--- a/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastSqr_helpers.fst
+++ b/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastSqr_helpers.fst
@@ -54,9 +54,9 @@ let lemma_sqr_part3
   =
   calc (==) {
     pow2_nine d0 d1 d2 d3 d4 d5 d6 d7 c;
-    (==) { () }
+    == { () }
     pow2_eight (pow2_64 * a0_sqr_hi + a0_sqr_lo) r8 (pow2_64 * a1_sqr_hi + a1_sqr_lo + r9) r10 (pow2_64 * a2_sqr_hi + a2_sqr_lo + r11) r12 (pow2_64 * a3_sqr_hi + a3_sqr_lo + r13) r14;
-    (==) {
+    == {
       assert_norm (mul_nats a0 a0 == a0 * a0);
       assert_norm (mul_nats a1 a1 == a1 * a1);
       assert_norm (mul_nats a2 a2 == a2 * a2);
@@ -107,21 +107,21 @@ let lemma_sqr (a:int) (a0 a1 a2 a3
 
   calc (==) {
     lhs_rem;
-    (==) { assert_by_tactic (pow2_seven 0 (2 * (mul_nats a0 a1)) (2 * (mul_nats a0 a2)) (2 * (mul_nats a0 a3 + mul_nats a1 a2)) (2 * (mul_nats a1 a3)) (2* (mul_nats a2 a3)) 0 == (2 * pow2_64) * pow2_five (mul_nats a0 a1) (mul_nats a0 a2) (mul_nats a0 a3) (mul_nats a1 a3) (mul_nats a2 a3) + (2 * pow2_192 * mul_nats a1 a2)) int_canon }
+    == { assert_by_tactic (pow2_seven 0 (2 * (mul_nats a0 a1)) (2 * (mul_nats a0 a2)) (2 * (mul_nats a0 a3 + mul_nats a1 a2)) (2 * (mul_nats a1 a3)) (2* (mul_nats a2 a3)) 0 == (2 * pow2_64) * pow2_five (mul_nats a0 a1) (mul_nats a0 a2) (mul_nats a0 a3) (mul_nats a1 a3) (mul_nats a2 a3) + (2 * pow2_192 * mul_nats a1 a2)) int_canon }
     (2 * pow2_64) * pow2_five (mul_nats a0 a1) (mul_nats a0 a2) (mul_nats a0 a3) (mul_nats a1 a3) (mul_nats a2 a3) + (2 * pow2_192 * mul_nats a1 a2);
-    (==) { }
+    == { }
     (2 * pow2_64) * pow2_six r8 r9 r10 r11 r12 r13 + (2 * pow2_192 * mul_nats a1 a2);
-    (==) { assert_norm (mul_nats a1 a2 == a1 * a2) }
+    == { assert_norm (mul_nats a1 a2 == a1 * a2) }
     (2 * pow2_64) * pow2_six r8 r9 r10 r11 r12 r13 + (2 * pow2_192 * (pow2_64 * rcx + rax));
-    (==) { assert_by_tactic (
+    == { assert_by_tactic (
       (2 * pow2_64) * pow2_six r8 r9 r10 r11 r12 r13 + (2 * pow2_192 * (pow2_64 * rcx + rax))
         ==
       pow2_64 * pow2_six (2*r8) (2*r9) (2*(r10+rax)) (2*(r11+rcx)) (2*r12) (2*r13)
     ) int_canon }
     pow2_64 * pow2_six (2*r8) (2*r9) (2*(r10+rax)) (2*(r11+rcx)) (2*r12) (2*r13);
-    (==) { }
+    == { }
     pow2_64 * pow2_seven r8' r9' r10' r11' r12' r13' r14';
-    (==) { assert_by_tactic (
+    == { assert_by_tactic (
          pow2_64 * pow2_seven r8' r9' r10' r11' r12' r13' r14' ==
          pow2_eight 0 r8' r9' r10' r11' r12' r13' r14'
       ) int_canon }
@@ -130,15 +130,15 @@ let lemma_sqr (a:int) (a0 a1 a2 a3
 
   calc (==) {
     a * a;
-    (==) { }
+    == { }
     pow2_seven (mul_nats a0 a0) (2*(mul_nats a0 a1)) (2*(mul_nats a0 a2) + (mul_nats a1 a1))
                          (2*((mul_nats a0 a3) + (mul_nats a1 a2))) (2*(mul_nats a1 a3) + (mul_nats a2 a2)) (2*(mul_nats a2 a3)) (mul_nats a3 a3);
-    (==) { assert_by_tactic (pow2_seven (mul_nats a0 a0) (2*(mul_nats a0 a1)) (2*(mul_nats a0 a2) + (mul_nats a1 a1))
+    == { assert_by_tactic (pow2_seven (mul_nats a0 a0) (2*(mul_nats a0 a1)) (2*(mul_nats a0 a2) + (mul_nats a1 a1))
                          (2*((mul_nats a0 a3) + (mul_nats a1 a2))) (2*(mul_nats a1 a3) + (mul_nats a2 a2)) (2*(mul_nats a2 a3)) (mul_nats a3 a3) == squares + lhs_rem) int_canon }
     squares + lhs_rem;
-    (==) { }
+    == { }
     squares + rhs_rem;
-    (==) {
+    == {
       assert (squares + rhs_rem ==  pow2_eight (mul_nats a0 a0) r8' ((mul_nats a1 a1) + r9') r10' ((mul_nats a2 a2) + r11') r12' ((mul_nats a3 a3) + r13') r14')
           by int_canon ()
     }

--- a/vale/code/crypto/sha/Vale.SHA.PPC64LE.SHA_helpers.fst
+++ b/vale/code/crypto/sha/Vale.SHA.PPC64LE.SHA_helpers.fst
@@ -460,13 +460,13 @@ let lemma_add_mod_associates_U32 (x y z:UInt32.t) :
   let open Lib.IntTypes in
   calc (==) {
     v (x +. (y +. z));
-    (==) { }
+    == { }
     (v x + (v y + v z) % pow2 32) % pow2 32;
-    (==) { FStar.Math.Lemmas.lemma_mod_add_distr (v x) (v y + v z) (pow2 32) }
+    == { FStar.Math.Lemmas.lemma_mod_add_distr (v x) (v y + v z) (pow2 32) }
     ((v x + v y) + v z) % pow2 32;
-    (==) { FStar.Math.Lemmas.lemma_mod_add_distr (v z) (v x + v y) (pow2 32) }
+    == { FStar.Math.Lemmas.lemma_mod_add_distr (v z) (v x + v y) (pow2 32) }
     ((v x + v y) % pow2 32 + v z) % pow2 32;
-    (==) { }
+    == { }
     v ((x +. y) +. z);
   };
   v_inj (x +. (y +. z)) ((x +. y) +. z)
@@ -478,14 +478,14 @@ let lemma_add_mod_ws_rearrangement (a b c d:UInt32.t) :
   let open Lib.IntTypes in
   calc (==) {
     a +. b +. c +. d;
-    (==) {}
+    == {}
     (((a +. b) +. c) +. d);
-    (==) {   lemma_add_mod_commutes ((a +. b) +. c) d;
+    == {   lemma_add_mod_commutes ((a +. b) +. c) d;
              lemma_add_mod_commutes (a +. b) c;
              lemma_add_mod_commutes a b
          }
     d +. (c +. (b +. a));
-    (==) { lemma_add_mod_associates_U32 d c (b +. a);
+    == { lemma_add_mod_associates_U32 d c (b +. a);
            lemma_add_mod_associates_U32 (d +. c) b a}
     (((d +. c) +. b) +. a);
   }
@@ -507,13 +507,13 @@ let lemma_ws_opaque (block:block_w) (t:counter) : Lemma
   let s0 = _sigma0 SHA2_256 t15 in
   calc (==) {
     ws_opaque block t;
-    (==) { Pervasives.reveal_opaque (`%ws) ws }
+    == { Pervasives.reveal_opaque (`%ws) ws }
     vv ((s1 +. t7 +. s0) +. t16);
-    (==) { lemma_add_wrap_is_add_mod (vv (s1 +. t7 +. s0)) (ws_opaque block (t-16)) }
+    == { lemma_add_wrap_is_add_mod (vv (s1 +. t7 +. s0)) (ws_opaque block (t-16)) }
     add_wrap (vv ((s1 +. t7) +. s0)) (ws_opaque block (t-16));
-    (==) { lemma_add_wrap_is_add_mod (vv (s1 +. t7)) sigma0 }
+    == { lemma_add_wrap_is_add_mod (vv (s1 +. t7)) sigma0 }
     add_wrap (add_wrap (vv (s1 +. t7)) sigma0) (ws_opaque block (t-16));
-    (==) { lemma_add_wrap_is_add_mod sigma1 (ws_opaque block (t-7)) }
+    == { lemma_add_wrap_is_add_mod sigma1 (ws_opaque block (t-7)) }
     add_wrap (add_wrap (add_wrap sigma1 (ws_opaque block (t - 7))) sigma0) (ws_opaque block (t - 16));
 
   }
@@ -741,9 +741,9 @@ let lemma_endian_relation (quads qs:seq quad32) (input2:seq UInt8.t) : Lemma
       Lib.ByteSequence.uint_from_bytes_be #U32 #SEC b;
       == { calc (==) {
              Lib.ByteSequence.nat_from_bytes_be #SEC b;
-             (==) { }
+             == { }
              Lib.ByteSequence.nat_from_bytes_be #SEC (seq_nat8_to_seq_uint8 (four_to_seq_LE (nat_to_four 8 ni)));
-             (==) { lemma_be_to_n_4 (four_to_seq_LE (nat_to_four 8 ni)) }
+             == { lemma_be_to_n_4 (four_to_seq_LE (nat_to_four 8 ni)) }
              be_bytes_to_nat32 (four_to_seq_LE (nat_to_four 8 ni));
            };
            v_inj (Lib.ByteSequence.uint_from_bytes_be #U32 #SEC b)

--- a/vale/code/crypto/sha/Vale.SHA.SHA_helpers.fst
+++ b/vale/code/crypto/sha/Vale.SHA.SHA_helpers.fst
@@ -192,13 +192,13 @@ let lemma_add_mod_associates_U32 (x y z:UInt32.t) :
   let open Lib.IntTypes in
   calc (==) {
     v (x +. (y +. z));
-    (==) { }
+    == { }
     (v x + (v y + v z) % pow2 32) % pow2 32;
-    (==) { FStar.Math.Lemmas.lemma_mod_add_distr (v x) (v y + v z) (pow2 32) }
+    == { FStar.Math.Lemmas.lemma_mod_add_distr (v x) (v y + v z) (pow2 32) }
     ((v x + v y) + v z) % pow2 32;
-    (==) { FStar.Math.Lemmas.lemma_mod_add_distr (v z) (v x + v y) (pow2 32) }
+    == { FStar.Math.Lemmas.lemma_mod_add_distr (v z) (v x + v y) (pow2 32) }
     ((v x + v y) % pow2 32 + v z) % pow2 32;
-    (==) { }
+    == { }
     v ((x +. y) +. z);
   };
   v_inj (x +. (y +. z)) ((x +. y) +. z)
@@ -467,14 +467,14 @@ let lemma_add_mod_ws_rearrangement (a b c d:UInt32.t) :
   let open Lib.IntTypes in
   calc (==) {
     a +. b +. c +. d;
-    (==) {}
+    == {}
     (((a +. b) +. c) +. d);
-    (==) {   lemma_add_mod_commutes ((a +. b) +. c) d;
+    == {   lemma_add_mod_commutes ((a +. b) +. c) d;
              lemma_add_mod_commutes (a +. b) c;
              lemma_add_mod_commutes a b
          }
     d +. (c +. (b +. a));
-    (==) { lemma_add_mod_associates_U32 d c (b +. a);
+    == { lemma_add_mod_associates_U32 d c (b +. a);
            lemma_add_mod_associates_U32 (d +. c) b a}
     (((d +. c) +. b) +. a);
   }
@@ -845,9 +845,9 @@ let lemma_endian_relation (quads qs:seq quad32) (input2:seq UInt8.t) : Lemma
       Lib.ByteSequence.uint_from_bytes_be #U32 #SEC b;
       == { calc (==) {
              Lib.ByteSequence.nat_from_bytes_be #SEC b;
-             (==) { }
+             == { }
              Lib.ByteSequence.nat_from_bytes_be #SEC (seq_nat8_to_seq_uint8 (four_to_seq_LE (nat_to_four 8 ni)));
-             (==) { lemma_be_to_n_4 (four_to_seq_LE (nat_to_four 8 ni)) }
+             == { lemma_be_to_n_4 (four_to_seq_LE (nat_to_four 8 ni)) }
              be_bytes_to_nat32 (four_to_seq_LE (nat_to_four 8 ni));
            };
            v_inj (Lib.ByteSequence.uint_from_bytes_be #U32 #SEC b)


### PR DESCRIPTION
Mostly generated by sed calls like these:

	sed 's/^\( *\)(==) {/\1== {/'
	sed 's/^\( *\)(<=) {/\1<= {/'

I'm not sure if this is too noisy to be useful, feel free to close the PR if so.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
