### PR TITLE
More cleanup of fuel options

### DIFF
--- a/vale/code/arch/Vale.Arch.MachineHeap.fst
+++ b/vale/code/arch/Vale.Arch.MachineHeap.fst
@@ -83,7 +83,7 @@ let correct_update_get128 ptr v mem =
   frame_update_heap32 (ptr+12) v.hi3 mem3;
   correct_update_get32 (ptr+12) v.hi3 mem3
 
-#reset-options "--z3rlimit 10 --max_fuel 2 --initial_fuel 2 --max_ifuel 1 --initial_ifuel 1"
+#reset-options "--z3rlimit 10 --fuel 2 --ifuel 1"
 
 let same_domain_update128 ptr v mem =
   let mem1 = update_heap32 ptr v.lo0 mem in

--- a/vale/code/arch/Vale.Arch.Types.fst
+++ b/vale/code/arch/Vale.Arch.Types.fst
@@ -44,7 +44,7 @@ let xor_lemmas () =
   FStar.Classical.forall_intro_3 lemma_BitwiseXorAssociative;
   ()
 
-#push-options "--max_fuel 3 --initial_fuel 3 --max_ifuel 3 --initial_ifuel 3"  // REVIEW: Why do we need this?
+#push-options "--fuel 3 --ifuel 3"  // REVIEW: Why do we need this?
 let lemma_quad32_xor () =
   quad32_xor_reveal ();
   reverse_bytes_nat32_reveal ();
@@ -73,7 +73,7 @@ let lemma_reverse_reverse_bytes_nat32 (n:nat32) :
   be_bytes_to_nat32_to_be_bytes r;
   ()
 
-#push-options "--max_fuel 3 --initial_fuel 3 --max_ifuel 3 --initial_ifuel 3"  // REVIEW: Why do we need this?
+#push-options "--fuel 3 --ifuel 3"  // REVIEW: Why do we need this?
 let lemma_reverse_bytes_quad32 (q:quad32) =
   quad32_xor_reveal ();
   reverse_bytes_nat32_reveal ();
@@ -270,7 +270,7 @@ let push_pop_xmm (x y:quad32) : Lemma
   hi64_reveal ();
   ()
 
-#push-options "--max_fuel 3 --initial_fuel 3 --max_ifuel 3 --initial_ifuel 3"  // REVIEW: Why do we need this?
+#push-options "--fuel 3 --ifuel 3"  // REVIEW: Why do we need this?
 let lemma_insrq_extrq_relations (x y:quad32) :
   Lemma (let z = insert_nat64 x (lo64 y) 0 in
          z == Mkfour y.lo0 y.lo1 x.hi2 x.hi3 /\

--- a/vale/code/arch/ppc64le/Vale.PPC64LE.Memory.fst
+++ b/vale/code/arch/ppc64le/Vale.PPC64LE.Memory.fst
@@ -446,7 +446,7 @@ let get_addr_ptr (t:base_typ) (ptr:int) (h:vale_heap) : Ghost (buffer t)
   =
   Some?.v (find_valid_buffer t ptr h)
 
-#reset-options "--fuel 0 --ifuel 0 --initial_fuel 0 --initial_ifuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --ifuel 0 --z3rlimit 20"
 let load_buffer_read (t:base_typ) (ptr:int) (h:vale_heap) : Lemma
   (requires valid_mem t ptr h)
   (ensures (

--- a/vale/code/arch/x64/Vale.Interop.fst
+++ b/vale/code/arch/x64/Vale.Interop.fst
@@ -439,7 +439,7 @@ let up_down_identity mem heap =
   in Classical.forall_intro (Classical.move_requires aux);
   assert (Map.equal heap new_heap)
 
-#reset-options "--z3rlimit 50 --max_fuel 1 --max_ifuel 1 --initial_fuel 1 --initial_ifuel 1"
+#reset-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 let rec update_buffer_up_mem_aux
   (h1 h2:machine_heap)

--- a/vale/code/arch/x64/Vale.Interop.fst
+++ b/vale/code/arch/x64/Vale.Interop.fst
@@ -10,7 +10,7 @@ open Vale.Def.Opaque_s
 //open Vale.Interop.Base
 open Vale.Lib.BufferViewHelpers
 
-#reset-options "--max_fuel 2 --initial_fuel 2 --max_ifuel 1 --initial_ifuel 1"
+#reset-options "--fuel 2 --ifuel 1"
 
 (* Write a buffer in the vale memory *)
 

--- a/vale/code/arch/x64/Vale.X64.BufferViewStore.fst
+++ b/vale/code/arch/x64/Vale.X64.BufferViewStore.fst
@@ -17,7 +17,7 @@ open FStar.Calc
 
 friend LowStar.BufferView.Up
 
-#reset-options "--z3rlimit 10 --fuel 0 --initial_fuel 0 --max_ifuel 1 --initial_ifuel 1"
+#reset-options "--z3rlimit 10 --fuel 0 --initial_fuel 0 --ifuel 1"
 
 let math_aux (a b c:int) : Lemma (a + b + (c - b) == a + c) = ()
 
@@ -45,7 +45,7 @@ let get128_aux (ptr:int) (heap:machine_heap) (v:quad32) (k:nat{k < 16}) : Lemma
   reveal_opaque (`%le_quad32_to_bytes) le_quad32_to_bytes;
   four_to_nat_8_injective ()
 
-#reset-options "--max_fuel 1 --initial_fuel 1 --z3rlimit 200"
+#reset-options "--fuel 1 --z3rlimit 200"
 
 let bv_upd_update_heap64 b heap i v mem =
   let dv = IB.get_downview b.IB.bsrc in

--- a/vale/code/arch/x64/Vale.X64.BufferViewStore.fst
+++ b/vale/code/arch/x64/Vale.X64.BufferViewStore.fst
@@ -17,7 +17,7 @@ open FStar.Calc
 
 friend LowStar.BufferView.Up
 
-#reset-options "--z3rlimit 10 --fuel 0 --initial_fuel 0 --ifuel 1"
+#set-options "--z3rlimit 10 --fuel 0 --ifuel 1"
 
 let math_aux (a b c:int) : Lemma (a + b + (c - b) == a + c) = ()
 

--- a/vale/code/arch/x64/Vale.X64.Bytes_Semantics.fst
+++ b/vale/code/arch/x64/Vale.X64.Bytes_Semantics.fst
@@ -61,7 +61,7 @@ open Vale.X64.Instruction_s
 //
 //(* The following lemmas prove that the unspecified heap remains invariant through execution *)
 //
-//#push-options "--fuel 0 --max_ifuel 1 --initial_ifuel 1"
+//#push-options "--fuel 0 --ifuel 1"
 //let update_operand_flags_same_unspecified (dst:operand64) (v:nat64) (s_orig s:machine_state) : Lemma
 //  (ensures (
 //    let s1 = update_operand64_preserve_flags'' dst v s_orig s in

--- a/vale/code/arch/x64/Vale.X64.Memory.fst
+++ b/vale/code/arch/x64/Vale.X64.Memory.fst
@@ -446,7 +446,7 @@ let get_addr_ptr (t:base_typ) (ptr:int) (h:vale_heap) : Ghost (buffer t)
   =
   Some?.v (find_valid_buffer t ptr h)
 
-#reset-options "--fuel 0 --ifuel 0 --initial_fuel 0 --initial_ifuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --ifuel 0 --z3rlimit 20"
 let load_buffer_read (t:base_typ) (ptr:int) (h:vale_heap) : Lemma
   (requires valid_mem t ptr h)
   (ensures (

--- a/vale/code/arch/x64/Vale.X64.StateLemmas.fst
+++ b/vale/code/arch/x64/Vale.X64.StateLemmas.fst
@@ -11,7 +11,7 @@ let same_heap_types = ()
 
 let use_machine_state_equal () = ()
 
-#set-options "--max_ifuel 2 --initial_ifuel 2"
+#set-options "--ifuel 2"
 let lemma_valid_mem_addr64 h ptr =
   MS.bytes_valid64 ptr (get_vale_heap h);
   MS.lemma_heap_get_heap h;

--- a/vale/code/arch/x64/interop/Vale.AES.Gcm_simplify.fst
+++ b/vale/code/arch/x64/interop/Vale.AES.Gcm_simplify.fst
@@ -44,7 +44,7 @@ val be_quad32_to_bytes_sel (q : quad32) (i:nat{i < 16}) :
 
 open FStar.Tactics
 
-#push-options "--z3cliopt smt.QI.EAGER_THRESHOLD=100 --z3cliopt smt.CASE_SPLIT=3 --z3cliopt smt.arith.nl=true --max_fuel 2 --initial_fuel 2 --ifuel 0 --smtencoding.elim_box true --smtencoding.nl_arith_repr native --z3rlimit 10"
+#push-options "--z3cliopt smt.QI.EAGER_THRESHOLD=100 --z3cliopt smt.CASE_SPLIT=3 --z3cliopt smt.arith.nl=true --fuel 2 --ifuel 0 --smtencoding.elim_box true --smtencoding.nl_arith_repr native --z3rlimit 10"
 
 let be_quad32_to_bytes_sel q i =
   reveal_opaque (`%be_quad32_to_bytes) be_quad32_to_bytes;

--- a/vale/code/crypto/aes/Vale.AES.AES256_helpers.fst
+++ b/vale/code/crypto/aes/Vale.AES.AES256_helpers.fst
@@ -77,7 +77,7 @@ let rec lemma_expand_key_256 (key:seq nat32) (size:nat) =
   )
 
 // SIMD version of round_key_256 is equivalent to scalar round_key_256
-#push-options "--max_fuel 3 --initial_fuel 3 --max_ifuel 3 --initial_ifuel 3"  // REVIEW: Why do we need this?
+#push-options "--fuel 3 --ifuel 3"  // REVIEW: Why do we need this?
 let lemma_simd_round_key (prev0 prev1:quad32) (rcon:nat32) (round:int) =
   quad32_xor_reveal ();
   reverse_bytes_nat32_reveal ();

--- a/vale/code/crypto/aes/Vale.AES.AES_helpers.fst
+++ b/vale/code/crypto/aes/Vale.AES.AES_helpers.fst
@@ -45,7 +45,7 @@ let rec lemma_expand_key_128 (key:seq nat32) (size:nat) =
 #reset-options
 
 // SIMD version of round_key_128 is equivalent to scalar round_key_128
-#push-options "--max_fuel 3 --initial_fuel 3 --max_ifuel 3 --initial_ifuel 3"  // REVIEW: Why do we need this?
+#push-options "--fuel 3 --ifuel 3"  // REVIEW: Why do we need this?
 let lemma_simd_round_key (prev:quad32) (rcon:nat32) =
   quad32_xor_reveal ();
   reverse_bytes_nat32_reveal ();
@@ -59,7 +59,7 @@ let commute_sub_bytes_shift_rows_forall () =
 let init_rounds_opaque (init:quad32) (round_keys:seq quad32) =
   eval_rounds_reveal ()
 
-#push-options "--max_ifuel 2 --initial_ifuel 2"  // REVIEW: Why do we need this?  Extra inversion to deal with opaque?
+#push-options "--ifuel 2"  // REVIEW: Why do we need this?  Extra inversion to deal with opaque?
 let finish_cipher (alg:algorithm) (input:quad32) (round_keys:seq quad32) =
   eval_rounds_reveal ();
   eval_cipher_reveal ();

--- a/vale/code/crypto/aes/Vale.AES.GCM_helpers.fst
+++ b/vale/code/crypto/aes/Vale.AES.GCM_helpers.fst
@@ -147,7 +147,7 @@ let insert_0_is_padding (q:quad32) :
 *)
 
 
-#reset-options "--z3cliopt smt.QI.EAGER_THRESHOLD=100 --z3cliopt smt.CASE_SPLIT=3 --z3cliopt smt.arith.nl=true --max_fuel 2 --initial_fuel 2 --ifuel 0 --smtencoding.elim_box true --smtencoding.nl_arith_repr native --z3rlimit 10"
+#reset-options "--z3cliopt smt.QI.EAGER_THRESHOLD=100 --z3cliopt smt.CASE_SPLIT=3 --z3cliopt smt.arith.nl=true --fuel 2 --ifuel 0 --smtencoding.elim_box true --smtencoding.nl_arith_repr native --z3rlimit 10"
 let le_quad32_to_bytes_sel (q : quad32) (i:nat{i < 16}) =
   reveal_opaque (`%le_quad32_to_bytes) le_quad32_to_bytes;
   let Mkfour q0 q1 q2 q3 = q in

--- a/vale/specs/defs/Vale.Def.Words.Seq_s.fst
+++ b/vale/specs/defs/Vale.Def.Words.Seq_s.fst
@@ -1,7 +1,7 @@
 module Vale.Def.Words.Seq_s
 open FStar.Mul
 
-#reset-options "--max_fuel 3 --initial_fuel 3"
+#reset-options "--fuel 3"
 let two_to_seq_LE #a x =
   let l = [x.lo; x.hi] in
   let s = seq_of_list l in
@@ -17,7 +17,7 @@ let two_to_seq_BE #a x =
   seq_of_list l
 #reset-options
 
-#reset-options "--max_fuel 5 --initial_fuel 5"
+#reset-options "--fuel 5"
 let four_to_seq_LE #a x =
   let l = [x.lo0; x.lo1; x.hi2; x.hi3] in
   let s = seq_of_list l in


### PR DESCRIPTION
The previous patch (8f6241f94e19785d12d25c8e0c773bf20f1b7b40) did not match cases like `--max_fuel 1 --initial_fuel 1`, but only the opposite order.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)
